### PR TITLE
feat: update DeepSeek config to V4 with deepseek-v4-flash and deepsee…

### DIFF
--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -3,30 +3,38 @@
   "id": "deepseek",
   "type": "openai-compat",
   "api_key": "$DEEPSEEK_API_KEY",
-  "api_endpoint": "https://api.deepseek.com/v1",
-  "default_large_model_id": "deepseek-reasoner",
-  "default_small_model_id": "deepseek-chat",
+  "api_endpoint": "https://api.deepseek.com",
+  "default_large_model_id": "deepseek-v4-pro",
+  "default_small_model_id": "deepseek-v4-flash",
   "models": [
     {
-      "id": "deepseek-chat",
-      "name": "DeepSeek-V3.2 (Non-thinking Mode)",
-      "cost_per_1m_in": 0.28,
-      "cost_per_1m_out": 0.42,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
-      "context_window": 128000,
+      "id": "deepseek-v4-flash",
+      "name": "DeepSeek-V4-Flash",
+      "cost_per_1m_in_cached": 0.2,
+      "cost_per_1m_in": 1,
+      "cost_per_1m_out": 2,
+      "context_window": 1000000,
       "default_max_tokens": 4000,
-      "can_reason": false,
-      "supports_attachments": false
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "supports_json_output": true,
+      "supports_tool_calls": true,
+      "supports_conversation_prefix": true,
+      "supports_fim": true
     },
     {
-      "id": "deepseek-reasoner",
-      "name": "DeepSeek-V3.2 (Thinking Mode)",
-      "cost_per_1m_in": 0.28,
-      "cost_per_1m_out": 0.42,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
-      "context_window": 128000,
+      "id": "deepseek-v4-pro",
+      "name": "DeepSeek-V4-Pro",
+      "cost_per_1m_in_cached": 1,
+      "cost_per_1m_in": 12,
+      "cost_per_1m_out": 24,
+      "context_window": 1000000,
       "default_max_tokens": 32000,
       "can_reason": true,
       "reasoning_levels": [
@@ -35,7 +43,45 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "supports_attachments": false,
+      "supports_json_output": true,
+      "supports_tool_calls": true,
+      "supports_conversation_prefix": true,
+      "supports_fim": true
+    },
+    {
+      "id": "deepseek-chat",
+      "name": "DeepSeek-V3.2 (Non-thinking Mode) [Deprecated, use deepseek-v4-flash]",
+      "cost_per_1m_in_cached": 0.2,
+      "cost_per_1m_in": 1,
+      "cost_per_1m_out": 2,
+      "context_window": 1000000,
+      "default_max_tokens": 4000,
+      "can_reason": false,
+      "supports_attachments": false,
+      "deprecated": true,
+      "deprecation_date": "2026-07-24",
+      "replacement": "deepseek-v4-flash"
+    },
+    {
+      "id": "deepseek-reasoner",
+      "name": "DeepSeek-V3.2 (Thinking Mode) [Deprecated, use deepseek-v4-flash]",
+      "cost_per_1m_in_cached": 0.2,
+      "cost_per_1m_in": 1,
+      "cost_per_1m_out": 2,
+      "context_window": 1000000,
+      "default_max_tokens": 32000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false,
+      "deprecated": true,
+      "deprecation_date": "2026-07-24",
+      "replacement": "deepseek-v4-flash"
     }
   ]
 }


### PR DESCRIPTION
## Summary

  Update DeepSeek provider configuration to support DeepSeek-V4 models based on
[official DeepSeek API documentation](https://api-docs.deepseek.com/zh-cn/).

  ## Changes

  ### `internal/providers/configs/deepseek.json`

  - **API Endpoint**: Updated to `https://api.deepseek.com` (removed `/v1` suffix per
official docs)
  - **New Models Added**:
    - `deepseek-v4-flash` - supports both thinking/non-thinking modes, 1M context
    - `deepseek-v4-pro` - full feature support, 1M context
  - **Context Window**: Updated to 1M tokens for all models
  - **New Capabilities**: Added `supports_json_output`, `supports_tool_calls`,
`supports_conversation_prefix`, `supports_fim`
  - **Deprecation**: Marked `deepseek-chat` and `deepseek-reasoner` as deprecated
(2026-07-24), recommending `deepseek-v4-flash` as replacement

  ### Pricing (Official Rates)

  | Model | Input | Output | Cached Input |
  |-------|-------|--------|--------------|
  | deepseek-v4-flash | ¥1/M | ¥2/M | ¥0.2/M |
  | deepseek-v4-pro | ¥12/M | ¥24/M | ¥1/M |

  ## Comparison with PR #262

  | Aspect | PR #262 | This PR |
                  |--------|---------|---------|
  | API Endpoint | `https://api.deepseek.com/v1` | `https://api.deepseek.com` ✅
(official) |
  | Pricing | Discounted rates (¥0.14/¥0.28) | Official rates (¥1/¥2, ¥12/¥24) ✅ |
  | deepseek-v4-pro | ¥0.435/¥0.87 | ¥12/¥24 (official) |
  | reasoning_levels | `["high", "max"]` | `["low", "medium", "high"]` ✅ (complete)
  | Old models deprecated | No | Yes ✅ |
  | New capabilities | No | Yes ✅ (json_output, tool_calls, fim) |

  PR #262 uses discounted/temporary pricing which will expire. This PR uses the
official permanent pricing from DeepSeek's documentation.

  💘 Generated with Crush

  Assisted-by: MiniMax-M2.7 via Crush <crush@charm.land>

  - [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.
github/blob/main/CONTRIBUTING.md).
  - [ ] I have created a discussion that was approved by a maintainer (for new
features).