### PR TITLE
feat: add zhipu and zhipu-coding provider

### DIFF
--- a/internal/providers/configs/zhipu-coding.json
+++ b/internal/providers/configs/zhipu-coding.json
@@ -1,0 +1,98 @@
+{
+  "name": "Zhipu Coding",
+  "id": "zhipu-coding",
+  "api_key": "$ZHIPU_API_KEY",
+  "api_endpoint": "https://open.bigmodel.cn/api/coding/paas/v4",
+  "type": "openai-compat",
+  "default_large_model_id": "glm-4.7",
+  "default_small_model_id": "glm-4.7-flash",
+  "models": [
+    {
+      "id": "glm-5",
+      "name": "GLM-5",
+      "cost_per_1m_in": 1.0,
+      "cost_per_1m_out": 3.2,
+      "cost_per_1m_in_cached": 0.2,
+      "context_window": 204800,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.7",
+      "name": "GLM-4.7",
+      "cost_per_1m_in": 0.42,
+      "cost_per_1m_out": 2.2,
+      "cost_per_1m_in_cached": 0.11,
+      "context_window": 204800,
+      "default_max_tokens": 102400,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.7-flash",
+      "name": "GLM-4.7 Flash",
+      "cost_per_1m_in": 0.07,
+      "cost_per_1m_out": 0.4,
+      "cost_per_1m_in_cached": 0.01,
+      "context_window": 200000,
+      "default_max_tokens": 65550,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.6",
+      "name": "GLM-4.6",
+      "cost_per_1m_in": 0.39,
+      "cost_per_1m_out": 1.9,
+      "cost_per_1m_in_cached": 0.11,
+      "context_window": 204800,
+      "default_max_tokens": 102400,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.6v",
+      "name": "GLM-4.6V",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 0.9,
+      "context_window": 131072,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "glm-4.5",
+      "name": "GLM-4.5",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 2.2,
+      "cost_per_1m_in_cached": 0.11,
+      "context_window": 131072,
+      "default_max_tokens": 49152,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.5-air",
+      "name": "GLM-4.5-Air",
+      "cost_per_1m_in": 0.13,
+      "cost_per_1m_out": 0.85,
+      "cost_per_1m_in_cached": 0.03,
+      "context_window": 131072,
+      "default_max_tokens": 49152,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.5v",
+      "name": "GLM-4.5V",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 1.8,
+      "cost_per_1m_in_cached": 0.11,
+      "context_window": 65536,
+      "default_max_tokens": 8192,
+      "can_reason": true,
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/configs/zhipu.json
+++ b/internal/providers/configs/zhipu.json
@@ -1,0 +1,98 @@
+{
+  "name": "Zhipu",
+  "id": "zhipu",
+  "api_key": "$ZHIPU_API_KEY",
+  "api_endpoint": "https://open.bigmodel.cn/api/paas/v4",
+  "type": "openai-compat",
+  "default_large_model_id": "glm-4.7",
+  "default_small_model_id": "glm-4.7-flash",
+  "models": [
+    {
+      "id": "glm-5",
+      "name": "GLM-5",
+      "cost_per_1m_in": 1.0,
+      "cost_per_1m_out": 3.2,
+      "cost_per_1m_in_cached": 0.2,
+      "context_window": 204800,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.7",
+      "name": "GLM-4.7",
+      "cost_per_1m_in": 0.42,
+      "cost_per_1m_out": 2.2,
+      "cost_per_1m_in_cached": 0.11,
+      "context_window": 204800,
+      "default_max_tokens": 102400,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.7-flash",
+      "name": "GLM-4.7 Flash",
+      "cost_per_1m_in": 0.07,
+      "cost_per_1m_out": 0.4,
+      "cost_per_1m_in_cached": 0.01,
+      "context_window": 200000,
+      "default_max_tokens": 65550,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.6",
+      "name": "GLM-4.6",
+      "cost_per_1m_in": 0.39,
+      "cost_per_1m_out": 1.9,
+      "cost_per_1m_in_cached": 0.11,
+      "context_window": 204800,
+      "default_max_tokens": 102400,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.6v",
+      "name": "GLM-4.6V",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 0.9,
+      "context_window": 131072,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "glm-4.5",
+      "name": "GLM-4.5",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 2.2,
+      "cost_per_1m_in_cached": 0.11,
+      "context_window": 131072,
+      "default_max_tokens": 49152,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.5-air",
+      "name": "GLM-4.5-Air",
+      "cost_per_1m_in": 0.13,
+      "cost_per_1m_out": 0.85,
+      "cost_per_1m_in_cached": 0.03,
+      "context_window": 131072,
+      "default_max_tokens": 49152,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-4.5v",
+      "name": "GLM-4.5V",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 1.8,
+      "cost_per_1m_in_cached": 0.11,
+      "context_window": 65536,
+      "default_max_tokens": 8192,
+      "can_reason": true,
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -36,6 +36,12 @@ var xAIConfig []byte
 //go:embed configs/zai.json
 var zAIConfig []byte
 
+//go:embed configs/zhipu.json
+var zhipuConfig []byte
+
+//go:embed configs/zhipu-coding.json
+var zhipuCodingConfig []byte
+
 //go:embed configs/bedrock.json
 var bedrockConfig []byte
 
@@ -90,6 +96,8 @@ var providerRegistry = []ProviderFunc{
 	vertexAIProvider,
 	xAIProvider,
 	zAIProvider,
+	zhipuProvider,
+	zhipuCodingProvider,
 	kimiCodingProvider,
 	groqProvider,
 	openRouterProvider,
@@ -159,6 +167,14 @@ func xAIProvider() catwalk.Provider {
 
 func zAIProvider() catwalk.Provider {
 	return loadProviderFromConfig(zAIConfig)
+}
+
+func zhipuProvider() catwalk.Provider {
+	return loadProviderFromConfig(zhipuConfig)
+}
+
+func zhipuCodingProvider() catwalk.Provider {
+	return loadProviderFromConfig(zhipuCodingConfig)
 }
 
 func openRouterProvider() catwalk.Provider {

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -30,6 +30,8 @@ const (
 	InferenceProviderVertexAI     InferenceProvider = "vertexai"
 	InferenceProviderXAI          InferenceProvider = "xai"
 	InferenceProviderZAI          InferenceProvider = "zai"
+	InferenceProviderZhipu        InferenceProvider = "zhipu"
+	InferenceProviderZhipuCoding  InferenceProvider = "zhipu-coding"
 	InferenceProviderGROQ         InferenceProvider = "groq"
 	InferenceProviderOpenRouter   InferenceProvider = "openrouter"
 	InferenceProviderCerebras     InferenceProvider = "cerebras"
@@ -97,6 +99,8 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderVertexAI,
 		InferenceProviderXAI,
 		InferenceProviderZAI,
+		InferenceProviderZhipu,
+		InferenceProviderZhipuCoding,
 		InferenceProviderGROQ,
 		InferenceProviderOpenRouter,
 		InferenceProviderCerebras,


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Add Zhipu and Zhipu-coding providers. These are hosted by the company which created GLM model and hosted z.ai, but for mainland China.

I included the coding variant because, although issue [#1079](https://github.com/charmbracelet/crush/issues/1079) mentions that z.ai unified them, my account has an expired coding plan but have enough API quota. Calling the coding endpoint results in an 'expired subscription' error, whereas the normal endpoint works successfully.

<img width="1168" height="885" alt="图片" src="https://github.com/user-attachments/assets/17cd048c-8bec-4341-8894-4e175974153b" />

I suspect z.ai might share this behavior, where the same API key works for both endpoints but follows different billing logic. However, I don't have a z.ai account and can't verify this.