### PR TITLE
fix: reduce default_max_tokens for glm4.7 (ZAI/zhipu/zhipucoding)

### DIFF
--- a/internal/providers/configs/zai.json
+++ b/internal/providers/configs/zai.json
@@ -1,120 +1,120 @@
 {
-  "name": "Z.AI",
-  "id": "zai",
-  "api_key": "$ZAI_API_KEY",
-  "api_endpoint": "https://api.z.ai/api/coding/paas/v4",
-  "type": "openai-compat",
-  "default_large_model_id": "glm-4.7",
-  "default_small_model_id": "glm-4.7-flash",
-  "models": [
-    {
-      "id": "glm-5.1",
-      "name": "GLM-5.1",
-      "cost_per_1m_in": 1.0,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0.2,
-      "context_window": 204800,
-      "default_max_tokens": 65536,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-5-turbo",
-      "name": "GLM-5-Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4.0,
-      "cost_per_1m_in_cached": 0.24,
-      "context_window": 200000,
-      "default_max_tokens": 128000,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-5",
-      "name": "GLM-5",
-      "cost_per_1m_in": 1.0,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0.2,
-      "context_window": 204800,
-      "default_max_tokens": 65536,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.7",
-      "name": "GLM-4.7",
-      "cost_per_1m_in": 0.42,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 204800,
-      "default_max_tokens": 102400,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.7-flash",
-      "name": "GLM-4.7 Flash",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.01,
-      "context_window": 200000,
-      "default_max_tokens": 65550,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.6",
-      "name": "GLM-4.6",
-      "cost_per_1m_in": 0.39,
-      "cost_per_1m_out": 1.9,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 204800,
-      "default_max_tokens": 102400,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.6v",
-      "name": "GLM-4.6V",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
-      "context_window": 131072,
-      "default_max_tokens": 65536,
-      "can_reason": true,
-      "supports_attachments": true
-    },
-    {
-      "id": "glm-4.5",
-      "name": "GLM-4.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 131072,
-      "default_max_tokens": 49152,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.5-air",
-      "name": "GLM-4.5-Air",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.85,
-      "cost_per_1m_in_cached": 0.03,
-      "context_window": 131072,
-      "default_max_tokens": 49152,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.5v",
-      "name": "GLM-4.5V",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 65536,
-      "default_max_tokens": 8192,
-      "can_reason": true,
-      "supports_attachments": true
-    }
-  ]
+	"name": "Z.AI",
+	"id": "zai",
+	"api_key": "$ZAI_API_KEY",
+	"api_endpoint": "https://api.z.ai/api/coding/paas/v4",
+	"type": "openai-compat",
+	"default_large_model_id": "glm-4.7",
+	"default_small_model_id": "glm-4.7-flash",
+	"models": [
+		{
+			"id": "glm-5.1",
+			"name": "GLM-5.1",
+			"cost_per_1m_in": 1.0,
+			"cost_per_1m_out": 3.2,
+			"cost_per_1m_in_cached": 0.2,
+			"context_window": 204800,
+			"default_max_tokens": 65536,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-5-turbo",
+			"name": "GLM-5-Turbo",
+			"cost_per_1m_in": 1.2,
+			"cost_per_1m_out": 4.0,
+			"cost_per_1m_in_cached": 0.24,
+			"context_window": 200000,
+			"default_max_tokens": 128000,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-5",
+			"name": "GLM-5",
+			"cost_per_1m_in": 1.0,
+			"cost_per_1m_out": 3.2,
+			"cost_per_1m_in_cached": 0.2,
+			"context_window": 204800,
+			"default_max_tokens": 65536,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.7",
+			"name": "GLM-4.7",
+			"cost_per_1m_in": 0.42,
+			"cost_per_1m_out": 2.2,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 204800,
+			"default_max_tokens": 98000,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.7-flash",
+			"name": "GLM-4.7 Flash",
+			"cost_per_1m_in": 0.07,
+			"cost_per_1m_out": 0.4,
+			"cost_per_1m_in_cached": 0.01,
+			"context_window": 200000,
+			"default_max_tokens": 65550,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.6",
+			"name": "GLM-4.6",
+			"cost_per_1m_in": 0.39,
+			"cost_per_1m_out": 1.9,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 204800,
+			"default_max_tokens": 102400,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.6v",
+			"name": "GLM-4.6V",
+			"cost_per_1m_in": 0.3,
+			"cost_per_1m_out": 0.9,
+			"context_window": 131072,
+			"default_max_tokens": 65536,
+			"can_reason": true,
+			"supports_attachments": true
+		},
+		{
+			"id": "glm-4.5",
+			"name": "GLM-4.5",
+			"cost_per_1m_in": 0.6,
+			"cost_per_1m_out": 2.2,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 131072,
+			"default_max_tokens": 49152,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.5-air",
+			"name": "GLM-4.5-Air",
+			"cost_per_1m_in": 0.13,
+			"cost_per_1m_out": 0.85,
+			"cost_per_1m_in_cached": 0.03,
+			"context_window": 131072,
+			"default_max_tokens": 49152,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.5v",
+			"name": "GLM-4.5V",
+			"cost_per_1m_in": 0.6,
+			"cost_per_1m_out": 1.8,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 65536,
+			"default_max_tokens": 8192,
+			"can_reason": true,
+			"supports_attachments": true
+		}
+	]
 }

