### PR TITLE
fix(synthetic): update pricing, add minimax-m2.1/gpt-oss meta

### DIFF
--- a/cmd/synthetic/main.go
+++ b/cmd/synthetic/main.go
@@ -120,6 +120,9 @@ func applyModelOverrides(model *Model) {
 
 	case strings.HasPrefix(model.ID, "hf:openai/gpt-oss"):
 		model.SupportedFeatures = []string{"tools", "reasoning"}
+
+	case strings.HasPrefix(model.ID, "hf:MiniMaxAI/MiniMax-M2.1"):
+		model.SupportedFeatures = []string{"tools", "reasoning"}
 	}
 }
 

--- a/internal/providers/configs/synthetic.json
+++ b/internal/providers/configs/synthetic.json
@@ -193,6 +193,25 @@
       "options": {}
     },
     {
+      "id": "hf:MiniMaxAI/MiniMax-M2.1",
+      "name": "MiniMax M2.1",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 1.2,
+      "cost_per_1m_in_cached": 0.3,
+      "cost_per_1m_out_cached": 0.3,
+      "context_window": 196608,
+      "default_max_tokens": 19660,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
       "id": "hf:Qwen/Qwen3-235B-A22B-Instruct-2507",
       "name": "Qwen3 235B A22B Instruct 2507",
       "cost_per_1m_in": 0.22,


### PR DESCRIPTION
Synthetic's JSON got auto-updated last night to include the new K2.5 model, I think when it was proxied from Fireworks, but the metadata wasn't quite correct because it needs the reasoning override until they include all the data in their API response. They've also moved to their own K2.5 instance since last night's update and changed the pricing for both it and K2-Thinking.

I considered changing the default large model to K2.5, but figured it might be a bit premature for now.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
