### PR TITLE
feat: update DeepSeek config with deepseek-v4-flash and pro

### DIFF
--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -1,41 +1,47 @@
 {
-  "name": "DeepSeek",
-  "id": "deepseek",
-  "type": "openai-compat",
-  "api_key": "$DEEPSEEK_API_KEY",
-  "api_endpoint": "https://api.deepseek.com/v1",
-  "default_large_model_id": "deepseek-reasoner",
-  "default_small_model_id": "deepseek-chat",
-  "models": [
-    {
-      "id": "deepseek-chat",
-      "name": "DeepSeek-V3.2 (Non-thinking Mode)",
-      "cost_per_1m_in": 0.28,
-      "cost_per_1m_out": 0.42,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
-      "context_window": 128000,
-      "default_max_tokens": 4000,
-      "can_reason": false,
-      "supports_attachments": false
-    },
-    {
-      "id": "deepseek-reasoner",
-      "name": "DeepSeek-V3.2 (Thinking Mode)",
-      "cost_per_1m_in": 0.28,
-      "cost_per_1m_out": 0.42,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
-      "context_window": 128000,
-      "default_max_tokens": 32000,
-      "can_reason": true,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_effort": "medium",
-      "supports_attachments": false
-    }
-  ]
+	"api_endpoint": "https://api.deepseek.com/v1",
+	"api_key": "$DEEPSEEK_API_KEY",
+	"default_large_model_id": "deepseek-v4-pro",
+	"default_small_model_id": "deepseek-v4-flash",
+	"id": "deepseek",
+	"models": [
+		{
+			"can_reason": true,
+			"context_window": 1000000,
+			"cost_per_1m_in": 0.14,
+			"cost_per_1m_in_cached": 0.0028,
+			"cost_per_1m_out": 0.28,
+			"cost_per_1m_out_cached": 0,
+			"default_max_tokens": 384000,
+			"default_reasoning_effort": "medium",
+			"id": "deepseek-v4-flash",
+			"name": "DeepSeek-V4-Flash",
+			"reasoning_levels": [
+				"low",
+				"medium",
+				"xhigh"
+			],
+			"supports_attachments": false
+		},
+		{
+			"can_reason": true,
+			"context_window": 1000000,
+			"cost_per_1m_in": 0.435,
+			"cost_per_1m_in_cached": 0.003625,
+			"cost_per_1m_out": 0.87,
+			"cost_per_1m_out_cached": 0,
+			"default_max_tokens": 384000,
+			"default_reasoning_effort": "medium",
+			"id": "deepseek-v4-pro",
+			"name": "DeepSeek-V4-Pro",
+			"reasoning_levels": [
+				"low",
+				"medium",
+				"xhigh"
+			],
+			"supports_attachments": false
+		}
+	],
+	"name": "DeepSeek",
+	"type": "openai-compat"
 }

--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -8,38 +8,40 @@
   "default_small_model_id": "deepseek-v4-flash",
   "models": [
     {
-      "can_reason": true,
-      "context_window": 1000000,
+      "id": "deepseek-v4-flash",
+      "name": "DeepSeek-V4-Flash",
       "cost_per_1m_in": 0.14,
       "cost_per_1m_in_cached": 0.0028,
       "cost_per_1m_out": 0.28,
       "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
       "default_max_tokens": 384000,
+      "can_reason": true,
       "default_reasoning_effort": "medium",
-      "id": "deepseek-v4-flash",
-      "name": "DeepSeek-V4-Flash",
       "reasoning_levels": [
         "low",
         "medium",
+        "high",
         "xhigh",
         "max"
       ],
       "supports_attachments": false
     },
     {
-      "can_reason": true,
-      "context_window": 1000000,
+      "id": "deepseek-v4-pro",
+      "name": "DeepSeek-V4-Pro",
       "cost_per_1m_in": 0.435,
       "cost_per_1m_in_cached": 0.003625,
       "cost_per_1m_out": 0.87,
       "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
       "default_max_tokens": 384000,
+      "can_reason": true,
       "default_reasoning_effort": "medium",
-      "id": "deepseek-v4-pro",
-      "name": "DeepSeek-V4-Pro",
       "reasoning_levels": [
         "low",
         "medium",
+        "high",
         "xhigh",
         "max"
       ],

--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -1,47 +1,49 @@
 {
-	"api_endpoint": "https://api.deepseek.com/v1",
-	"api_key": "$DEEPSEEK_API_KEY",
-	"default_large_model_id": "deepseek-v4-pro",
-	"default_small_model_id": "deepseek-v4-flash",
-	"id": "deepseek",
-	"models": [
-		{
-			"can_reason": true,
-			"context_window": 1000000,
-			"cost_per_1m_in": 0.14,
-			"cost_per_1m_in_cached": 0.0028,
-			"cost_per_1m_out": 0.28,
-			"cost_per_1m_out_cached": 0,
-			"default_max_tokens": 384000,
-			"default_reasoning_effort": "medium",
-			"id": "deepseek-v4-flash",
-			"name": "DeepSeek-V4-Flash",
-			"reasoning_levels": [
-				"low",
-				"medium",
-				"xhigh"
-			],
-			"supports_attachments": false
-		},
-		{
-			"can_reason": true,
-			"context_window": 1000000,
-			"cost_per_1m_in": 0.435,
-			"cost_per_1m_in_cached": 0.003625,
-			"cost_per_1m_out": 0.87,
-			"cost_per_1m_out_cached": 0,
-			"default_max_tokens": 384000,
-			"default_reasoning_effort": "medium",
-			"id": "deepseek-v4-pro",
-			"name": "DeepSeek-V4-Pro",
-			"reasoning_levels": [
-				"low",
-				"medium",
-				"xhigh"
-			],
-			"supports_attachments": false
-		}
-	],
-	"name": "DeepSeek",
-	"type": "openai-compat"
+  "name": "DeepSeek",
+  "id": "deepseek",
+  "type": "openai-compat",
+  "api_key": "$DEEPSEEK_API_KEY",
+  "api_endpoint": "https://api.deepseek.com/v1",
+  "default_large_model_id": "deepseek-v4-pro",
+  "default_small_model_id": "deepseek-v4-flash",
+  "models": [
+    {
+      "can_reason": true,
+      "context_window": 1000000,
+      "cost_per_1m_in": 0.14,
+      "cost_per_1m_in_cached": 0.0028,
+      "cost_per_1m_out": 0.28,
+      "cost_per_1m_out_cached": 0,
+      "default_max_tokens": 384000,
+      "default_reasoning_effort": "medium",
+      "id": "deepseek-v4-flash",
+      "name": "DeepSeek-V4-Flash",
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "xhigh",
+        "max"
+      ],
+      "supports_attachments": false
+    },
+    {
+      "can_reason": true,
+      "context_window": 1000000,
+      "cost_per_1m_in": 0.435,
+      "cost_per_1m_in_cached": 0.003625,
+      "cost_per_1m_out": 0.87,
+      "cost_per_1m_out_cached": 0,
+      "default_max_tokens": 384000,
+      "default_reasoning_effort": "medium",
+      "id": "deepseek-v4-pro",
+      "name": "DeepSeek-V4-Pro",
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "xhigh",
+        "max"
+      ],
+      "supports_attachments": false
+    }
+  ]
 }