--- a/internal/providers/configs/zhipu-coding.json
+++ b/internal/providers/configs/zhipu-coding.json
@@ -1,98 +1,98 @@
 {
-  "name": "Zhipu Coding",
-  "id": "zhipu-coding",
-  "api_key": "$ZHIPU_API_KEY",
-  "api_endpoint": "https://open.bigmodel.cn/api/coding/paas/v4",
-  "type": "openai-compat",
-  "default_large_model_id": "glm-4.7",
-  "default_small_model_id": "glm-4.7-flash",
-  "models": [
-    {
-      "id": "glm-5",
-      "name": "GLM-5",
-      "cost_per_1m_in": 1.0,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0.2,
-      "context_window": 204800,
-      "default_max_tokens": 65536,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.7",
-      "name": "GLM-4.7",
-      "cost_per_1m_in": 0.42,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 204800,
-      "default_max_tokens": 102400,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.7-flash",
-      "name": "GLM-4.7 Flash",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.01,
-      "context_window": 200000,
-      "default_max_tokens": 65550,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.6",
-      "name": "GLM-4.6",
-      "cost_per_1m_in": 0.39,
-      "cost_per_1m_out": 1.9,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 204800,
-      "default_max_tokens": 102400,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.6v",
-      "name": "GLM-4.6V",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
-      "context_window": 131072,
-      "default_max_tokens": 65536,
-      "can_reason": true,
-      "supports_attachments": true
-    },
-    {
-      "id": "glm-4.5",
-      "name": "GLM-4.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 131072,
-      "default_max_tokens": 49152,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.5-air",
-      "name": "GLM-4.5-Air",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.85,
-      "cost_per_1m_in_cached": 0.03,
-      "context_window": 131072,
-      "default_max_tokens": 49152,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.5v",
-      "name": "GLM-4.5V",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 65536,
-      "default_max_tokens": 8192,
-      "can_reason": true,
-      "supports_attachments": true
-    }
-  ]
+	"name": "Zhipu Coding",
+	"id": "zhipu-coding",
+	"api_key": "$ZHIPU_API_KEY",
+	"api_endpoint": "https://open.bigmodel.cn/api/coding/paas/v4",
+	"type": "openai-compat",
+	"default_large_model_id": "glm-4.7",
+	"default_small_model_id": "glm-4.7-flash",
+	"models": [
+		{
+			"id": "glm-5",
+			"name": "GLM-5",
+			"cost_per_1m_in": 1.0,
+			"cost_per_1m_out": 3.2,
+			"cost_per_1m_in_cached": 0.2,
+			"context_window": 204800,
+			"default_max_tokens": 65536,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.7",
+			"name": "GLM-4.7",
+			"cost_per_1m_in": 0.42,
+			"cost_per_1m_out": 2.2,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 204800,
+			"default_max_tokens": 98000,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.7-flash",
+			"name": "GLM-4.7 Flash",
+			"cost_per_1m_in": 0.07,
+			"cost_per_1m_out": 0.4,
+			"cost_per_1m_in_cached": 0.01,
+			"context_window": 200000,
+			"default_max_tokens": 65550,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.6",
+			"name": "GLM-4.6",
+			"cost_per_1m_in": 0.39,
+			"cost_per_1m_out": 1.9,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 204800,
+			"default_max_tokens": 102400,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.6v",
+			"name": "GLM-4.6V",
+			"cost_per_1m_in": 0.3,
+			"cost_per_1m_out": 0.9,
+			"context_window": 131072,
+			"default_max_tokens": 65536,
+			"can_reason": true,
+			"supports_attachments": true
+		},
+		{
+			"id": "glm-4.5",
+			"name": "GLM-4.5",
+			"cost_per_1m_in": 0.6,
+			"cost_per_1m_out": 2.2,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 131072,
+			"default_max_tokens": 49152,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.5-air",
+			"name": "GLM-4.5-Air",
+			"cost_per_1m_in": 0.13,
+			"cost_per_1m_out": 0.85,
+			"cost_per_1m_in_cached": 0.03,
+			"context_window": 131072,
+			"default_max_tokens": 49152,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.5v",
+			"name": "GLM-4.5V",
+			"cost_per_1m_in": 0.6,
+			"cost_per_1m_out": 1.8,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 65536,
+			"default_max_tokens": 8192,
+			"can_reason": true,
+			"supports_attachments": true
+		}
+	]
 }

