### PR TITLE
feat(cerebras): add zai-glm-4.7 model

### DIFF
--- a/internal/providers/configs/cerebras.json
+++ b/internal/providers/configs/cerebras.json
@@ -65,6 +65,16 @@
             "default_max_tokens": 25000,
             "can_reason": false,
             "supports_attachments": false
+        },
+        {
+            "id": "zai-glm-4.7",
+            "name": "Z.ai GLM 4.7",
+            "cost_per_1m_in": 2.25,
+            "cost_per_1m_out": 2.75,
+            "context_window": 131072,
+            "default_max_tokens": 25000,
+            "can_reason": false,
+            "supports_attachments": false
         }
     ]
 }


### PR DESCRIPTION
Adds Z.ai GLM 4.7 (`zai-glm-4.7`) to the Cerebras provider model registry config.

Testing
- Not run (config-only change)