### PR TITLE
Add mandatory inference prefixes based on regions for AWS bedrock models

### DIFF
--- a/internal/providers/configs/bedrock.json
+++ b/internal/providers/configs/bedrock.json
@@ -19,7 +19,8 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "regions": ["us", "eu", "jp", "au", "global"]
     },
     {
       "id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -31,7 +32,8 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "supports_attachments": true,
+      "regions": ["us", "eu", "jp", "au", "global"]
     },
     {
       "id": "anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -43,7 +45,8 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "supports_attachments": true,
+      "regions": ["us", "eu", "jp", "au", "global"]
     },
     {
       "id": "anthropic.claude-opus-4-7",
@@ -57,7 +60,8 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "regions": ["us", "eu", "jp", "au", "global"]
     },
     {
       "id": "anthropic.claude-opus-4-6-v1",
@@ -71,7 +75,8 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "regions": ["us", "eu", "au", "global"]
     },
     {
       "id": "anthropic.claude-opus-4-5-20251101-v1:0",
@@ -83,31 +88,8 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
-    },
-    {
-      "id": "anthropic.claude-opus-4-1-20250805-v1:0",
-      "name": "AWS Claude Opus 4.1",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 75,
-      "cost_per_1m_in_cached": 18.75,
-      "cost_per_1m_out_cached": 1.5,
-      "context_window": 200000,
-      "default_max_tokens": 32000,
-      "can_reason": true,
-      "supports_attachments": true
-    },
-    {
-      "id": "anthropic.claude-opus-4-20250514-v1:0",
-      "name": "AWS Claude Opus 4",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 75,
-      "cost_per_1m_in_cached": 18.75,
-      "cost_per_1m_out_cached": 1.5,
-      "context_window": 200000,
-      "default_max_tokens": 32000,
-      "can_reason": true,
-      "supports_attachments": true
+      "supports_attachments": true,
+      "regions": ["us", "eu", "global"]
     },
     {
       "id": "anthropic.claude-sonnet-4-20250514-v1:0",
@@ -119,7 +101,34 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "supports_attachments": true,
+      "regions": ["us", "eu", "apac", "global"]
+    },
+    {
+      "id": "anthropic.claude-opus-4-20250514-v1:0",
+      "name": "AWS Claude Opus 4",
+      "cost_per_1m_in": 15,
+      "cost_per_1m_out": 75,
+      "cost_per_1m_in_cached": 18.75,
+      "cost_per_1m_out_cached": 1.5,
+      "context_window": 200000,
+      "default_max_tokens": 32000,
+      "can_reason": true,
+      "supports_attachments": true,
+      "regions": ["us"]
+    },
+    {
+      "id": "anthropic.claude-opus-4-1-20250805-v1:0",
+      "name": "AWS Claude Opus 4.1",
+      "cost_per_1m_in": 15,
+      "cost_per_1m_out": 75,
+      "cost_per_1m_in_cached": 18.75,
+      "cost_per_1m_out_cached": 1.5,
+      "context_window": 200000,
+      "default_max_tokens": 32000,
+      "can_reason": true,
+      "supports_attachments": true,
+      "regions": ["us"]
     }
   ]
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -4,7 +4,11 @@ package providers
 import (
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"log"
+	"os"
+	"slices"
+	"strings"
 
 	"charm.land/catwalk/pkg/catwalk"
 )
@@ -189,7 +193,87 @@ func azureProvider() catwalk.Provider {
 }
 
 func bedrockProvider() catwalk.Provider {
-	return loadProviderFromConfig(bedrockConfig)
+	p := loadProviderFromConfig(bedrockConfig)
+
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	}
+
+	regionsByModelID, err := loadBedrockRegionsByModelID()
+	if err != nil {
+		log.Printf("Error loading bedrock regions: %v", err)
+		return catwalk.Provider{}
+	}
+
+	prefix := bedrockRegionPrefix(region)
+	origLarge := p.DefaultLargeModelID
+	origSmall := p.DefaultSmallModelID
+
+	resolved := make([]catwalk.Model, 0, len(p.Models))
+	for _, m := range p.Models {
+		id := m.ID
+		regions := regionsByModelID[id]
+
+		switch {
+		case slices.Contains(regions, prefix):
+			m.ID = prefix + "." + m.ID
+		case slices.Contains(regions, "global"):
+			m.ID = "global." + m.ID
+		default:
+			continue
+		}
+
+		if id == origLarge {
+			p.DefaultLargeModelID = m.ID
+		}
+		if id == origSmall {
+			p.DefaultSmallModelID = m.ID
+		}
+		resolved = append(resolved, m)
+	}
+	p.Models = resolved
+
+	return p
+}
+
+// bedrockRegionPrefix maps an AWS region to the inference profile prefix used
+// by Bedrock cross-region inference. Returns an empty string when the region
+// is unknown or unset, in which case the global profile is used as fallback.
+func bedrockRegionPrefix(region string) string {
+	switch {
+	case strings.HasPrefix(region, "us-") || region == "ca-central-1":
+		return "us"
+	case strings.HasPrefix(region, "eu-"):
+		return "eu"
+	case region == "ap-northeast-1":
+		return "jp"
+	case region == "ap-southeast-2":
+		return "au"
+	case strings.HasPrefix(region, "ap-"):
+		return "apac"
+	default:
+		return ""
+	}
+}
+
+func loadBedrockRegionsByModelID() (map[string][]string, error) {
+	var config struct {
+		Models []struct {
+			ID      string   `json:"id"`
+			Regions []string `json:"regions"`
+		} `json:"models"`
+	}
+
+	if err := json.Unmarshal(bedrockConfig, &config); err != nil {
+		return nil, fmt.Errorf("unmarshal bedrock config: %w", err)
+	}
+
+	regionsByModelID := make(map[string][]string, len(config.Models))
+	for _, model := range config.Models {
+		regionsByModelID[model.ID] = model.Regions
+	}
+	return regionsByModelID, nil
 }
 
 func cerebrasProvider() catwalk.Provider {


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

## Summary

Resolves #223 

- Bedrock models now get their inference profile prefix resolved at load time based on `AWS_REGION` / `AWS_DEFAULT_REGION`, with per-model region filtering: use the regional prefix if available, fall back to `global`, or exclude the model if neither applies (e.g. Opus 4/4.1 are US-only).
- Added `TestBedrockConfigRegions` to assert every model in `bedrock.json` has at least one region configured, and updated `TestBedrockProvider` to verify correct model count and prefix per region.

## Why this approach

Simpler to maintain: one loop, one switch, no extra helpers. The tests validate the config itself, so adding or updating models in `bedrock.json` will fail fast if regions are missing.

## Tradeoff

The `Regions` field on the `Model` struct is currently only used by Bedrock. This feels like feature creep on a shared type, but creating a separate Bedrock-specific config struct seemed like over-engineering for a single field. Happy to hear suggestions from maintainers on a better home for this.

## Testing done

- All unit tests pass.
- Tested with a personal AWS account in `us-east-1` — confirmed that **inference profiles are mandatory** for all current Anthropic models on Bedrock (direct model ID invocation returns `ValidationException`). See [comment on #223](https://github.com/charmbracelet/catwalk/issues/223#issuecomment-4105888159) for details.
- Used this branch with crush for a couple of days against a work Bedrock account (EU region) without issues.
- Used this branch to fire a couple of prompts with Opus 4.6 using a us-east-1 personal account.