--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -11,13 +11,12 @@
       "id": "deepseek-v4-flash",
       "name": "DeepSeek-V4-Flash",
       "cost_per_1m_in": 0.14,
-      "cost_per_1m_in_cached": 0.0028,
       "cost_per_1m_out": 0.28,
+      "cost_per_1m_in_cached": 0.0028,
       "cost_per_1m_out_cached": 0,
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
-      "default_reasoning_effort": "medium",
       "reasoning_levels": [
         "low",
         "medium",
@@ -25,19 +24,19 @@
         "xhigh",
         "max"
       ],
+      "default_reasoning_effort": "medium",
       "supports_attachments": false
     },
     {
       "id": "deepseek-v4-pro",
       "name": "DeepSeek-V4-Pro",
       "cost_per_1m_in": 0.435,
-      "cost_per_1m_in_cached": 0.003625,
       "cost_per_1m_out": 0.87,
+      "cost_per_1m_in_cached": 0.003625,
       "cost_per_1m_out_cached": 0,
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
-      "default_reasoning_effort": "medium",
       "reasoning_levels": [
         "low",
         "medium",
@@ -45,6 +44,7 @@
         "xhigh",
         "max"
       ],
+      "default_reasoning_effort": "medium",
       "supports_attachments": false
     }
   ]

--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -18,11 +18,8 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
-        "low",
-        "medium",
         "high",
-        "xhigh",
-        "max"
+        "xhigh"
       ],
       "default_reasoning_effort": "medium",
       "supports_attachments": false
@@ -38,11 +35,8 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
-        "low",
-        "medium",
         "high",
-        "xhigh",
-        "max"
+        "xhigh"
       ],
       "default_reasoning_effort": "medium",
       "supports_attachments": false

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -30,6 +30,7 @@ const (
 	InferenceProviderVertexAI     InferenceProvider = "vertexai"
 	InferenceProviderXAI          InferenceProvider = "xai"
 	InferenceProviderZAI          InferenceProvider = "zai"
+	InferenceProviderDeepSeek     InferenceProvider = "deepseek"
 	InferenceProviderZhipu        InferenceProvider = "zhipu"
 	InferenceProviderZhipuCoding  InferenceProvider = "zhipu-coding"
 	InferenceProviderGROQ         InferenceProvider = "groq"


### PR DESCRIPTION
Fantasy v0.22.0 has fixed the `reasoning_content` callback issue, so V4 can now work properly.
The two official model names `deepseek-chat` and `deepseek-reasoner` will be deprecated on 2026/07/24.
For compatibility, they correspond to the non-reasoning and reasoning modes of `deepseek-v4-flash` respectively.
There is no need to keep the old names
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/1f24ed96-97a0-410b-bdad-5c016c30ff6b" />


[Refer](https://api-docs.deepseek.com)
because Fantasy does not and has no need to support DeepSeek's exclusive reasoning level `max`.
Therefore, the model reasoning mode is set to the compatible versions: **low, medium, xhigh**.
<img width="450" height="240" alt="image" src="https://github.com/user-attachments/assets/2d195133-a663-4560-bc74-880fb097d3ef" />
[Refer](https://api-docs.deepseek.com/guides/thinking_mode)

# Parameter source

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/1244e96d-53bf-4d76-98c5-55ad7dc392a2" />

[Refer](https://api-docs.deepseek.com/quick_start/pricing)