### PR TITLE
fix(anthropic): enable haiku 4.5 reasoning

### DIFF
--- a/internal/providers/configs/anthropic.json
+++ b/internal/providers/configs/anthropic.json
@@ -28,8 +28,7 @@
       "cost_per_1m_out_cached": 0.09999999999999999,
       "context_window": 200000,
       "default_max_tokens": 32000,
-      "can_reason": false,
-      "has_reasoning_efforts": false,
+      "can_reason": true,
       "supports_attachments": true
     },
     {


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

From [the system card](https://www.anthropic.com/claude-haiku-4-5-system-card) § 1.1.2 Extended thinking mode
> As with each model released by Anthropic beginning with Claude Sonnet 3.7, Claude Haiku 4.5 is a hybrid reasoning model. This means that by default the model will answer a query rapidly, but users have the option to toggle on “extended thinking mode”, where the model will spend more time considering its response before it answers. Note that our previous model in the Haiku small-model class, Claude Haiku 3.5, did not have an extended thinking mode.