### PR TITLE
chore: add gpt 5.2 codex via github copilot

### DIFF
--- a/internal/providers/configs/copilot.json
+++ b/internal/providers/configs/copilot.json
@@ -176,6 +176,19 @@
       "options": {}
     },
     {
+      "id": "gpt-5.2-codex",
+      "name": "GPT-5.2-Codex",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 400000,
+      "default_max_tokens": 128000,
+      "can_reason": false,
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
       "id": "grok-code-fast-1",
       "name": "Grok Code Fast 1",
       "cost_per_1m_in": 0,


### PR DESCRIPTION
For some reason they didn't add this model to `https://api.githubcopilot.com/models` yet, so the script is not able to fetch it.

Adding manually for now. I tested to ensure it works.