### PR TITLE
feat(gemini): add 3 pro preview

### DIFF
--- a/internal/providers/configs/gemini.json
+++ b/internal/providers/configs/gemini.json
@@ -8,6 +8,19 @@
   "default_small_model_id": "gemini-2.5-flash",
   "models": [
     {
+      "id": "gemini-3-pro-preview",
+      "name": "Gemini 3 Pro (preview)",
+      "cost_per_1m_in": 2,
+      "cost_per_1m_out": 12,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.2,
+      "context_window": 1048576,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "has_reasoning_efforts": false,
+      "supports_attachments": true
+    },
+    {
       "id": "gemini-2.5-pro",
       "name": "Gemini 2.5 Pro",
       "cost_per_1m_in": 1.25,


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

Note that Gemini 3 does come with [API changes](https://ai.google.dev/gemini-api/docs/gemini-3#new_api_features_in_gemini_3), but they shouldn't break existing uses. The biggest one is introducing support for OpenAI-style reasoning effort; it defaults to high and can be set to low, with medium coming later.