### PR TITLE
feat(openrouter): add openai/gpt-oss-120b and openai/gpt-oss-20b models

### DIFF
--- a/internal/providers/configs/openrouter.json
+++ b/internal/providers/configs/openrouter.json
@@ -1943,6 +1943,32 @@
       "can_reason": false,
       "has_reasoning_efforts": false,
       "supports_attachments": false
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "name": "OpenAI: GPT OSS 120B",
+      "cost_per_1m_in": 0.15,
+      "cost_per_1m_out": 0.6,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "has_reasoning_efforts": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "openai/gpt-oss-20b",
+      "name": "OpenAI: GPT OSS 20B",
+      "cost_per_1m_in": 0.05,
+      "cost_per_1m_out": 0.2,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "has_reasoning_efforts": false,
+      "supports_attachments": false
     }
   ],
   "default_headers": {


### PR DESCRIPTION
### Describe your changes

Adds OpenAI GPT OSS models in the OpenRouter provider configuration.

### Related issue/discussion: NA

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
