### PR TITLE
Add Alibaba coding-plan provider

### DIFF
--- a/internal/providers/configs/alibaba-coding.json
+++ b/internal/providers/configs/alibaba-coding.json
@@ -1,6 +1,6 @@
 {
   "name": "Alibaba Coding Plan",
-  "id": "alibaba",
+  "id": "alibaba-coding",
   "type": "openai-compat",
   "api_key": "$ALIBABA_API_KEY",
   "api_endpoint": "https://coding-intl.dashscope.aliyuncs.com/v1",
@@ -47,7 +47,7 @@
     },
     {
       "id": "qwen3-max-2026-01-23",
-      "name": "Qwen3 Max 2026-01-23 (Coding Plan)",
+      "name": "Qwen3 Max 2026-01-23",
       "context_window": 262144,
       "default_max_tokens": 65536,
       "cost_per_1m_in": 0,
@@ -66,7 +66,7 @@
     },
     {
       "id": "qwen3.5-plus",
-      "name": "Qwen3.5 Plus (Vision + Coding Plan)",
+      "name": "Qwen3.5 Plus",
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "cost_per_1m_in": 0,
@@ -85,7 +85,7 @@
     },
     {
       "id": "kimi-k2.5",
-      "name": "Moonshot Kimi K2.5 (Coding Plan + Vision)",
+      "name": "Moonshot Kimi K2.5",
       "context_window": 262144,
       "default_max_tokens": 32768,
       "cost_per_1m_in": 0,
@@ -104,7 +104,7 @@
     },
     {
       "id": "glm-5",
-      "name": "GLM 5 (Coding Plan)",
+      "name": "GLM 5",
       "context_window": 202752,
       "default_max_tokens": 16384,
       "cost_per_1m_in": 0,
@@ -123,7 +123,7 @@
     },
     {
       "id": "glm-4.7",
-      "name": "GLM 4.7 (Coding Plan)",
+      "name": "GLM 4.7",
       "context_window": 131072,
       "default_max_tokens": 16384,
       "cost_per_1m_in": 0,
@@ -142,7 +142,7 @@
     },
     {
       "id": "MiniMax-M2.5",
-      "name": "MiniMax M2.5 (Coding Plan + Vision)",
+      "name": "MiniMax M2.5",
       "context_window": 262144,
       "default_max_tokens": 65536,
       "cost_per_1m_in": 0,

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -84,8 +84,8 @@ var miniMaxChinaConfig []byte
 //go:embed configs/ionet.json
 var ioNetConfig []byte
 
-//go:embed configs/alibaba.json
-var alibabaConfig []byte
+//go:embed configs/alibaba-coding.json
+var alibabaCodingConfig []byte
 
 // ProviderFunc is a function that returns a Provider.
 type ProviderFunc func() catwalk.Provider
@@ -116,7 +116,7 @@ var providerRegistry = []ProviderFunc{
 	miniMaxProvider,
 	miniMaxChinaProvider,
 	ioNetProvider,
-	alibabaProvider,
+	alibabaCodingProvider,
 }
 
 // GetAll returns all registered providers.
@@ -237,6 +237,6 @@ func ioNetProvider() catwalk.Provider {
 	return loadProviderFromConfig(ioNetConfig)
 }
 
-func alibabaProvider() catwalk.Provider {
-	return loadProviderFromConfig(alibabaConfig)
+func alibabaCodingProvider() catwalk.Provider {
+	return loadProviderFromConfig(alibabaCodingConfig)
 }

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -21,31 +21,31 @@ type InferenceProvider string
 
 // All the inference providers supported by the system.
 const (
-	InferenceProviderOpenAI       InferenceProvider = "openai"
-	InferenceProviderAnthropic    InferenceProvider = "anthropic"
-	InferenceProviderSynthetic    InferenceProvider = "synthetic"
-	InferenceProviderGemini       InferenceProvider = "gemini"
-	InferenceProviderAzure        InferenceProvider = "azure"
-	InferenceProviderBedrock      InferenceProvider = "bedrock"
-	InferenceProviderVertexAI     InferenceProvider = "vertexai"
-	InferenceProviderXAI          InferenceProvider = "xai"
-	InferenceProviderZAI          InferenceProvider = "zai"
-	InferenceProviderZhipu        InferenceProvider = "zhipu"
-	InferenceProviderZhipuCoding  InferenceProvider = "zhipu-coding"
-	InferenceProviderGROQ         InferenceProvider = "groq"
-	InferenceProviderOpenRouter   InferenceProvider = "openrouter"
-	InferenceProviderCerebras     InferenceProvider = "cerebras"
-	InferenceProviderVenice       InferenceProvider = "venice"
-	InferenceProviderChutes       InferenceProvider = "chutes"
-	InferenceProviderHuggingFace  InferenceProvider = "huggingface"
-	InferenceAIHubMix             InferenceProvider = "aihubmix"
-	InferenceKimiCoding           InferenceProvider = "kimi-coding"
-	InferenceProviderCopilot      InferenceProvider = "copilot"
-	InferenceProviderVercel       InferenceProvider = "vercel"
-	InferenceProviderMiniMax      InferenceProvider = "minimax"
-	InferenceProviderMiniMaxChina InferenceProvider = "minimax-china"
-	InferenceProviderIoNet        InferenceProvider = "ionet"
-	InferenceProviderAlibaba      InferenceProvider = "alibaba"
+	InferenceProviderOpenAI        InferenceProvider = "openai"
+	InferenceProviderAnthropic     InferenceProvider = "anthropic"
+	InferenceProviderSynthetic     InferenceProvider = "synthetic"
+	InferenceProviderGemini        InferenceProvider = "gemini"
+	InferenceProviderAzure         InferenceProvider = "azure"
+	InferenceProviderBedrock       InferenceProvider = "bedrock"
+	InferenceProviderVertexAI      InferenceProvider = "vertexai"
+	InferenceProviderXAI           InferenceProvider = "xai"
+	InferenceProviderZAI           InferenceProvider = "zai"
+	InferenceProviderZhipu         InferenceProvider = "zhipu"
+	InferenceProviderZhipuCoding   InferenceProvider = "zhipu-coding"
+	InferenceProviderGROQ          InferenceProvider = "groq"
+	InferenceProviderOpenRouter    InferenceProvider = "openrouter"
+	InferenceProviderCerebras      InferenceProvider = "cerebras"
+	InferenceProviderVenice        InferenceProvider = "venice"
+	InferenceProviderChutes        InferenceProvider = "chutes"
+	InferenceProviderHuggingFace   InferenceProvider = "huggingface"
+	InferenceAIHubMix              InferenceProvider = "aihubmix"
+	InferenceKimiCoding            InferenceProvider = "kimi-coding"
+	InferenceProviderCopilot       InferenceProvider = "copilot"
+	InferenceProviderVercel        InferenceProvider = "vercel"
+	InferenceProviderMiniMax       InferenceProvider = "minimax"
+	InferenceProviderMiniMaxChina  InferenceProvider = "minimax-china"
+	InferenceProviderIoNet         InferenceProvider = "ionet"
+	InferenceProviderAlibabaCoding InferenceProvider = "alibaba-coding"
 )
 
 // Provider represents an AI provider configuration.
@@ -115,7 +115,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderMiniMax,
 		InferenceProviderMiniMaxChina,
 		InferenceProviderIoNet,
-		InferenceProviderAlibaba,
+		InferenceProviderAlibabaCoding,
 	}
 }
 


### PR DESCRIPTION
Adds a new Alibaba provider config and registers it in the provider registry:
- add internal/providers/configs/alibaba.json
- register provider embed+factory in internal/providers/providers.go
- add InferenceProviderAlibaba to known providers
---

* Closes #200
* Crush PR: https://github.com/charmbracelet/crush/pull/2353