### PR TITLE
Refactor: Auto-discover provider configs from embedded directory

### DIFF
--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -2,161 +2,49 @@
 package providers
 
 import (
-	_ "embed"
+	"embed"
 	"encoding/json"
+	"io/fs"
 	"log"
+	"path/filepath"
+	"strings"
 
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
 )
 
-//go:embed configs/openai.json
-var openAIConfig []byte
-
-//go:embed configs/anthropic.json
-var anthropicConfig []byte
-
-//go:embed configs/gemini.json
-var geminiConfig []byte
-
-//go:embed configs/openrouter.json
-var openRouterConfig []byte
-
-//go:embed configs/azure.json
-var azureConfig []byte
-
-//go:embed configs/vertexai.json
-var vertexAIConfig []byte
-
-//go:embed configs/xai.json
-var xAIConfig []byte
-
-//go:embed configs/zai.json
-var zAIConfig []byte
-
-//go:embed configs/bedrock.json
-var bedrockConfig []byte
-
-//go:embed configs/groq.json
-var groqConfig []byte
-
-//go:embed configs/cerebras.json
-var cerebrasConfig []byte
-
-//go:embed configs/venice.json
-var veniceConfig []byte
-
-//go:embed configs/chutes.json
-var chutesConfig []byte
-
-//go:embed configs/deepseek.json
-var deepSeekConfig []byte
-
-//go:embed configs/huggingface.json
-var huggingFaceConfig []byte
-
-//go:embed configs/aihubmix.json
-var aiHubMixConfig []byte
-
-// ProviderFunc is a function that returns a Provider.
-type ProviderFunc func() catwalk.Provider
-
-var providerRegistry = []ProviderFunc{
-	anthropicProvider,
-	openAIProvider,
-	geminiProvider,
-	azureProvider,
-	bedrockProvider,
-	vertexAIProvider,
-	xAIProvider,
-	zAIProvider,
-	groqProvider,
-	openRouterProvider,
-	cerebrasProvider,
-	veniceProvider,
-	chutesProvider,
-	deepSeekProvider,
-	huggingFaceProvider,
-	aiHubMixProvider,
-}
+//go:embed configs/*.json
+var configsFS embed.FS
 
 // GetAll returns all registered providers.
 func GetAll() []catwalk.Provider {
-	providers := make([]catwalk.Provider, 0, len(providerRegistry))
-	for _, providerFunc := range providerRegistry {
-		providers = append(providers, providerFunc())
+	var providers []catwalk.Provider
+
+	entries, err := fs.ReadDir(configsFS, "configs")
+	if err != nil {
+		log.Printf("Error reading configs directory: %v", err)
+		return providers
 	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		configPath := filepath.Join("configs", entry.Name())
+		configData, err := fs.ReadFile(configsFS, configPath)
+		if err != nil {
+			log.Printf("Error reading config %s: %v", entry.Name(), err)
+			continue
+		}
+
+		var provider catwalk.Provider
+		if err := json.Unmarshal(configData, &provider); err != nil {
+			log.Printf("Error unmarshaling config %s: %v", entry.Name(), err)
+			continue
+		}
+
+		providers = append(providers, provider)
+	}
+
 	return providers
-}
-
-func loadProviderFromConfig(configData []byte) catwalk.Provider {
-	var p catwalk.Provider
-	if err := json.Unmarshal(configData, &p); err != nil {
-		log.Printf("Error loading provider config: %v", err)
-		return catwalk.Provider{}
-	}
-	return p
-}
-
-func openAIProvider() catwalk.Provider {
-	return loadProviderFromConfig(openAIConfig)
-}
-
-func anthropicProvider() catwalk.Provider {
-	return loadProviderFromConfig(anthropicConfig)
-}
-
-func geminiProvider() catwalk.Provider {
-	return loadProviderFromConfig(geminiConfig)
-}
-
-func azureProvider() catwalk.Provider {
-	return loadProviderFromConfig(azureConfig)
-}
-
-func bedrockProvider() catwalk.Provider {
-	return loadProviderFromConfig(bedrockConfig)
-}
-
-func vertexAIProvider() catwalk.Provider {
-	return loadProviderFromConfig(vertexAIConfig)
-}
-
-func xAIProvider() catwalk.Provider {
-	return loadProviderFromConfig(xAIConfig)
-}
-
-func zAIProvider() catwalk.Provider {
-	return loadProviderFromConfig(zAIConfig)
-}
-
-func openRouterProvider() catwalk.Provider {
-	return loadProviderFromConfig(openRouterConfig)
-}
-
-func groqProvider() catwalk.Provider {
-	return loadProviderFromConfig(groqConfig)
-}
-
-func cerebrasProvider() catwalk.Provider {
-	return loadProviderFromConfig(cerebrasConfig)
-}
-
-func veniceProvider() catwalk.Provider {
-	return loadProviderFromConfig(veniceConfig)
-}
-
-func chutesProvider() catwalk.Provider {
-	return loadProviderFromConfig(chutesConfig)
-}
-
-func deepSeekProvider() catwalk.Provider {
-	return loadProviderFromConfig(deepSeekConfig)
-}
-
-func huggingFaceProvider() catwalk.Provider {
-	return loadProviderFromConfig(huggingFaceConfig)
-}
-
-func aiHubMixProvider() catwalk.Provider {
-	return loadProviderFromConfig(aiHubMixConfig)
 }


### PR DESCRIPTION
Replace manual provider rehgistration with automated  config discovery. This elimntes the need to modify source code when adding new providers... contributors can now simply add relevant json files to configs/ directory without needing code changes.

- Removing individual embed variables for each provider
- Removing provider-specific functions and manual registry
- used `embed.FS` to auto-discover all .json files in configs/
- proper handling of invalid configs
- Reduce code by ~90% while maintaining same functionality

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
