### PR TITLE
feat: add `embedded` package to allow offline functionality

### DIFF
--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -1,0 +1,13 @@
+// Package embedded provides access to all providers in a embedded manner.
+// This basically means offline access to the providers.
+package embedded
+
+import (
+	"github.com/charmbracelet/catwalk/internal/providers"
+	"github.com/charmbracelet/catwalk/pkg/catwalk"
+)
+
+// GetAll returns all embedded providers.
+func GetAll() []catwalk.Provider {
+	return providers.GetAll()
+}


### PR DESCRIPTION
This will be needed by Crush for its "offline mode".