### PR TITLE
chore(config): normalize floating point to 0.8 for readability

### DIFF
--- a/internal/providers/configs/anthropic.json
+++ b/internal/providers/configs/anthropic.json
@@ -58,7 +58,7 @@
     {
       "id": "claude-3-5-haiku-20241022",
       "name": "Claude 3.5 Haiku",
-      "cost_per_1m_in": 0.7999999999999999,
+      "cost_per_1m_in": 0.8,
       "cost_per_1m_out": 4,
       "cost_per_1m_in_cached": 1,
       "cost_per_1m_out_cached": 0.08,


### PR DESCRIPTION
### Describe your changes
Replaced `0.7999999999999999` with `0.8` in the `cost_per_1m_in` field for the `Claude 3.5 Haiku` model configuration.

### Related issue/discussion: None

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
