### PR TITLE
fix: grok 4 does not support reasoning levels

### DIFF
--- a/internal/providers/configs/xai.json
+++ b/internal/providers/configs/xai.json
@@ -53,10 +53,6 @@
       "context_window": 256000,
       "default_max_tokens": 20000,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "high"
-      ],
       "supports_attachments": true
     },
     {


### PR DESCRIPTION
It was returning an error if you selected one. The documentations says it's not supported:

https://docs.x.ai/developers/models

<img width="690" height="215" alt="Screenshot 2026-02-13 at 18 09 58" src="https://github.com/user-attachments/assets/373bdc9a-e122-41f5-8580-a462955b204c" />
