### PR TITLE
feat: add support for anthropic thinking effort

### DIFF
--- a/internal/providers/configs/anthropic.json
+++ b/internal/providers/configs/anthropic.json
@@ -57,8 +57,6 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "reasoning_levels": ["low", "medium", "high", "max"],
-      "default_reasoning_efforts": "medium",
       "supports_attachments": true
     },
     {


### PR DESCRIPTION
* Fantasy PR: https://github.com/charmbracelet/fantasy/pull/147
* https://platform.claude.com/docs/en/build-with-claude/effort

Not every models supports it. From their docs:

<img width="734" height="90" alt="Screenshot 2026-02-26 at 16 07 05" src="https://github.com/user-attachments/assets/5de0bfa2-e438-4dbb-a221-0990c0f4d11c" />

I'm restricting it to Sonnet 4.6 and Opus 4.6 because only those two support `thinking: {type: "adaptive"}` which gives better results.

In Crush:

<img width="463" height="238" alt="Screenshot 2026-02-26 at 16 12 15" src="https://github.com/user-attachments/assets/edf646c8-fc6c-497a-98e0-c47ed24a8a43" />
