### PR TITLE
feat: add gpt-5

### DIFF
--- a/internal/providers/configs/openai.json
+++ b/internal/providers/configs/openai.json
@@ -36,6 +36,42 @@
       "supports_attachments": true
     },
     {
+      "id": "gpt-5",
+      "name": "GPT-5",
+      "cost_per_1m_in": 1.25,
+      "cost_per_1m_out": 10,
+      "cost_per_1m_in_cached": 0.25,
+      "cost_per_1m_out_cached": 0.25,
+      "context_window": 400000,
+      "default_max_tokens": 128000,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "gpt-5-mini",
+      "name": "GPT-5 Mini",
+      "cost_per_1m_in": 0.25,
+      "cost_per_1m_out": 2,
+      "cost_per_1m_in_cached": 0.025,
+      "cost_per_1m_out_cached": 0.025,
+      "context_window": 400000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "gpt-5-nano",
+      "name": "GPT-5 Nano",
+      "cost_per_1m_in": 0.05,
+      "cost_per_1m_out": 0.4,
+      "cost_per_1m_in_cached": 0.005,
+      "cost_per_1m_out_cached": 0.005,
+      "context_window": 400000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
       "id": "gpt-4.1",
       "name": "GPT-4.1",
       "cost_per_1m_in": 2,


### PR DESCRIPTION
see: https://platform.openai.com/docs/models/compare?model=gpt-5-nano

<img width="2246" height="2206" alt="CleanShot 2025-08-07 at 14 46 18@2x" src="https://github.com/user-attachments/assets/4b2b7466-c051-4cc2-9d5b-55533d565bf7" />


it doesn't have a cost per cached output, so I'm using the same value as input.