### PR TITLE
Add FriendliAI provider support

### DIFF
--- a/internal/providers/configs/friendli.json
+++ b/internal/providers/configs/friendli.json
@@ -1,0 +1,71 @@
+{
+  "name": "FriendliAI",
+  "id": "friendli",
+  "type": "openai",
+  "api_key": "$FRIENDLI_TOKEN",
+  "api_endpoint": "https://api.friendli.ai/serverless/v1",
+  "default_large_model_id": "meta-llama/Llama-3.3-70B-Instruct",
+  "default_small_model_id": "meta-llama/Llama-3.1-8B-Instruct",
+  "models": [
+    {
+      "id": "meta-llama/Llama-3.3-70B-Instruct",
+      "name": "Llama 3.3 70B Instruct",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 0.6,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 4096,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "meta-llama/Llama-3.1-8B-Instruct",
+      "name": "Llama 3.1 8B Instruct",
+      "cost_per_1m_in": 0.1,
+      "cost_per_1m_out": 0.1,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 4096,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "LGAI-EXAONE/EXAONE-4.0.1-32B",
+      "name": "EXAONE 4.0.1 32B",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 1.0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 4096,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "K-intelligence/Midm-2.0-Base-Instruct",
+      "name": "Midm 2.0 Base Instruct",
+      "cost_per_1m_in": 0.0,
+      "cost_per_1m_out": 0.0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 32768,
+      "default_max_tokens": 4096,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "skt/A.X-4.0",
+      "name": "A.X 4.0",
+      "cost_per_1m_in": 0.0,
+      "cost_per_1m_out": 0.0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 32768,
+      "default_max_tokens": 4096,
+      "can_reason": false,
+      "supports_attachments": false
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -48,6 +48,9 @@ var cerebrasConfig []byte
 //go:embed configs/venice.json
 var veniceConfig []byte
 
+//go:embed configs/friendli.json
+var friendliConfig []byte
+
 // ProviderFunc is a function that returns a Provider.
 type ProviderFunc func() catwalk.Provider
 
@@ -65,6 +68,7 @@ var providerRegistry = []ProviderFunc{
 	lambdaProvider,
 	cerebrasProvider,
 	veniceProvider,
+	friendliProvider,
 }
 
 // GetAll returns all registered providers.
@@ -135,4 +139,8 @@ func cerebrasProvider() catwalk.Provider {
 
 func veniceProvider() catwalk.Provider {
 	return loadProviderFromConfig(veniceConfig)
+}
+
+func friendliProvider() catwalk.Provider {
+	return loadProviderFromConfig(friendliConfig)
 }


### PR DESCRIPTION
## Summary
- Add FriendliAI provider configuration with 5 popular models
- Register FriendliAI in the provider registry 
- Support OpenAI-compatible API integration with token-based authentication

## Models Added
- Llama 3.3 70B Instruct (default large model) - $0.6/1M tokens
- Llama 3.1 8B Instruct (default small model) - $0.1/1M tokens  
- EXAONE 4.0.1 32B - $0.6/$1.0 per 1M input/output tokens
- Midm 2.0 Base Instruct - Free model
- A.X 4.0 - Free model

## Technical Details
- Uses `FRIENDLI_TOKEN` environment variable for authentication
- Endpoint: `https://api.friendli.ai/serverless/v1`
- Compatible with OpenAI API standard

## Test plan
- [x] Build succeeds without errors
- [x] FriendliAI provider appears in `/providers` endpoint
- [x] All 5 models are correctly registered
- [ ] Test actual API calls with valid FRIENDLI_TOKEN

🤖 Generated with [Claude Code](https://claude.ai/code)