### PR TITLE
Add DeepSeek to the list of providers

### DIFF
--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -1,0 +1,36 @@
+{
+  "name": "DeepSeek",
+  "id": "deepseek",
+  "type": "openai",
+  "api_key": "$DEEPSEEK_API_KEY",
+  "api_endpoint": "https://api.deepseek.com/v1",
+  "default_large_model_id": "deepseek-reasoner",
+  "default_small_model_id": "deepseek-chat",
+  "models": [
+    {
+      "id": "deepseek-chat",
+      "name": "DeepSeek-V3.1 (Non-thinking Mode)",
+      "cost_per_1m_in": 0.56,
+      "cost_per_1m_out": 1.68,
+      "cost_per_1m_in_cached": 0.07,
+      "cost_per_1m_out_cached": 1.68,
+      "context_window": 128000,
+      "default_max_tokens": 4000,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek-reasoner",
+      "name": "DeepSeek-V3.1 (Thinking Mode)",
+      "cost_per_1m_in": 0.56,
+      "cost_per_1m_out": 1.68,
+      "cost_per_1m_in_cached": 0.07,
+      "cost_per_1m_out_cached": 1.68,
+      "context_window": 128000,
+      "default_max_tokens": 32000,
+      "can_reason": true,
+      "supports_attachments": false
+    }
+  ]
+}
+

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -48,6 +48,9 @@ var cerebrasConfig []byte
 //go:embed configs/venice.json
 var veniceConfig []byte
 
+//go:embed configs/deepseek.json
+var deepSeekConfig []byte
+
 // ProviderFunc is a function that returns a Provider.
 type ProviderFunc func() catwalk.Provider
 
@@ -65,6 +68,7 @@ var providerRegistry = []ProviderFunc{
 	lambdaProvider,
 	cerebrasProvider,
 	veniceProvider,
+	deepSeekProvider,
 }
 
 // GetAll returns all registered providers.
@@ -135,4 +139,8 @@ func cerebrasProvider() catwalk.Provider {
 
 func veniceProvider() catwalk.Provider {
 	return loadProviderFromConfig(veniceConfig)
+}
+
+func deepSeekProvider() catwalk.Provider {
+	return loadProviderFromConfig(deepSeekConfig)
 }


### PR DESCRIPTION
### Describe your changes

Added Official DeepSeek provider with DeepSeek V3.1 models and tested in Crush using `CATWALK_URL=http://localhost:8080`

- deepseek-chat (V3.1 non-thinking)
- deepseek-reasoner (V3.1 thinking)

### Related issue/discussion: https://github.com/charmbracelet/catwalk/issues/23

### Checklist before requesting a review

- [X ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [ X] I have performed a self-review of my code

### If this is a feature

- [X ] I have created a discussion (continued #23)
- [ ] A project maintainer has approved this feature request. Link to comment:
