### PR TITLE
chore: show per-provider models

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,10 +137,10 @@ func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider) {
 	
 	if len(provider.Models) > 0 {
 		fmt.Fprintf(w, "\n## Models\n\n")
-		fmt.Fprintf(w, "| Model ID | Name | Context Window | Default Max Tokens |\n")
-		fmt.Fprintf(w, "|----------|------|----------------|------------------|\n")
+		fmt.Fprintf(w, "| Model ID | Name | Context Window | Default Max Tokens | Input Cost ($/M) | Output Cost ($/M) |\n")
+		fmt.Fprintf(w, "|----------|------|----------------|------------------|------------------|------------------|\n")
 		for _, model := range provider.Models {
-			fmt.Fprintf(w, "| `%s` | %s | %d | %d |\n", model.ID, model.Name, model.ContextWindow, model.DefaultMaxTokens)
+			fmt.Fprintf(w, "| `%s` | %s | %d | %d | %.6f | %.6f |\n", model.ID, model.Name, model.ContextWindow, model.DefaultMaxTokens, model.CostPer1MIn, model.CostPer1MOut)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -110,7 +111,7 @@ func providersSpecificHandler(w http.ResponseWriter, r *http.Request) {
 	if pretty {
 		// Return as markdown table
 		w.Header().Set("Content-Type", "text/markdown")
-		renderProviderMarkdown(w, *foundProvider)
+		renderProviderMarkdown(w, *foundProvider, r)
 	} else {
 		// Return as JSON
 		w.Header().Set("Content-Type", "application/json")
@@ -122,7 +123,7 @@ func providersSpecificHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider) {
+func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider, r *http.Request) {
 	// Header
 	fmt.Fprintf(w, "# Provider: %s\n\n", provider.Name)
 	
@@ -137,10 +138,33 @@ func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider) {
 	
 	if len(provider.Models) > 0 {
 		fmt.Fprintf(w, "\n## Models\n\n")
-		fmt.Fprintf(w, "| Model ID | Name | Context Window | Default Max Tokens | Input Cost ($/M) | Output Cost ($/M) |\n")
-		fmt.Fprintf(w, "|----------|------|----------------|------------------|------------------|------------------|\n")
-		for _, model := range provider.Models {
-			fmt.Fprintf(w, "| `%s` | %s | %d | %d | %.6f | %.6f |\n", model.ID, model.Name, model.ContextWindow, model.DefaultMaxTokens, model.CostPer1MIn, model.CostPer1MOut)
+		
+		// Handle sorting
+		models := provider.Models
+		sortParam := r.URL.Query().Get("sort")
+		
+		switch sortParam {
+		case "output":
+			// Sort by output cost (ascending)
+			sort.Slice(models, func(i, j int) bool {
+				return models[i].CostPer1MOut < models[j].CostPer1MOut
+			})
+		case "context":
+			// Sort by context window (descending)
+			sort.Slice(models, func(i, j int) bool {
+				return models[i].ContextWindow > models[j].ContextWindow
+			})
+		default:
+			// Default sort by input cost (ascending)
+			sort.Slice(models, func(i, j int) bool {
+				return models[i].CostPer1MIn < models[j].CostPer1MIn
+			})
+		}
+		
+		fmt.Fprintf(w, "| Model ID | Name | Context Window | Input Cost ($/M) | Output Cost ($/M) |\n")
+		fmt.Fprintf(w, "|----------|------|----------------|------------------|------------------|\n")
+		for _, model := range models {
+			fmt.Fprintf(w, "| `%s` | %s | %d | %.6f | %.6f |\n", model.ID, model.Name, model.ContextWindow, model.CostPer1MIn, model.CostPer1MOut)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -4,10 +4,8 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
 
@@ -88,9 +86,6 @@ func providersSpecificHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if pretty printing is requested
-	pretty := r.URL.Query().Get("pretty") == "true"
-
 	// Get all providers
 	allProviders := providers.GetAll()
 
@@ -108,71 +103,11 @@ func providersSpecificHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if pretty {
-		// Return as markdown table
-		w.Header().Set("Content-Type", "text/markdown")
-		renderProviderMarkdown(w, *foundProvider, r)
-	} else {
-		// Return as JSON
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(foundProvider); err != nil {
-			log.Printf("Error encoding provider response: %v", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	}
-}
-
-func yesNo(b bool) string {
-	if b {
-		return "yes"
-	}
-	return "no"
-}
-
-func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider, r *http.Request) {
-	// Header
-	fmt.Fprintf(w, "# Provider: %s\n\n", provider.Name)
-
-	// Basic info table
-	fmt.Fprintf(w, "| Field | Value |\n")
-	fmt.Fprintf(w, "|-------|-------|\n")
-	fmt.Fprintf(w, "| ID | `%s` |\n", provider.ID)
-	fmt.Fprintf(w, "| Type | `%s` |\n", provider.Type)
-	fmt.Fprintf(w, "| API Endpoint | `%s` |\n", provider.APIEndpoint)
-	fmt.Fprintf(w, "| Default Large Model ID | `%s` |\n", provider.DefaultLargeModelID)
-	fmt.Fprintf(w, "| Default Small Model ID | `%s` |\n", provider.DefaultSmallModelID)
-
-	if len(provider.Models) > 0 {
-		fmt.Fprintf(w, "\n## Available Models\n\n")
-
-		// Handle sorting
-		models := provider.Models
-		sortParam := r.URL.Query().Get("sort")
-
-		switch sortParam {
-		case "output":
-			// Sort by output cost (ascending)
-			sort.Slice(models, func(i, j int) bool {
-				return models[i].CostPer1MOut < models[j].CostPer1MOut
-			})
-		case "context":
-			// Sort by context window (descending)
-			sort.Slice(models, func(i, j int) bool {
-				return models[i].ContextWindow > models[j].ContextWindow
-			})
-		default:
-			// Default sort by input cost (ascending)
-			sort.Slice(models, func(i, j int) bool {
-				return models[i].CostPer1MIn < models[j].CostPer1MIn
-			})
-		}
-
-		fmt.Fprintf(w, "| Name | ID | Context Window | Input Cost ($/M) | Output Cost ($/M) | Reasoning |\n")
-		fmt.Fprintf(w, "|----------|------|----------------|------------------|------------------|----------|\n")
-		for _, model := range models {
-			fmt.Fprintf(w, "| %s | `%s` | %d | %.6f | %.6f | %s |\n", model.Name, model.ID, model.ContextWindow, model.CostPer1MIn, model.CostPer1MOut, yesNo(model.CanReason))
-		}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(foundProvider); err != nil {
+		log.Printf("Error encoding provider response: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -123,6 +123,13 @@ func providersSpecificHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
 func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider, r *http.Request) {
 	// Header
 	fmt.Fprintf(w, "# Provider: %s\n\n", provider.Name)
@@ -137,7 +144,7 @@ func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider, r 
 	fmt.Fprintf(w, "| Default Small Model ID | `%s` |\n", provider.DefaultSmallModelID)
 
 	if len(provider.Models) > 0 {
-		fmt.Fprintf(w, "\n## Models\n\n")
+		fmt.Fprintf(w, "\n## Available Models\n\n")
 
 		// Handle sorting
 		models := provider.Models
@@ -161,10 +168,10 @@ func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider, r 
 			})
 		}
 
-		fmt.Fprintf(w, "| Model ID | Name | Context Window | Input Cost ($/M) | Output Cost ($/M) |\n")
-		fmt.Fprintf(w, "|----------|------|----------------|------------------|------------------|\n")
+		fmt.Fprintf(w, "| Name | ID | Context Window | Input Cost ($/M) | Output Cost ($/M) | Reasoning |\n")
+		fmt.Fprintf(w, "|----------|------|----------------|------------------|------------------|----------|\n")
 		for _, model := range models {
-			fmt.Fprintf(w, "| `%s` | %s | %d | %.6f | %.6f |\n", model.ID, model.Name, model.ContextWindow, model.CostPer1MIn, model.CostPer1MOut)
+			fmt.Fprintf(w, "| %s | `%s` | %d | %.6f | %.6f | %s |\n", model.Name, model.ID, model.ContextWindow, model.CostPer1MIn, model.CostPer1MOut, yesNo(model.CanReason))
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func providersSpecificHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Get all providers
 	allProviders := providers.GetAll()
-	
+
 	// Find the specific provider by ID
 	var foundProvider *catwalk.Provider
 	for _, provider := range allProviders {
@@ -126,7 +126,7 @@ func providersSpecificHandler(w http.ResponseWriter, r *http.Request) {
 func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider, r *http.Request) {
 	// Header
 	fmt.Fprintf(w, "# Provider: %s\n\n", provider.Name)
-	
+
 	// Basic info table
 	fmt.Fprintf(w, "| Field | Value |\n")
 	fmt.Fprintf(w, "|-------|-------|\n")
@@ -135,14 +135,14 @@ func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider, r 
 	fmt.Fprintf(w, "| API Endpoint | `%s` |\n", provider.APIEndpoint)
 	fmt.Fprintf(w, "| Default Large Model ID | `%s` |\n", provider.DefaultLargeModelID)
 	fmt.Fprintf(w, "| Default Small Model ID | `%s` |\n", provider.DefaultSmallModelID)
-	
+
 	if len(provider.Models) > 0 {
 		fmt.Fprintf(w, "\n## Models\n\n")
-		
+
 		// Handle sorting
 		models := provider.Models
 		sortParam := r.URL.Query().Get("sort")
-		
+
 		switch sortParam {
 		case "output":
 			// Sort by output cost (ascending)
@@ -160,7 +160,7 @@ func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider, r 
 				return models[i].CostPer1MIn < models[j].CostPer1MIn
 			})
 		}
-		
+
 		fmt.Fprintf(w, "| Model ID | Name | Context Window | Input Cost ($/M) | Output Cost ($/M) |\n")
 		fmt.Fprintf(w, "|----------|------|----------------|------------------|------------------|\n")
 		for _, model := range models {

--- a/main.go
+++ b/main.go
@@ -4,11 +4,14 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"charm.land/catwalk/internal/providers"
+	"charm.land/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/x/etag"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -69,6 +72,79 @@ func providersHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func providersSpecificHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract provider ID from the URL path
+	path := strings.TrimPrefix(r.URL.Path, "/v2/providers/")
+	providerID := strings.TrimSuffix(path, "/")
+
+	if providerID == "" {
+		http.Error(w, "Provider ID is required", http.StatusBadRequest)
+		return
+	}
+
+	// Check if pretty printing is requested
+	pretty := r.URL.Query().Get("pretty") == "true"
+
+	// Get all providers
+	allProviders := providers.GetAll()
+	
+	// Find the specific provider by ID
+	var foundProvider *catwalk.Provider
+	for _, provider := range allProviders {
+		if string(provider.ID) == providerID {
+			foundProvider = &provider
+			break
+		}
+	}
+
+	if foundProvider == nil {
+		http.Error(w, "Provider not found", http.StatusNotFound)
+		return
+	}
+
+	if pretty {
+		// Return as markdown table
+		w.Header().Set("Content-Type", "text/markdown")
+		renderProviderMarkdown(w, *foundProvider)
+	} else {
+		// Return as JSON
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(foundProvider); err != nil {
+			log.Printf("Error encoding provider response: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func renderProviderMarkdown(w http.ResponseWriter, provider catwalk.Provider) {
+	// Header
+	fmt.Fprintf(w, "# Provider: %s\n\n", provider.Name)
+	
+	// Basic info table
+	fmt.Fprintf(w, "| Field | Value |\n")
+	fmt.Fprintf(w, "|-------|-------|\n")
+	fmt.Fprintf(w, "| ID | `%s` |\n", provider.ID)
+	fmt.Fprintf(w, "| Type | `%s` |\n", provider.Type)
+	fmt.Fprintf(w, "| API Endpoint | `%s` |\n", provider.APIEndpoint)
+	fmt.Fprintf(w, "| Default Large Model ID | `%s` |\n", provider.DefaultLargeModelID)
+	fmt.Fprintf(w, "| Default Small Model ID | `%s` |\n", provider.DefaultSmallModelID)
+	
+	if len(provider.Models) > 0 {
+		fmt.Fprintf(w, "\n## Models\n\n")
+		fmt.Fprintf(w, "| Model ID | Name | Context Window | Default Max Tokens |\n")
+		fmt.Fprintf(w, "|----------|------|----------------|------------------|\n")
+		for _, model := range provider.Models {
+			fmt.Fprintf(w, "| `%s` | %s | %d | %d |\n", model.ID, model.Name, model.ContextWindow, model.DefaultMaxTokens)
+		}
+	}
+}
+
 func providersHandlerDeprecated(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -81,6 +157,7 @@ func providersHandlerDeprecated(w http.ResponseWriter, _ *http.Request) {
 func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/providers", providersHandler)
+	mux.HandleFunc("/v2/providers/", providersSpecificHandler)
 	mux.HandleFunc("/providers", providersHandlerDeprecated)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

This implements showing the available models per provider by extending the models endpoint: `/v2/models/foobar`