### PR TITLE
fix: update deprecated default model IDs

### DIFF
--- a/cmd/neuralwatt/main.go
+++ b/cmd/neuralwatt/main.go
@@ -113,7 +113,7 @@ func main() {
 		APIEndpoint:         "https://api.neuralwatt.com/v1",
 		Type:                catwalk.TypeOpenAICompat,
 		DefaultLargeModelID: "zai-org/GLM-5.1-FP8",
-		DefaultSmallModelID: "mistralai/Devstral-Small-2-24B-Instruct-2512",
+		DefaultSmallModelID: "Qwen/Qwen3.6-35B-A3B",
 	}
 
 	modelsResp, err := fetchNeuralwattModels(neuralwattProvider.APIEndpoint)

--- a/cmd/opencode-zen/main.go
+++ b/cmd/opencode-zen/main.go
@@ -138,8 +138,8 @@ func main() {
 		APIKey:              "$OPENCODE_API_KEY",
 		APIEndpoint:         "https://opencode.ai/zen/v1",
 		Type:                catwalk.TypeOpenAICompat,
-		DefaultLargeModelID: "minimax-m2.5-free",
-		DefaultSmallModelID: "minimax-m2.5-free",
+		DefaultLargeModelID: "kimi-k2.6-fast",
+		DefaultSmallModelID: "Qwen/Qwen3.6-35B-A3B",
 	}
 
 	for _, zenModel := range zenModels {

--- a/internal/providers/configs/neuralwatt.json
+++ b/internal/providers/configs/neuralwatt.json
@@ -5,7 +5,7 @@
   "api_endpoint": "https://api.neuralwatt.com/v1",
   "type": "openai-compat",
   "default_large_model_id": "zai-org/GLM-5.1-FP8",
-  "default_small_model_id": "mistralai/Devstral-Small-2-24B-Instruct-2512",
+  "default_small_model_id": "Qwen/Qwen3.6-35B-A3B",
   "models": [
     {
       "id": "mistralai/Devstral-Small-2-24B-Instruct-2512",

--- a/internal/providers/configs/opencode-zen.json
+++ b/internal/providers/configs/opencode-zen.json
@@ -4,8 +4,8 @@
   "api_key": "$OPENCODE_API_KEY",
   "api_endpoint": "https://opencode.ai/zen/v1",
   "type": "openai-compat",
-  "default_large_model_id": "minimax-m2.5-free",
-  "default_small_model_id": "minimax-m2.5-free",
+  "default_large_model_id": "kimi-k2.6-fast",
+  "default_small_model_id": "Qwen/Qwen3.6-35B-A3B",
   "models": [
     {
       "id": "big-pickle",


### PR DESCRIPTION
## Summary

The current hardcoded default model references will break when Devstral-Small-24B and MiniMax-M2.5 are deprecated from their respective provider APIs. The nightly model sync will remove these entries, causing defaults to point to non-existent models.

## Changes

| File | Old Value | New Value |
|------|-----------|-----------|
| `cmd/neuralwatt/main.go` | `mistralai/Devstral-Small-2-24B-Instruct-2512` | `Qwen/Qwen3.6-35B-A3B` |
| `internal/providers/configs/neuralwatt.json` | `mistralai/Devstral-Small-2-24B-Instruct-2512` | `Qwen/Qwen3.6-35B-A3B` |
| `cmd/opencode-zen/main.go` | `minimax-m2.5-free` (large) | `kimi-k2.6-fast` |
| `cmd/opencode-zen/main.go` | `minimax-m2.5-free` (small) | `Qwen/Qwen3.6-35B-A3B` |
| `internal/providers/configs/opencode-zen.json` | `minimax-m2.5-free` (large) | `kimi-k2.6-fast` |
| `internal/providers/configs/opencode-zen.json` | `minimax-m2.5-free` (small) | `Qwen/Qwen3.6-35B-A3B` |

## Rationale

- **Devstral-Small-24B → Qwen3.6-35B-A3B**: Qwen3.6-35B is the designated replacement for the Devstral small model tier. It offers comparable coding performance with better availability.
- **MiniMax-M2.5-Free → Kimi-K2.6-Fast**: Kimi-K2.6-Fast is the replacement for the MiniMax-M2.5 free tier in the OpenCode Zen provider. It provides similar quality at comparable or better latency.

## Impact

Without this change, any client relying on the default model IDs will fail once the models are removed from the provider APIs during the nightly sync. Updating these defaults proactively ensures a smooth transition.

Draft until we confirm the replacement model IDs are stable in production.