### PR TITLE
chore!: migrate go module to `charm.land/catwalk`

### DIFF
--- a/cmd/copilot/main.go
+++ b/cmd/copilot/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"charm.land/catwalk/pkg/catwalk"
 )
 
 type Response struct {

--- a/cmd/huggingface/main.go
+++ b/cmd/huggingface/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"charm.land/catwalk/pkg/catwalk"
 )
 
 // SupportedProviders defines which providers we want to support.

--- a/cmd/openrouter/main.go
+++ b/cmd/openrouter/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"charm.land/catwalk/pkg/catwalk"
 )
 
 // Model represents the complete model configuration.

--- a/cmd/synthetic/main.go
+++ b/cmd/synthetic/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"charm.land/catwalk/pkg/catwalk"
 )
 
 // Model represents a model from the Synthetic API.

--- a/cmd/vercel/main.go
+++ b/cmd/vercel/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"charm.land/catwalk/pkg/catwalk"
 )
 
 // Model represents a model from the Vercel API.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/charmbracelet/catwalk
+module charm.land/catwalk
 
 go 1.25.5
 

--- a/internal/deprecated/old.go
+++ b/internal/deprecated/old.go
@@ -1,7 +1,7 @@
 // Package deprecated is used to serve the old verion of the provider config
 package deprecated
 
-import "github.com/charmbracelet/catwalk/pkg/catwalk"
+import "charm.land/catwalk/pkg/catwalk"
 
 // Provider represents an AI provider configuration.
 type Provider struct {

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"charm.land/catwalk/pkg/catwalk"
 )
 
 //go:embed configs/openai.json

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/charmbracelet/catwalk/internal/deprecated"
-	"github.com/charmbracelet/catwalk/internal/providers"
+	"charm.land/catwalk/internal/deprecated"
+	"charm.land/catwalk/internal/providers"
 	"github.com/charmbracelet/x/etag"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"

--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -3,8 +3,8 @@
 package embedded
 
 import (
-	"github.com/charmbracelet/catwalk/internal/providers"
-	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"charm.land/catwalk/internal/providers"
+	"charm.land/catwalk/pkg/catwalk"
 )
 
 // GetAll returns all embedded providers.


### PR DESCRIPTION
BREAKING CHANGE: This will need users to update the import path.

---

What do you think? Should we release v1.0.0 after this?

IMO it's probably fine to release as minor because we're likely the only user, and this is a v0.* version anyway.