### PR TITLE
fix: reduce default_max_tokens for glm4.7 (ZAI/zhipu/zhipucoding)

### DIFF
--- a/internal/providers/configs/zai.json
+++ b/internal/providers/configs/zai.json
@@ -47,7 +47,7 @@
       "cost_per_1m_out": 2.2,
       "cost_per_1m_in_cached": 0.11,
       "context_window": 204800,
-      "default_max_tokens": 102400,
+      "default_max_tokens": 98000,
       "can_reason": true,
       "supports_attachments": false
     },

--- a/internal/providers/configs/zhipu-coding.json
+++ b/internal/providers/configs/zhipu-coding.json
@@ -25,7 +25,7 @@
       "cost_per_1m_out": 2.2,
       "cost_per_1m_in_cached": 0.11,
       "context_window": 204800,
-      "default_max_tokens": 102400,
+      "default_max_tokens": 98000,
       "can_reason": true,
       "supports_attachments": false
     },

--- a/internal/providers/configs/zhipu.json
+++ b/internal/providers/configs/zhipu.json
@@ -36,7 +36,7 @@
       "cost_per_1m_out": 2.2,
       "cost_per_1m_in_cached": 0.11,
       "context_window": 204800,
-      "default_max_tokens": 102400,
+      "default_max_tokens": 98000,
       "can_reason": true,
       "supports_attachments": false
     },


### PR DESCRIPTION
Reduce default_max_tokens for glm4.7 to ensure API stability during peak hours.
Providers: ZAI, zhipu, zhipucoding.
This change prevents context length errors in high traffic periods.
