### PR TITLE
fix(synthetic): update default model from Kimi-K2.5 to K2.6

### DIFF
--- a/cmd/synthetic/main.go
+++ b/cmd/synthetic/main.go
@@ -114,7 +114,7 @@ func applyModelOverrides(model *Model) {
 	case strings.HasPrefix(model.ID, "hf:moonshotai/Kimi-K2-Thinking"):
 		model.SupportedFeatures = []string{"tools", "reasoning"}
 
-	case strings.HasPrefix(model.ID, "hf:moonshotai/Kimi-K2.5"):
+	case strings.HasPrefix(model.ID, "hf:moonshotai/Kimi-K2.6"):
 		model.SupportedFeatures = []string{"tools", "reasoning"}
 
 	case strings.HasPrefix(model.ID, "hf:moonshotai/Kimi-K2"):
@@ -159,7 +159,7 @@ func main() {
 		APIKey:              "$SYNTHETIC_API_KEY",
 		APIEndpoint:         "https://api.synthetic.new/openai/v1",
 		Type:                catwalk.TypeOpenAICompat,
-		DefaultLargeModelID: "hf:moonshotai/Kimi-K2.5",
+		DefaultLargeModelID: "hf:moonshotai/Kimi-K2.6",
 		DefaultSmallModelID: "hf:deepseek-ai/DeepSeek-V3.2",
 		Models:              []catwalk.Model{},
 	}

--- a/internal/providers/configs/synthetic.json
+++ b/internal/providers/configs/synthetic.json
@@ -4,7 +4,7 @@
   "api_key": "$SYNTHETIC_API_KEY",
   "api_endpoint": "https://api.synthetic.new/openai/v1",
   "type": "openai-compat",
-  "default_large_model_id": "hf:moonshotai/Kimi-K2.5",
+  "default_large_model_id": "hf:moonshotai/Kimi-K2.6",
   "default_small_model_id": "hf:deepseek-ai/DeepSeek-V3.2",
   "models": [
     {
@@ -136,7 +136,13 @@
       "cost_per_1m_out_cached": 0.95,
       "context_window": 262144,
       "default_max_tokens": 32768,
-      "can_reason": false,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {


### PR DESCRIPTION

## Summary

- Update `default_large_model_id` from `Kimi-K2.5` to `Kimi-K2.6` in synthetic provider
- Update feature matcher case from `K2.5` to `K2.6` (enables reasoning support)
- Regenerate `synthetic.json` with correct defaults and reasoning config

The v0.39.2 tag added Kimi-K2.6 as a model but didn't update the default reference, causing `TestValidDefaultModels` to fail in CI.

## Test plan

- [x] `go test ./internal/providers/` passes
- [ ] CI build passes

💘 Generated with Crush