### PR TITLE
Update cerebras.json - adds gpt-oss-120b

### DIFF
--- a/internal/providers/configs/cerebras.json
+++ b/internal/providers/configs/cerebras.json
@@ -38,6 +38,16 @@
             "supports_attachments": false
         },
         {
+            "id": "gpt-oss-120b",
+            "name": "gpt-oss-120b",
+            "cost_per_1m_in": 0.4,
+            "cost_per_1m_out": 0.8,
+            "context_window": 128000,
+            "default_max_tokens": 65536,
+            "can_reason": true,
+            "supports_attachments": false
+        },
+        {
             "id": "qwen-3-32b",
             "name": "Qwen 3 32B",
             "cost_per_1m_in": 0.4,


### PR DESCRIPTION
### Describe your changes

this simply adds the gpt-oss-120b model that cerebras provides (these same settings have been play-tested in crush since 0.2.1 I think it was; also in 0.4 and 0.6.1).

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
