### PR TITLE
Fix "has_reasoning_effort" -> "has_reasoning_efforts"

### DIFF
--- a/internal/providers/configs/azure.json
+++ b/internal/providers/configs/azure.json
@@ -59,7 +59,7 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
@@ -73,7 +73,7 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
@@ -87,7 +87,7 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
@@ -101,7 +101,7 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
@@ -163,7 +163,7 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "medium",
       "supports_attachments": false
     },

--- a/internal/providers/configs/lambda.json
+++ b/internal/providers/configs/lambda.json
@@ -17,7 +17,7 @@
       "context_window": 164000,
       "default_max_tokens": 8192,
       "can_reason": true,
-      "has_reasoning_effort": false,
+      "has_reasoning_efforts": false,
       "supports_attachments": false
     },
     {
@@ -30,7 +30,7 @@
       "context_window": 164000,
       "default_max_tokens": 8192,
       "can_reason": true,
-      "has_reasoning_effort": false,
+      "has_reasoning_efforts": false,
       "supports_attachments": false
     },
     {

--- a/internal/providers/configs/openai.json
+++ b/internal/providers/configs/openai.json
@@ -17,7 +17,7 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "minimal",
       "supports_attachments": true
     },
@@ -31,7 +31,7 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "low",
       "supports_attachments": true
     },
@@ -45,7 +45,7 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "low",
       "supports_attachments": true
     },
@@ -59,7 +59,7 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "low",
       "supports_attachments": true
     },
@@ -73,7 +73,7 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
@@ -123,7 +123,7 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "has_reasoning_effort": true,
+      "has_reasoning_efforts": true,
       "default_reasoning_effort": "medium",
       "supports_attachments": false
     },


### PR DESCRIPTION
### Describe your changes

Based on https://github.com/charmbracelet/catwalk/blob/239810362e819bda15fdecfa892927c84de25613/pkg/catwalk/provider.go#L61 the field name should be "has_reasoning_efforts" with an "s" at the end. This PR corrects the included provider configs to use the proper name.

### Related issue/discussion: N/A

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code