### PR TITLE
chore: add openai gpt 5.2 and gpt 5.1 codex max

### DIFF
--- a/internal/providers/configs/openai.json
+++ b/internal/providers/configs/openai.json
@@ -50,6 +50,20 @@
       "supports_attachments": true
     },
     {
+      "id": "gpt-5.1-codex-max",
+      "name": "GPT-5.1 Codex Max",
+      "cost_per_1m_in": 1.25,
+      "cost_per_1m_out": 10,
+      "cost_per_1m_in_cached": 0.125,
+      "cost_per_1m_out_cached": 0.125,
+      "context_window": 400000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": ["minimal", "low", "medium", "high"],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
       "id": "gpt-5.1-codex-mini",
       "name": "GPT-5.1 Codex Mini",
       "cost_per_1m_in": 0.25,


### PR DESCRIPTION
* Fantasy PR: https://github.com/charmbracelet/fantasy/pull/97
* GPT 5.2: https://platform.openai.com/docs/models/gpt-5.2
* GPT 5.1 Codex Max: https://platform.openai.com/docs/models/gpt-5.1-codex-max