### PR TITLE
fix(neuralwatt): update default small model ID from Devstral to Qwen3.6-35B

### DIFF
--- a/cmd/neuralwatt/main.go
+++ b/cmd/neuralwatt/main.go
@@ -113,7 +113,7 @@ func main() {
 		APIEndpoint:         "https://api.neuralwatt.com/v1",
 		Type:                catwalk.TypeOpenAICompat,
 		DefaultLargeModelID: "zai-org/GLM-5.1-FP8",
-		DefaultSmallModelID: "mistralai/Devstral-Small-2-24B-Instruct-2512",
+		DefaultSmallModelID: "Qwen/Qwen3.6-35B-A3B",
 	}
 
 	modelsResp, err := fetchNeuralwattModels(neuralwattProvider.APIEndpoint)

--- a/internal/providers/configs/neuralwatt.json
+++ b/internal/providers/configs/neuralwatt.json
@@ -5,7 +5,7 @@
   "api_endpoint": "https://api.neuralwatt.com/v1",
   "type": "openai-compat",
   "default_large_model_id": "zai-org/GLM-5.1-FP8",
-  "default_small_model_id": "mistralai/Devstral-Small-2-24B-Instruct-2512",
+  "default_small_model_id": "Qwen/Qwen3.6-35B-A3B",
   "models": [
     {
       "id": "mistralai/Devstral-Small-2-24B-Instruct-2512",


### PR DESCRIPTION
## Summary

Update the Neuralwatt provider default small model ID from `mistralai/Devstral-Small-2-24B-Instruct-2512` to `Qwen/Qwen3.6-35B-A3B`.

Devstral-Small-24B is being deprecated from the Neuralwatt API. Once the nightly model sync removes it, the hardcoded default would point to a non-existent model. Qwen3.6-35B is the designated replacement for the small model tier.

## Changes

| File | Change |
|-|-|
| `cmd/neuralwatt/main.go` | `DefaultSmallModelID`: Devstral → Qwen3.6-35B |
| `internal/providers/configs/neuralwatt.json` | `default_small_model_id`: Devstral → Qwen3.6-35B |

Only touches Neuralwatt provider files. No other providers affected.

Draft until we confirm Qwen3.6-35B is stable as the small default in production.