### PR TITLE
Add regional Alibaba pay providers

### DIFF
--- a/internal/providers/configs/alibaba-coding.json
+++ b/internal/providers/configs/alibaba-coding.json
@@ -1,6 +1,6 @@
 {
   "name": "Alibaba Coding Plan",
-  "id": "alibaba",
+  "id": "alibaba-coding",
   "type": "openai-compat",
   "api_key": "$ALIBABA_API_KEY",
   "api_endpoint": "https://coding-intl.dashscope.aliyuncs.com/v1",
@@ -47,7 +47,7 @@
     },
     {
       "id": "qwen3-max-2026-01-23",
-      "name": "Qwen3 Max 2026-01-23 (Coding Plan)",
+      "name": "Qwen3 Max 2026-01-23",
       "context_window": 262144,
       "default_max_tokens": 65536,
       "cost_per_1m_in": 0,
@@ -66,7 +66,7 @@
     },
     {
       "id": "qwen3.5-plus",
-      "name": "Qwen3.5 Plus (Vision + Coding Plan)",
+      "name": "Qwen3.5 Plus",
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "cost_per_1m_in": 0,
@@ -85,7 +85,7 @@
     },
     {
       "id": "kimi-k2.5",
-      "name": "Moonshot Kimi K2.5 (Coding Plan + Vision)",
+      "name": "Moonshot Kimi K2.5",
       "context_window": 262144,
       "default_max_tokens": 32768,
       "cost_per_1m_in": 0,
@@ -104,7 +104,7 @@
     },
     {
       "id": "glm-5",
-      "name": "GLM 5 (Coding Plan)",
+      "name": "GLM 5",
       "context_window": 202752,
       "default_max_tokens": 16384,
       "cost_per_1m_in": 0,
@@ -123,7 +123,7 @@
     },
     {
       "id": "glm-4.7",
-      "name": "GLM 4.7 (Coding Plan)",
+      "name": "GLM 4.7",
       "context_window": 131072,
       "default_max_tokens": 16384,
       "cost_per_1m_in": 0,
@@ -142,7 +142,7 @@
     },
     {
       "id": "MiniMax-M2.5",
-      "name": "MiniMax M2.5 (Coding Plan + Vision)",
+      "name": "MiniMax M2.5",
       "context_window": 262144,
       "default_max_tokens": 65536,
       "cost_per_1m_in": 0,

--- a/internal/providers/configs/alibaba-pay-china.json
+++ b/internal/providers/configs/alibaba-pay-china.json
@@ -1,0 +1,163 @@
+{
+  "name": "Alibaba Pay China",
+  "id": "alibaba-pay-china",
+  "type": "openai-compat",
+  "api_key": "$ALIBABA_API_KEY",
+  "api_endpoint": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+  "default_large_model_id": "qwen3-max-2026-01-23",
+  "default_small_model_id": "glm-4.7",
+  "models": [
+    {
+      "id": "qwen3-coder-next",
+      "name": "Qwen3 Coder Next",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3-coder-plus",
+      "name": "Qwen3 Coder Plus",
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3-max-2026-01-23",
+      "name": "Qwen3 Max 2026-01-23",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3.5-plus",
+      "name": "Qwen3.5 Plus",
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    },
+    {
+      "id": "kimi-k2.5",
+      "name": "Moonshot Kimi K2.5",
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    },
+    {
+      "id": "glm-5",
+      "name": "GLM 5",
+      "context_window": 202752,
+      "default_max_tokens": 16384,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "glm-4.7",
+      "name": "GLM 4.7",
+      "context_window": 131072,
+      "default_max_tokens": 16384,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "MiniMax-M2.5",
+      "name": "MiniMax M2.5",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    }
+  ]
+}

--- a/internal/providers/configs/alibaba-pay-us.json
+++ b/internal/providers/configs/alibaba-pay-us.json
@@ -1,0 +1,163 @@
+{
+  "name": "Alibaba Pay US",
+  "id": "alibaba-pay-us",
+  "type": "openai-compat",
+  "api_key": "$ALIBABA_API_KEY",
+  "api_endpoint": "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+  "default_large_model_id": "qwen3-max-2026-01-23",
+  "default_small_model_id": "glm-4.7",
+  "models": [
+    {
+      "id": "qwen3-coder-next",
+      "name": "Qwen3 Coder Next",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3-coder-plus",
+      "name": "Qwen3 Coder Plus",
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3-max-2026-01-23",
+      "name": "Qwen3 Max 2026-01-23",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3.5-plus",
+      "name": "Qwen3.5 Plus",
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    },
+    {
+      "id": "kimi-k2.5",
+      "name": "Moonshot Kimi K2.5",
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    },
+    {
+      "id": "glm-5",
+      "name": "GLM 5",
+      "context_window": 202752,
+      "default_max_tokens": 16384,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "glm-4.7",
+      "name": "GLM 4.7",
+      "context_window": 131072,
+      "default_max_tokens": 16384,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "MiniMax-M2.5",
+      "name": "MiniMax M2.5",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    }
+  ]
+}

--- a/internal/providers/configs/alibaba-pay.json
+++ b/internal/providers/configs/alibaba-pay.json
@@ -1,0 +1,163 @@
+{
+  "name": "Alibaba Pay",
+  "id": "alibaba-pay",
+  "type": "openai-compat",
+  "api_key": "$ALIBABA_API_KEY",
+  "api_endpoint": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+  "default_large_model_id": "qwen3-max-2026-01-23",
+  "default_small_model_id": "glm-4.7",
+  "models": [
+    {
+      "id": "qwen3-coder-next",
+      "name": "Qwen3 Coder Next",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3-coder-plus",
+      "name": "Qwen3 Coder Plus",
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3-max-2026-01-23",
+      "name": "Qwen3 Max 2026-01-23",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3.5-plus",
+      "name": "Qwen3.5 Plus",
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    },
+    {
+      "id": "kimi-k2.5",
+      "name": "Moonshot Kimi K2.5",
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    },
+    {
+      "id": "glm-5",
+      "name": "GLM 5",
+      "context_window": 202752,
+      "default_max_tokens": 16384,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "glm-4.7",
+      "name": "GLM 4.7",
+      "context_window": 131072,
+      "default_max_tokens": 16384,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "MiniMax-M2.5",
+      "name": "MiniMax M2.5",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    }
+  ]
+}

--- a/internal/providers/configs/alibaba.json
+++ b/internal/providers/configs/alibaba.json
@@ -1,0 +1,163 @@
+{
+  "name": "Alibaba Coding Plan",
+  "id": "alibaba",
+  "type": "openai-compat",
+  "api_key": "$ALIBABA_API_KEY",
+  "api_endpoint": "https://coding-intl.dashscope.aliyuncs.com/v1",
+  "default_large_model_id": "qwen3-max-2026-01-23",
+  "default_small_model_id": "glm-4.7",
+  "models": [
+    {
+      "id": "qwen3-coder-next",
+      "name": "Qwen3 Coder Next",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3-coder-plus",
+      "name": "Qwen3 Coder Plus",
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3-max-2026-01-23",
+      "name": "Qwen3 Max 2026-01-23 (Coding Plan)",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "qwen3.5-plus",
+      "name": "Qwen3.5 Plus (Vision + Coding Plan)",
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    },
+    {
+      "id": "kimi-k2.5",
+      "name": "Moonshot Kimi K2.5 (Coding Plan + Vision)",
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    },
+    {
+      "id": "glm-5",
+      "name": "GLM 5 (Coding Plan)",
+      "context_window": 202752,
+      "default_max_tokens": 16384,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "glm-4.7",
+      "name": "GLM 4.7 (Coding Plan)",
+      "context_window": 131072,
+      "default_max_tokens": 16384,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "options": {}
+    },
+    {
+      "id": "MiniMax-M2.5",
+      "name": "MiniMax M2.5 (Coding Plan + Vision)",
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true,
+      "options": {}
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -84,8 +84,8 @@ var miniMaxChinaConfig []byte
 //go:embed configs/ionet.json
 var ioNetConfig []byte
 
-//go:embed configs/alibaba.json
-var alibabaConfig []byte
+//go:embed configs/alibaba-coding.json
+var alibabaCodingConfig []byte
 
 // ProviderFunc is a function that returns a Provider.
 type ProviderFunc func() catwalk.Provider
@@ -116,7 +116,7 @@ var providerRegistry = []ProviderFunc{
 	miniMaxProvider,
 	miniMaxChinaProvider,
 	ioNetProvider,
-	alibabaProvider,
+	alibabaCodingProvider,
 }
 
 // GetAll returns all registered providers.
@@ -237,6 +237,6 @@ func ioNetProvider() catwalk.Provider {
 	return loadProviderFromConfig(ioNetConfig)
 }
 
-func alibabaProvider() catwalk.Provider {
-	return loadProviderFromConfig(alibabaConfig)
+func alibabaCodingProvider() catwalk.Provider {
+	return loadProviderFromConfig(alibabaCodingConfig)
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -84,6 +84,9 @@ var miniMaxChinaConfig []byte
 //go:embed configs/ionet.json
 var ioNetConfig []byte
 
+//go:embed configs/alibaba.json
+var alibabaConfig []byte
+
 // ProviderFunc is a function that returns a Provider.
 type ProviderFunc func() catwalk.Provider
 
@@ -113,6 +116,7 @@ var providerRegistry = []ProviderFunc{
 	miniMaxProvider,
 	miniMaxChinaProvider,
 	ioNetProvider,
+	alibabaProvider,
 }
 
 // GetAll returns all registered providers.
@@ -231,4 +235,8 @@ func miniMaxChinaProvider() catwalk.Provider {
 
 func ioNetProvider() catwalk.Provider {
 	return loadProviderFromConfig(ioNetConfig)
+}
+
+func alibabaProvider() catwalk.Provider {
+	return loadProviderFromConfig(alibabaConfig)
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -87,6 +87,15 @@ var ioNetConfig []byte
 //go:embed configs/alibaba-coding.json
 var alibabaCodingConfig []byte
 
+//go:embed configs/alibaba-pay.json
+var alibabaPayConfig []byte
+
+//go:embed configs/alibaba-pay-us.json
+var alibabaPayUSConfig []byte
+
+//go:embed configs/alibaba-pay-china.json
+var alibabaPayChinaConfig []byte
+
 // ProviderFunc is a function that returns a Provider.
 type ProviderFunc func() catwalk.Provider
 
@@ -117,6 +126,9 @@ var providerRegistry = []ProviderFunc{
 	miniMaxChinaProvider,
 	ioNetProvider,
 	alibabaCodingProvider,
+	alibabaPayProvider,
+	alibabaPayUSProvider,
+	alibabaPayChinaProvider,
 }
 
 // GetAll returns all registered providers.
@@ -239,4 +251,16 @@ func ioNetProvider() catwalk.Provider {
 
 func alibabaCodingProvider() catwalk.Provider {
 	return loadProviderFromConfig(alibabaCodingConfig)
+}
+
+func alibabaPayProvider() catwalk.Provider {
+	return loadProviderFromConfig(alibabaPayConfig)
+}
+
+func alibabaPayUSProvider() catwalk.Provider {
+	return loadProviderFromConfig(alibabaPayUSConfig)
+}
+
+func alibabaPayChinaProvider() catwalk.Provider {
+	return loadProviderFromConfig(alibabaPayChinaConfig)
 }

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -45,6 +45,7 @@ const (
 	InferenceProviderMiniMax      InferenceProvider = "minimax"
 	InferenceProviderMiniMaxChina InferenceProvider = "minimax-china"
 	InferenceProviderIoNet        InferenceProvider = "ionet"
+	InferenceProviderAlibaba      InferenceProvider = "alibaba"
 )
 
 // Provider represents an AI provider configuration.
@@ -113,6 +114,8 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderVercel,
 		InferenceProviderMiniMax,
 		InferenceProviderMiniMaxChina,
+		InferenceProviderIoNet,
+		InferenceProviderAlibaba,
 	}
 }
 

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -46,6 +46,9 @@ const (
 	InferenceProviderMiniMaxChina  InferenceProvider = "minimax-china"
 	InferenceProviderIoNet         InferenceProvider = "ionet"
 	InferenceProviderAlibabaCoding InferenceProvider = "alibaba-coding"
+	InferenceProviderAlibabaPay    InferenceProvider = "alibaba-pay"
+	InferenceProviderAlibabaPayUS  InferenceProvider = "alibaba-pay-us"
+	InferenceProviderAlibabaPayCN  InferenceProvider = "alibaba-pay-china"
 )
 
 // Provider represents an AI provider configuration.
@@ -116,6 +119,9 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderMiniMaxChina,
 		InferenceProviderIoNet,
 		InferenceProviderAlibabaCoding,
+		InferenceProviderAlibabaPay,
+		InferenceProviderAlibabaPayUS,
+		InferenceProviderAlibabaPayCN,
 	}
 }
 

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -21,31 +21,31 @@ type InferenceProvider string
 
 // All the inference providers supported by the system.
 const (
-	InferenceProviderOpenAI       InferenceProvider = "openai"
-	InferenceProviderAnthropic    InferenceProvider = "anthropic"
-	InferenceProviderSynthetic    InferenceProvider = "synthetic"
-	InferenceProviderGemini       InferenceProvider = "gemini"
-	InferenceProviderAzure        InferenceProvider = "azure"
-	InferenceProviderBedrock      InferenceProvider = "bedrock"
-	InferenceProviderVertexAI     InferenceProvider = "vertexai"
-	InferenceProviderXAI          InferenceProvider = "xai"
-	InferenceProviderZAI          InferenceProvider = "zai"
-	InferenceProviderZhipu        InferenceProvider = "zhipu"
-	InferenceProviderZhipuCoding  InferenceProvider = "zhipu-coding"
-	InferenceProviderGROQ         InferenceProvider = "groq"
-	InferenceProviderOpenRouter   InferenceProvider = "openrouter"
-	InferenceProviderCerebras     InferenceProvider = "cerebras"
-	InferenceProviderVenice       InferenceProvider = "venice"
-	InferenceProviderChutes       InferenceProvider = "chutes"
-	InferenceProviderHuggingFace  InferenceProvider = "huggingface"
-	InferenceAIHubMix             InferenceProvider = "aihubmix"
-	InferenceKimiCoding           InferenceProvider = "kimi-coding"
-	InferenceProviderCopilot      InferenceProvider = "copilot"
-	InferenceProviderVercel       InferenceProvider = "vercel"
-	InferenceProviderMiniMax      InferenceProvider = "minimax"
-	InferenceProviderMiniMaxChina InferenceProvider = "minimax-china"
-	InferenceProviderIoNet        InferenceProvider = "ionet"
-	InferenceProviderAlibaba      InferenceProvider = "alibaba"
+	InferenceProviderOpenAI        InferenceProvider = "openai"
+	InferenceProviderAnthropic     InferenceProvider = "anthropic"
+	InferenceProviderSynthetic     InferenceProvider = "synthetic"
+	InferenceProviderGemini        InferenceProvider = "gemini"
+	InferenceProviderAzure         InferenceProvider = "azure"
+	InferenceProviderBedrock       InferenceProvider = "bedrock"
+	InferenceProviderVertexAI      InferenceProvider = "vertexai"
+	InferenceProviderXAI           InferenceProvider = "xai"
+	InferenceProviderZAI           InferenceProvider = "zai"
+	InferenceProviderZhipu         InferenceProvider = "zhipu"
+	InferenceProviderZhipuCoding   InferenceProvider = "zhipu-coding"
+	InferenceProviderGROQ          InferenceProvider = "groq"
+	InferenceProviderOpenRouter    InferenceProvider = "openrouter"
+	InferenceProviderCerebras      InferenceProvider = "cerebras"
+	InferenceProviderVenice        InferenceProvider = "venice"
+	InferenceProviderChutes        InferenceProvider = "chutes"
+	InferenceProviderHuggingFace   InferenceProvider = "huggingface"
+	InferenceAIHubMix              InferenceProvider = "aihubmix"
+	InferenceKimiCoding            InferenceProvider = "kimi-coding"
+	InferenceProviderCopilot       InferenceProvider = "copilot"
+	InferenceProviderVercel        InferenceProvider = "vercel"
+	InferenceProviderMiniMax       InferenceProvider = "minimax"
+	InferenceProviderMiniMaxChina  InferenceProvider = "minimax-china"
+	InferenceProviderIoNet         InferenceProvider = "ionet"
+	InferenceProviderAlibabaCoding InferenceProvider = "alibaba-coding"
 )
 
 // Provider represents an AI provider configuration.
@@ -115,7 +115,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderMiniMax,
 		InferenceProviderMiniMaxChina,
 		InferenceProviderIoNet,
-		InferenceProviderAlibaba,
+		InferenceProviderAlibabaCoding,
 	}
 }
 


### PR DESCRIPTION
* Closes #200
* Crush PR: https://github.com/charmbracelet/crush/pull/2353

## Summary
- add `alibaba-pay` (Singapore) using `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
- add `alibaba-pay-us` using `https://dashscope-us.aliyuncs.com/compatible-mode/v1`
- add `alibaba-pay-china` using `https://dashscope.aliyuncs.com/compatible-mode/v1`
- register all three providers in the registry and `KnownProviders`

## Notes
- keeps `alibaba-coding` separate and unchanged (`coding-intl` endpoint)