### PR TITLE
feat: add MaxAttachments field to Model struct

### DIFF
--- a/internal/providers/configs/gemini.json
+++ b/internal/providers/configs/gemini.json
@@ -19,7 +19,8 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "gemini-3.1-pro-preview-customtools",
@@ -33,7 +34,8 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "gemini-3-pro-preview",
@@ -47,7 +49,8 @@
       "can_reason": true,
       "reasoning_levels": ["low", "high"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "gemini-3-flash-preview",
@@ -61,7 +64,8 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "minimal",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "gemini-2.5-pro",
@@ -73,7 +77,8 @@
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "gemini-2.5-flash",
@@ -85,7 +90,8 @@
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     }
   ]
 }

--- a/internal/providers/configs/vertexai.json
+++ b/internal/providers/configs/vertexai.json
@@ -19,7 +19,8 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "gemini-3.1-pro-preview-customtools",
@@ -33,7 +34,8 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "gemini-3-pro-preview",
@@ -47,7 +49,8 @@
       "can_reason": true,
       "reasoning_levels": ["low", "high"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "gemini-3-flash-preview",
@@ -61,7 +64,8 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "minimal",
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "gemini-2.5-pro",
@@ -73,7 +77,8 @@
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "gemini-2.5-flash",
@@ -85,7 +90,8 @@
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "supports_attachments": true
+      "supports_attachments": true,
+      "max_attachments": 10
     },
     {
       "id": "claude-sonnet-4-6",

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -91,6 +91,7 @@ type Model struct {
 	ReasoningLevels        []string     `json:"reasoning_levels,omitempty"`
 	DefaultReasoningEffort string       `json:"default_reasoning_effort,omitempty"`
 	SupportsImages         bool         `json:"supports_attachments"`
+	MaxAttachments         int          `json:"max_attachments,omitempty"`
 	Options                ModelOptions `json:"options,omitzero"`
 }
 


### PR DESCRIPTION
## Summary

- Add `MaxAttachments int` field to `catwalk.Model` struct (`json:"max_attachments,omitempty"`)
- Set `max_attachments: 10` for all Gemini models in `gemini.json` and `vertexai.json`

## Motivation

Some AI providers enforce hard per-request limits on image attachments. For example, Google Gemini caps at 10 images per request — exceeding this makes sessions permanently unusable (see charmbracelet/crush#2604). Currently there is no way to express this limit in Catwalk's `Model` struct, forcing downstream consumers to hard-code provider-specific limits.

## Changes

### `pkg/catwalk/provider.go`

```go
type Model struct {
    // ... existing fields ...
    SupportsImages         bool         `json:"supports_attachments"`
    MaxAttachments         int          `json:"max_attachments,omitempty"` // NEW
    Options                ModelOptions `json:"options,omitzero"`
}
```

Semantics:
- `0` (zero / omitted): no hard limit, rely on context window limits instead
- `> 0`: maximum number of image attachments allowed in a single request

### `internal/providers/configs/gemini.json`

Add `"max_attachments": 10` to all 6 Gemini models.

### `internal/providers/configs/vertexai.json`

Add `"max_attachments": 10` to all 6 Gemini models. Claude models on Vertex AI are left without the field (no known hard limit).

## Known limits

| Provider | Model | Limit | Source |
|---|---|---|---|
| Gemini | All models | 10 | [Google docs](https://ai.google.dev/gemini-api/docs/image-understanding#limitations) |
| Vertex AI | Gemini models | 10 | Same as Gemini |
| Anthropic | All models | — | No hard limit (context window) |
| OpenAI | All models | — | No hard limit (context window) |

## Downstream impact

Once this ships, Crush can replace its hard-coded `maxImagesForModel()` switch with a simple read from `model.CatwalkCfg.MaxAttachments`, eliminating provider-specific logic from the consumer side.

## Test plan

- `go build ./...` — passes
- `go test ./... -count=1` — all existing tests pass
- JSON configs correctly deserialize with the new field

Closes #258
