### PR TITLE
fix `default_reasoning_efforts` typo

### DIFF
--- a/internal/providers/configs/anthropic.json
+++ b/internal/providers/configs/anthropic.json
@@ -18,7 +18,7 @@
       "default_max_tokens": 64000,
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
-      "default_reasoning_efforts": "medium",
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -39,12 +39,12 @@
       "cost_per_1m_in": 5,
       "cost_per_1m_out": 25,
       "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.50,
+      "cost_per_1m_out_cached": 0.5,
       "context_window": 1000000,
       "default_max_tokens": 126000,
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
-      "default_reasoning_efforts": "medium",
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -53,7 +53,7 @@
       "cost_per_1m_in": 5,
       "cost_per_1m_out": 25,
       "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.50,
+      "cost_per_1m_out_cached": 0.5,
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,

--- a/internal/providers/configs/cerebras.json
+++ b/internal/providers/configs/cerebras.json
@@ -1,52 +1,48 @@
 {
-    "name": "Cerebras",
-    "id": "cerebras",
-    "type": "openai-compat",
-    "api_key": "$CEREBRAS_API_KEY",
-    "api_endpoint": "https://api.cerebras.ai/v1",
-    "default_large_model_id": "gpt-oss-120b",
-    "default_small_model_id": "qwen-3-235b-a22b-instruct-2507",
-    "default_headers": {
-        "X-Cerebras-3rd-Party-Integration": "crush"
+  "name": "Cerebras",
+  "id": "cerebras",
+  "type": "openai-compat",
+  "api_key": "$CEREBRAS_API_KEY",
+  "api_endpoint": "https://api.cerebras.ai/v1",
+  "default_large_model_id": "gpt-oss-120b",
+  "default_small_model_id": "qwen-3-235b-a22b-instruct-2507",
+  "default_headers": {
+    "X-Cerebras-3rd-Party-Integration": "crush"
+  },
+  "models": [
+    {
+      "id": "gpt-oss-120b",
+      "name": "OpenAI GPT OSS",
+      "cost_per_1m_in": 0.35,
+      "cost_per_1m_out": 0.75,
+      "context_window": 131072,
+      "default_max_tokens": 25000,
+      "can_reason": true,
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
     },
-    "models": [
-        {
-            "id": "gpt-oss-120b",
-            "name": "OpenAI GPT OSS",
-            "cost_per_1m_in": 0.35,
-            "cost_per_1m_out": 0.75,
-            "context_window": 131072,
-            "default_max_tokens": 25000,
-            "can_reason": true,
-            "reasoning_levels": [
-                "low",
-                "medium",
-                "high"
-            ],
-            "default_reasoning_efforts": "medium",
-            "supports_attachments": false
-        },
-        {
-            "id": "qwen-3-235b-a22b-instruct-2507",
-            "name": "Qwen 3 235B Instruct",
-            "cost_per_1m_in": 0.6,
-            "cost_per_1m_out": 1.2,
-            "context_window": 131072,
-            "default_max_tokens": 25000,
-            "can_reason": false,
-            "supports_attachments": false
-        },
-        {
-            "id": "zai-glm-4.7",
-            "name": "Z.ai GLM 4.7",
-            "cost_per_1m_in": 2.25,
-            "cost_per_1m_out": 2.75,
-            "context_window": 131072,
-            "default_max_tokens": 25000,
-            "can_reason": false,
-            "supports_attachments": false,
-            "temperature": 1,
-            "top_p": 0.95
-        }
-    ]
+    {
+      "id": "qwen-3-235b-a22b-instruct-2507",
+      "name": "Qwen 3 235B Instruct",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 1.2,
+      "context_window": 131072,
+      "default_max_tokens": 25000,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "zai-glm-4.7",
+      "name": "Z.ai GLM 4.7",
+      "cost_per_1m_in": 2.25,
+      "cost_per_1m_out": 2.75,
+      "context_window": 131072,
+      "default_max_tokens": 25000,
+      "can_reason": false,
+      "supports_attachments": false,
+      "temperature": 1,
+      "top_p": 0.95
+    }
+  ]
 }

--- a/internal/providers/configs/chutes.json
+++ b/internal/providers/configs/chutes.json
@@ -15,12 +15,8 @@
       "context_window": 262000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -31,12 +27,8 @@
       "context_window": 98000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -47,12 +39,8 @@
       "context_window": 75000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -63,12 +51,8 @@
       "context_window": 75000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -101,12 +85,8 @@
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -117,12 +97,8 @@
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -133,12 +109,8 @@
       "context_window": 75000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -160,12 +132,8 @@
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -176,12 +144,8 @@
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -225,12 +189,8 @@
       "context_window": 32768,
       "default_max_tokens": 8192,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -252,12 +212,8 @@
       "context_window": 163840,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {

--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -29,12 +29,8 @@
       "context_window": 128000,
       "default_max_tokens": 32000,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "supports_attachments": false
     }
   ]

