### PR TITLE
chore: update the vercel config to use the vercel provider

### DIFF
--- a/cmd/vercel/main.go
+++ b/cmd/vercel/main.go
@@ -85,7 +85,7 @@ func main() {
 		ID:                  catwalk.InferenceProviderVercel,
 		APIKey:              "$VERCEL_API_KEY",
 		APIEndpoint:         "https://ai-gateway.vercel.sh/v1",
-		Type:                catwalk.TypeOpenAICompat,
+		Type:                catwalk.TypeVercel,
 		DefaultLargeModelID: "anthropic/claude-sonnet-4",
 		DefaultSmallModelID: "anthropic/claude-haiku-4.5",
 		Models:              []catwalk.Model{},
@@ -146,7 +146,12 @@ func main() {
 		var reasoningLevels []string
 		var defaultReasoning string
 		if canReason {
+			// Base reasoning levels supported by most providers
 			reasoningLevels = []string{"low", "medium", "high"}
+			// Anthropic models support extended Vercel reasoning levels
+			if strings.HasPrefix(model.ID, "anthropic/") {
+				reasoningLevels = []string{"none", "minimal", "low", "medium", "high", "xhigh"}
+			}
 			defaultReasoning = "medium"
 		}
 

--- a/internal/providers/configs/vercel.json
+++ b/internal/providers/configs/vercel.json
@@ -3,7 +3,7 @@
   "id": "vercel",
   "api_key": "$VERCEL_API_KEY",
   "api_endpoint": "https://ai-gateway.vercel.sh/v1",
-  "type": "openai-compat",
+  "type": "vercel",
   "default_large_model_id": "anthropic/claude-sonnet-4",
   "default_small_model_id": "anthropic/claude-haiku-4.5",
   "models": [
@@ -70,9 +70,12 @@
       "default_max_tokens": 8000,
       "can_reason": true,
       "reasoning_levels": [
+        "none",
+        "minimal",
         "low",
         "medium",
-        "high"
+        "high",
+        "xhigh"
       ],
       "default_reasoning_effort": "medium",
       "supports_attachments": true,
@@ -89,9 +92,12 @@
       "default_max_tokens": 8000,
       "can_reason": true,
       "reasoning_levels": [
+        "none",
+        "minimal",
         "low",
         "medium",
-        "high"
+        "high",
+        "xhigh"
       ],
       "default_reasoning_effort": "medium",
       "supports_attachments": true,
@@ -108,9 +114,12 @@
       "default_max_tokens": 8000,
       "can_reason": true,
       "reasoning_levels": [
+        "none",
+        "minimal",
         "low",
         "medium",
-        "high"
+        "high",
+        "xhigh"
       ],
       "default_reasoning_effort": "medium",
       "supports_attachments": true,
@@ -127,9 +136,12 @@
       "default_max_tokens": 8000,
       "can_reason": true,
       "reasoning_levels": [
+        "none",
+        "minimal",
         "low",
         "medium",
-        "high"
+        "high",
+        "xhigh"
       ],
       "default_reasoning_effort": "medium",
       "supports_attachments": true,
@@ -146,9 +158,12 @@
       "default_max_tokens": 8000,
       "can_reason": true,
       "reasoning_levels": [
+        "none",
+        "minimal",
         "low",
         "medium",
-        "high"
+        "high",
+        "xhigh"
       ],
       "default_reasoning_effort": "medium",
       "supports_attachments": true,
@@ -165,9 +180,12 @@
       "default_max_tokens": 8000,
       "can_reason": true,
       "reasoning_levels": [
+        "none",
+        "minimal",
         "low",
         "medium",
-        "high"
+        "high",
+        "xhigh"
       ],
       "default_reasoning_effort": "medium",
       "supports_attachments": true,
@@ -184,9 +202,12 @@
       "default_max_tokens": 8000,
       "can_reason": true,
       "reasoning_levels": [
+        "none",
+        "minimal",
         "low",
         "medium",
-        "high"
+        "high",
+        "xhigh"
       ],
       "default_reasoning_effort": "medium",
       "supports_attachments": true,
@@ -1720,19 +1741,6 @@
       "cost_per_1m_in_cached": 0.19999999999999998,
       "cost_per_1m_out_cached": 0,
       "context_window": 1000000,
-      "default_max_tokens": 8000,
-      "can_reason": false,
-      "supports_attachments": false,
-      "options": {}
-    },
-    {
-      "id": "alibaba/qwen3-max",
-      "name": "Qwen3 Max",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0.24,
-      "cost_per_1m_out_cached": 0,
-      "context_window": 262144,
       "default_max_tokens": 8000,
       "can_reason": false,
       "supports_attachments": false,

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -8,6 +8,7 @@ const (
 	TypeOpenAI       Type = "openai"
 	TypeOpenAICompat Type = "openai-compat"
 	TypeOpenRouter   Type = "openrouter"
+	TypeVercel       Type = "vercel"
 	TypeAnthropic    Type = "anthropic"
 	TypeGoogle       Type = "google"
 	TypeAzure        Type = "azure"
@@ -112,6 +113,7 @@ func KnownProviderTypes() []Type {
 		TypeOpenAI,
 		TypeOpenAICompat,
 		TypeOpenRouter,
+		TypeVercel,
 		TypeAnthropic,
 		TypeGoogle,
 		TypeAzure,


### PR DESCRIPTION
This updates the vercel config so it uses the vercel provider introduced in https://github.com/charmbracelet/fantasy/pull/129, this enables proper handling of caching for anthropic models and reasoning across all models that support it.