### PR TITLE
Feat: Add support for model API type, Add anthropic to vertexai

### DIFF
--- a/internal/providers/configs/vertexai.json
+++ b/internal/providers/configs/vertexai.json
@@ -30,6 +30,48 @@
       "default_max_tokens": 50000,
       "can_reason": true,
       "supports_attachments": true
+    },
+    {
+      "id": "claude-opus-4-1-20250805",
+      "name": "Claude Opus 4.1",
+      "type": "anthropic",
+      "cost_per_1m_in": 15,
+      "cost_per_1m_out": 75,
+      "cost_per_1m_in_cached": 18.75,
+      "cost_per_1m_out_cached": 1.5,
+      "context_window": 200000,
+      "default_max_tokens": 32000,
+      "can_reason": true,
+      "has_reasoning_efforts": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "claude-sonnet-4-20250514",
+      "name": "Claude Sonnet 4",
+      "type": "anthropic",
+      "cost_per_1m_in": 3,
+      "cost_per_1m_out": 15,
+      "cost_per_1m_in_cached": 3.75,
+      "cost_per_1m_out_cached": 0.3,
+      "context_window": 200000,
+      "default_max_tokens": 50000,
+      "can_reason": true,
+      "has_reasoning_efforts": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "claude-3-5-haiku-20241022",
+      "name": "Claude 3.5 Haiku",
+      "type": "anthropic",
+      "cost_per_1m_in": 0.7999999999999999,
+      "cost_per_1m_out": 4,
+      "cost_per_1m_in_cached": 1,
+      "cost_per_1m_out_cached": 0.08,
+      "context_window": 200000,
+      "default_max_tokens": 5000,
+      "can_reason": false,
+      "has_reasoning_efforts": false,
+      "supports_attachments": true
     }
   ]
 }

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -51,6 +51,7 @@ type Provider struct {
 type Model struct {
 	ID                     string  `json:"id"`
 	Name                   string  `json:"name"`
+	Type                   Type    `json:"type"`
 	CostPer1MIn            float64 `json:"cost_per_1m_in"`
 	CostPer1MOut           float64 `json:"cost_per_1m_out"`
 	CostPer1MInCached      float64 `json:"cost_per_1m_in_cached"`


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

This is a minor add. I'm happy to pull out the "type" addition to models, but this seems a more elegant way to differentiate than the current method in crush (which does a string comparison to _try_ and detect anthropic apis for vertex) 