--- a/internal/providers/configs/gemini.json
+++ b/internal/providers/configs/gemini.json
@@ -18,7 +18,7 @@
       "default_max_tokens": 64000,
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
-      "default_reasoning_efforts": "medium",
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -32,7 +32,7 @@
       "default_max_tokens": 64000,
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
-      "default_reasoning_efforts": "medium",
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -46,7 +46,7 @@
       "default_max_tokens": 64000,
       "can_reason": true,
       "reasoning_levels": ["low", "high"],
-      "default_reasoning_efforts": "high",
+      "default_reasoning_effort": "high",
       "supports_attachments": true
     },
     {
@@ -60,7 +60,7 @@
       "default_max_tokens": 50000,
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
-      "default_reasoning_efforts": "minimal",
+      "default_reasoning_effort": "minimal",
       "supports_attachments": true
     },
     {

--- a/internal/providers/configs/groq.json
+++ b/internal/providers/configs/groq.json
@@ -16,12 +16,8 @@
       "cost_per_1m_out_cached": 0.5,
       "context_window": 131072,
       "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_efforts": "medium",
+      "reasoning_levels": ["low", "medium", "high"],
+      "default_reasoning_effort": "medium",
       "default_max_tokens": 10000
     },
     {

--- a/internal/providers/configs/vertexai.json
+++ b/internal/providers/configs/vertexai.json
@@ -18,7 +18,7 @@
       "default_max_tokens": 64000,
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
-      "default_reasoning_efforts": "medium",
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -32,7 +32,7 @@
       "default_max_tokens": 64000,
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
-      "default_reasoning_efforts": "medium",
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -46,7 +46,7 @@
       "default_max_tokens": 64000,
       "can_reason": true,
       "reasoning_levels": ["low", "high"],
-      "default_reasoning_efforts": "high",
+      "default_reasoning_effort": "high",
       "supports_attachments": true
     },
     {
@@ -60,7 +60,7 @@
       "default_max_tokens": 50000,
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
-      "default_reasoning_efforts": "minimal",
+      "default_reasoning_effort": "minimal",
       "supports_attachments": true
     },
     {
@@ -98,7 +98,7 @@
       "default_max_tokens": 50000,
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
-      "default_reasoning_efforts": "medium",
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -119,12 +119,12 @@
       "cost_per_1m_in": 5,
       "cost_per_1m_out": 25,
       "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.50,
+      "cost_per_1m_out_cached": 0.5,
       "context_window": 200000,
       "default_max_tokens": 126000,
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
-      "default_reasoning_efforts": "medium",
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
@@ -133,7 +133,7 @@
       "cost_per_1m_in": 5,
       "cost_per_1m_out": 25,
       "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.50,
+      "cost_per_1m_out_cached": 0.5,
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,


### PR DESCRIPTION
Heya - noticed this, which seems like an obvious typo since the schema is `default_reasoning_effort` (singular).

Pardon the other changes - my editor auto-formatted, and I figured that should probably just come along for the ride (if not me it'll be someone else).