### PR TITLE
fix: casing consistency

### DIFF
--- a/internal/providers/configs/gemini.json
+++ b/internal/providers/configs/gemini.json
@@ -9,7 +9,7 @@
   "models": [
     {
       "id": "gemini-3-pro-preview",
-      "name": "Gemini 3 Pro (preview)",
+      "name": "Gemini 3 Pro (Preview)",
       "cost_per_1m_in": 2,
       "cost_per_1m_out": 12,
       "cost_per_1m_in_cached": 0,


### PR DESCRIPTION
To match other cases where we're using "(Preview)" as well as the general title case convention.