### PR TITLE
fix(anthropic,bedrock): align effort levels with Anthropic API docs

### DIFF
--- a/internal/providers/configs/anthropic.json
+++ b/internal/providers/configs/anthropic.json
@@ -18,7 +18,7 @@
       "default_max_tokens": 64000,
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
-      "default_reasoning_effort": "medium",
+      "default_reasoning_effort": "high",
       "supports_attachments": true
     },
     {
@@ -43,8 +43,8 @@
       "context_window": 1000000,
       "default_max_tokens": 126000,
       "can_reason": true,
-      "reasoning_levels": ["low", "medium", "high", "max"],
-      "default_reasoning_effort": "medium",
+      "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "high",
       "supports_attachments": true
     },
     {
@@ -58,7 +58,7 @@
       "default_max_tokens": 126000,
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
-      "default_reasoning_effort": "medium",
+      "default_reasoning_effort": "high",
       "supports_attachments": true
     },
     {

--- a/internal/providers/configs/bedrock.json
+++ b/internal/providers/configs/bedrock.json
@@ -17,6 +17,8 @@
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
+      "reasoning_levels": ["low", "medium", "high", "max"],
+      "default_reasoning_effort": "high",
       "supports_attachments": true
     },
     {
@@ -53,6 +55,8 @@
       "context_window": 1000000,
       "default_max_tokens": 126000,
       "can_reason": true,
+      "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "high",
       "supports_attachments": true
     },
     {
@@ -65,6 +69,8 @@
       "context_window": 1000000,
       "default_max_tokens": 126000,
       "can_reason": true,
+      "reasoning_levels": ["low", "medium", "high", "max"],
+      "default_reasoning_effort": "high",
       "supports_attachments": true
     },
     {


### PR DESCRIPTION
## Summary

Populate `reasoning_levels` / `default_reasoning_effort` on the Anthropic-on-Bedrock entries that support the `effort` parameter, and correct the direct-Anthropic entries so both provider JSONs agree with [Anthropic's Effort docs](https://docs.anthropic.com/en/docs/build-with-claude/effort).

Ref [charmbracelet/crush#2887](https://github.com/charmbracelet/crush/pull/2887) — Crush's reasoning-effort dialog hides itself when `reasoning_levels` is empty, so bedrock users can't currently pick `max`/`xhigh` through the UI even though the same models on the direct Anthropic provider work fine.

## Before / after

| Provider / Model | levels before | levels after | default before | default after |
|---|---|---|---|---|
| `bedrock` / `anthropic.claude-sonnet-4-6` | — | `[low, medium, high, max]` | — | `high` |
| `bedrock` / `anthropic.claude-opus-4-7` | — | `[low, medium, high, xhigh, max]` | — | `high` |
| `bedrock` / `anthropic.claude-opus-4-6-v1` | — | `[low, medium, high, max]` | — | `high` |
| `anthropic` / `claude-sonnet-4-6` | `[low, medium, high, max]` | (unchanged) | `medium` | `high` |
| `anthropic` / `claude-opus-4-7` | `[low, medium, high, max]` | `[low, medium, high, xhigh, max]` | `medium` | `high` |
| `anthropic` / `claude-opus-4-6` | `[low, medium, high, max]` | (unchanged) | `medium` | `high` |

## Rationale

Per Anthropic's effort docs:

- **`xhigh`** is Opus-4.7-only. Existing `anthropic.json` entry for opus-4-7 was missing it.
- **`max`** is supported on Opus 4.7, Opus 4.6, Sonnet 4.6, and Mythos Preview. Other reasoning-capable models (`opus-4-5`, `opus-4-1`, `sonnet-4-5`, `sonnet-4`, `haiku-4-5`) are left untouched — they don't advertise per-level effort support yet, so I'm not adding `reasoning_levels` for them in this PR.
- **Default is `high`**. Per the docs: *"Setting `effort` to `\"high\"` produces exactly the same behavior as omitting the `effort` parameter entirely."* The previous `medium` default did not match server behavior.

## Tests

- JSON validates and embeds cleanly (`go build ./...`).
- `go test ./...` passes.
- No code changes — pure catwalk metadata update.

## Not included (intentional)

- `bedrock / anthropic.claude-haiku-4-5-20251001-v1:0` currently has `can_reason: false` while `anthropic / claude-haiku-4-5-20251001` has `can_reason: true`. That's a separate discrepancy worth its own discussion; leaving it alone here.
- Mythos Preview and other models with `can_reason: true` but no per-level effort support stay unchanged.

![JJ Bot](https://www.gravatar.com/avatar/3cd1a8b0b916de49df61865fc284236dde7067f75ade4ad27e7de7f4671bbe7c?s=20) Generated with [JJ Bot](mailto:john.jansen+bot@me.com)