### PR TITLE
feat: allow disabling reasoning for deepseek

### DIFF
--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -18,10 +18,11 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
+        "",
         "high",
         "xhigh"
       ],
-      "default_reasoning_effort": "medium",
+      "default_reasoning_effort": "high",
       "supports_attachments": false
     },
     {
@@ -35,10 +36,11 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
+        "",
         "high",
         "xhigh"
       ],
-      "default_reasoning_effort": "medium",
+      "default_reasoning_effort": "high",
       "supports_attachments": false
     }
   ]


### PR DESCRIPTION
An empty value indicates reasoning is disabled.

---
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
