### PR TITLE
feat(minimax): enable can_reason flag for all MiniMax models

### DIFF
--- a/internal/providers/configs/minimax-china.json
+++ b/internal/providers/configs/minimax-china.json
@@ -15,7 +15,8 @@
       "cost_per_1m_in_cached": 0.06,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2.7",
@@ -25,7 +26,8 @@
       "cost_per_1m_in_cached": 0.06,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2.5-highspeed",
@@ -35,7 +37,8 @@
       "cost_per_1m_in_cached": 0.03,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2.5",
@@ -45,7 +48,8 @@
       "cost_per_1m_in_cached": 0.03,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2.1-highspeed",
@@ -55,7 +59,8 @@
       "cost_per_1m_in_cached": 0.03,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2.1",
@@ -65,7 +70,8 @@
       "cost_per_1m_in_cached": 0.03,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2",
@@ -75,7 +81,8 @@
       "cost_per_1m_in_cached": 0.03,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 196608,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "can_reason": true
     }
   ]
 }

--- a/internal/providers/configs/minimax.json
+++ b/internal/providers/configs/minimax.json
@@ -15,7 +15,8 @@
       "cost_per_1m_in_cached": 0.06,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2.7",
@@ -25,7 +26,8 @@
       "cost_per_1m_in_cached": 0.06,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2.5-highspeed",
@@ -35,7 +37,8 @@
       "cost_per_1m_in_cached": 0.03,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2.5",
@@ -45,7 +48,8 @@
       "cost_per_1m_in_cached": 0.03,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2.1-highspeed",
@@ -55,7 +59,8 @@
       "cost_per_1m_in_cached": 0.03,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2.1",
@@ -65,7 +70,8 @@
       "cost_per_1m_in_cached": 0.03,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "can_reason": true
     },
     {
       "id": "MiniMax-M2",
@@ -75,7 +81,8 @@
       "cost_per_1m_in_cached": 0.03,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 200000,
-      "default_max_tokens": 20000
+      "default_max_tokens": 20000,
+      "can_reason": true
     }
   ]
 }


### PR DESCRIPTION
Adds can_reason: true to all MiniMax model entries in both minimax.json and minimax-china.json, enabling the Interleaved Thinking toggle in the Crush TUI for MiniMax M2+ models.

Closes #283

💘 Generated with Crush

Assisted-by: Crush:MiniMax-M2.7-highspeed

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
