### PR TITLE
fix(bedrock): fix claude 4.7 identifier in bedrock

### DIFF
--- a/internal/providers/configs/bedrock.json
+++ b/internal/providers/configs/bedrock.json
@@ -44,7 +44,7 @@
       "supports_attachments": true
     },
     {
-      "id": "anthropic.claude-opus-4-7-v1",
+      "id": "anthropic.claude-opus-4-7",
       "name": "AWS Claude Opus 4.7",
       "cost_per_1m_in": 5,
       "cost_per_1m_out": 25,


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Picking model identifier `anthropic.claude-opus-4-7-v1` does not work with AWS Bedrock. [Docs in AWS Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html) point to an identifier without a version suffix `anthropic.claude-opus-4-7`.

Tested locally using my bedrock api key, using a go workspace to include catwalk with my local changes and running crush with `CRUSH_DISABLE_PROVIDER_AUTO_UPDATE=1` to force it to use the embedded list.