--- a/internal/providers/configs/zhipu.json
+++ b/internal/providers/configs/zhipu.json
@@ -1,109 +1,109 @@
 {
-  "name": "Zhipu",
-  "id": "zhipu",
-  "api_key": "$ZHIPU_API_KEY",
-  "api_endpoint": "https://open.bigmodel.cn/api/paas/v4",
-  "type": "openai-compat",
-  "default_large_model_id": "glm-4.7",
-  "default_small_model_id": "glm-4.7-flash",
-  "models": [
-    {
-      "id": "glm-5.1",
-      "name": "GLM-5.1",
-      "cost_per_1m_in": 1.0,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0.2,
-      "context_window": 204800,
-      "default_max_tokens": 65536,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-5",
-      "name": "GLM-5",
-      "cost_per_1m_in": 1.0,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0.2,
-      "context_window": 204800,
-      "default_max_tokens": 65536,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.7",
-      "name": "GLM-4.7",
-      "cost_per_1m_in": 0.42,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 204800,
-      "default_max_tokens": 102400,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.7-flash",
-      "name": "GLM-4.7 Flash",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.01,
-      "context_window": 200000,
-      "default_max_tokens": 65550,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.6",
-      "name": "GLM-4.6",
-      "cost_per_1m_in": 0.39,
-      "cost_per_1m_out": 1.9,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 204800,
-      "default_max_tokens": 102400,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.6v",
-      "name": "GLM-4.6V",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
-      "context_window": 131072,
-      "default_max_tokens": 65536,
-      "can_reason": true,
-      "supports_attachments": true
-    },
-    {
-      "id": "glm-4.5",
-      "name": "GLM-4.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 131072,
-      "default_max_tokens": 49152,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.5-air",
-      "name": "GLM-4.5-Air",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.85,
-      "cost_per_1m_in_cached": 0.03,
-      "context_window": 131072,
-      "default_max_tokens": 49152,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-4.5v",
-      "name": "GLM-4.5V",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0.11,
-      "context_window": 65536,
-      "default_max_tokens": 8192,
-      "can_reason": true,
-      "supports_attachments": true
-    }
-  ]
+	"name": "Zhipu",
+	"id": "zhipu",
+	"api_key": "$ZHIPU_API_KEY",
+	"api_endpoint": "https://open.bigmodel.cn/api/paas/v4",
+	"type": "openai-compat",
+	"default_large_model_id": "glm-4.7",
+	"default_small_model_id": "glm-4.7-flash",
+	"models": [
+		{
+			"id": "glm-5.1",
+			"name": "GLM-5.1",
+			"cost_per_1m_in": 1.0,
+			"cost_per_1m_out": 3.2,
+			"cost_per_1m_in_cached": 0.2,
+			"context_window": 204800,
+			"default_max_tokens": 65536,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-5",
+			"name": "GLM-5",
+			"cost_per_1m_in": 1.0,
+			"cost_per_1m_out": 3.2,
+			"cost_per_1m_in_cached": 0.2,
+			"context_window": 204800,
+			"default_max_tokens": 65536,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.7",
+			"name": "GLM-4.7",
+			"cost_per_1m_in": 0.42,
+			"cost_per_1m_out": 2.2,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 204800,
+			"default_max_tokens": 98000,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.7-flash",
+			"name": "GLM-4.7 Flash",
+			"cost_per_1m_in": 0.07,
+			"cost_per_1m_out": 0.4,
+			"cost_per_1m_in_cached": 0.01,
+			"context_window": 200000,
+			"default_max_tokens": 65550,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.6",
+			"name": "GLM-4.6",
+			"cost_per_1m_in": 0.39,
+			"cost_per_1m_out": 1.9,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 204800,
+			"default_max_tokens": 102400,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.6v",
+			"name": "GLM-4.6V",
+			"cost_per_1m_in": 0.3,
+			"cost_per_1m_out": 0.9,
+			"context_window": 131072,
+			"default_max_tokens": 65536,
+			"can_reason": true,
+			"supports_attachments": true
+		},
+		{
+			"id": "glm-4.5",
+			"name": "GLM-4.5",
+			"cost_per_1m_in": 0.6,
+			"cost_per_1m_out": 2.2,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 131072,
+			"default_max_tokens": 49152,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.5-air",
+			"name": "GLM-4.5-Air",
+			"cost_per_1m_in": 0.13,
+			"cost_per_1m_out": 0.85,
+			"cost_per_1m_in_cached": 0.03,
+			"context_window": 131072,
+			"default_max_tokens": 49152,
+			"can_reason": true,
+			"supports_attachments": false
+		},
+		{
+			"id": "glm-4.5v",
+			"name": "GLM-4.5V",
+			"cost_per_1m_in": 0.6,
+			"cost_per_1m_out": 1.8,
+			"cost_per_1m_in_cached": 0.11,
+			"context_window": 65536,
+			"default_max_tokens": 8192,
+			"can_reason": true,
+			"supports_attachments": true
+		}
+	]
 }


### PR DESCRIPTION
Reduce default_max_tokens for glm4.7 to ensure API stability during peak hours.
Providers: ZAI, zhipu, zhipucoding.
This change prevents context length errors in high traffic periods.
