### PR TITLE
chore: add novita ai provider

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,10 +29,6 @@ jobs:
         run: go run ./cmd/avian/main.go
         continue-on-error: true
 
-      - name: Neuralwatt
-        run: go run ./cmd/neuralwatt/main.go
-        continue-on-error: true
-
       - name: Chutes
         run: go run ./cmd/chutes/main.go
         continue-on-error: true
@@ -47,6 +43,14 @@ jobs:
 
       - name: io.net
         run: go run ./cmd/ionet/main.go
+        continue-on-error: true
+
+      - name: Neuralwatt
+        run: go run ./cmd/neuralwatt/main.go
+        continue-on-error: true
+
+      - name: NovitaAI
+        run: go run ./cmd/novita/main.go
         continue-on-error: true
 
       - name: OpenCode Go

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -66,6 +66,7 @@ tasks:
       - task: gen:ionet
       - task: gen:nebius
       - task: gen:neuralwatt
+      - task: gen:novita
       - task: gen:opencode-go
       - task: gen:opencode-zen
       - task: gen:openrouter
@@ -118,6 +119,11 @@ tasks:
     desc: Generate Neuralwatt provider configurations
     cmds:
       - go run cmd/neuralwatt/main.go
+
+  gen:novita:
+    desc: Generate NovitaAI provider configurations
+    cmds:
+      - go run cmd/novita/main.go
 
   gen:opencode-go:
     desc: Generate OpenCode Go provider configurations

--- a/cmd/novita/main.go
+++ b/cmd/novita/main.go
@@ -1,5 +1,5 @@
-// Package main provides a command-line tool to fetch models from NovitaAI
-// and generate a configuration file for the provider.
+// Package main provides a command-line tool to fetch models from NovitaAI and
+// generate a configuration file for the provider.
 package main
 
 import (
@@ -19,17 +19,17 @@ import (
 )
 
 type NovitaAIModel struct {
-	ID                  string   `json:"id"`
-	DisplayName         string   `json:"display_name"`
+	ID                   string   `json:"id"`
+	DisplayName          string   `json:"display_name"`
 	InputTokenPricePerM  float64  `json:"input_token_price_per_m"`
 	OutputTokenPricePerM float64  `json:"output_token_price_per_m"`
-	ContextSize         int64    `json:"context_size"`
-	MaxOutputTokens     int64    `json:"max_output_tokens"`
-	Status              int      `json:"status"`
-	ModelType           string   `json:"model_type"`
-	Features            []string `json:"features"`
-	Endpoints           []string `json:"endpoints"`
-	InputModalities     []string `json:"input_modalities"`
+	ContextSize          int64    `json:"context_size"`
+	MaxOutputTokens      int64    `json:"max_output_tokens"`
+	Status               int      `json:"status"`
+	ModelType            string   `json:"model_type"`
+	Features             []string `json:"features"`
+	Endpoints            []string `json:"endpoints"`
+	InputModalities      []string `json:"input_modalities"`
 }
 
 type ModelsResponse struct {

--- a/cmd/novita/main.go
+++ b/cmd/novita/main.go
@@ -1,0 +1,183 @@
+// Package main provides a command-line tool to fetch models from NovitaAI
+// and generate a configuration file for the provider.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+type NovitaAIModel struct {
+	ID                  string   `json:"id"`
+	DisplayName         string   `json:"display_name"`
+	InputTokenPricePerM  float64  `json:"input_token_price_per_m"`
+	OutputTokenPricePerM float64  `json:"output_token_price_per_m"`
+	ContextSize         int64    `json:"context_size"`
+	MaxOutputTokens     int64    `json:"max_output_tokens"`
+	Status              int      `json:"status"`
+	ModelType           string   `json:"model_type"`
+	Features            []string `json:"features"`
+	Endpoints           []string `json:"endpoints"`
+	InputModalities     []string `json:"input_modalities"`
+}
+
+type ModelsResponse struct {
+	Data []NovitaAIModel `json:"data"`
+}
+
+func main() {
+	novitaAIProvider := catwalk.Provider{
+		Name:                "NovitaAI",
+		ID:                  catwalk.InferenceProviderNovitaAI,
+		APIKey:              "$NOVITA_API_KEY",
+		APIEndpoint:         "https://api.novita.ai/openai/v1",
+		Type:                catwalk.TypeOpenAICompat,
+		DefaultLargeModelID: "moonshotai/kimi-k2.5",
+		DefaultSmallModelID: "zai-org/glm-4.7-flash",
+	}
+
+	modelsResp, err := fetchNovitaAIModels(novitaAIProvider.APIEndpoint)
+	if err != nil {
+		log.Fatal("Error fetching NovitaAI models:", err)
+	}
+
+	for _, model := range modelsResp.Data {
+		if shouldSkipModel(model) {
+			fmt.Printf("Skipping model %s\n", model.ID)
+			continue
+		}
+
+		var reasoningLevels []string
+		var defaultReasoning string
+		if supportsReasoningLevels(model.ID) {
+			reasoningLevels = []string{"low", "medium", "high"}
+			defaultReasoning = "medium"
+		}
+
+		name := model.DisplayName
+		if name == "" {
+			name = fallbackDisplayName(model.ID)
+		}
+
+		m := catwalk.Model{
+			ID:                     model.ID,
+			Name:                   name,
+			CostPer1MIn:            roundCost(model.InputTokenPricePerM / 10000),
+			CostPer1MOut:           roundCost(model.OutputTokenPricePerM / 10000),
+			ContextWindow:          model.ContextSize,
+			DefaultMaxTokens:       model.MaxOutputTokens,
+			CanReason:              contains(model.Features, "reasoning"),
+			ReasoningLevels:        reasoningLevels,
+			DefaultReasoningEffort: defaultReasoning,
+			SupportsImages:         contains(model.InputModalities, "image"),
+		}
+
+		novitaAIProvider.Models = append(novitaAIProvider.Models, m)
+		fmt.Printf("Added model %s with context window %d\n", model.ID, model.ContextSize)
+	}
+
+	slices.SortFunc(novitaAIProvider.Models, func(a catwalk.Model, b catwalk.Model) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	data, err := json.MarshalIndent(novitaAIProvider, "", "  ")
+	if err != nil {
+		log.Fatal("Error marshaling NovitaAI provider:", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile("internal/providers/configs/novita.json", data, 0o600); err != nil {
+		log.Fatal("Error writing NovitaAI provider config:", err)
+	}
+
+	fmt.Printf("Generated novita.json with %d models\n", len(novitaAIProvider.Models))
+}
+
+func fetchNovitaAIModels(apiEndpoint string) (*ModelsResponse, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiEndpoint+"/models", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Charm-Catwalk/1.0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching models: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading models response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, body)
+	}
+
+	_ = os.MkdirAll("tmp", 0o700)
+	_ = os.WriteFile("tmp/novita-response.json", body, 0o600)
+
+	var mr ModelsResponse
+	if err := json.Unmarshal(body, &mr); err != nil {
+		return nil, fmt.Errorf("decoding models response: %w", err)
+	}
+
+	return &mr, nil
+}
+
+func shouldSkipModel(model NovitaAIModel) bool {
+	if model.Status != 1 || model.ModelType != "chat" {
+		return true
+	}
+	if model.ContextSize < 100000 {
+		return true
+	}
+	if model.InputTokenPricePerM <= 0 || model.OutputTokenPricePerM <= 0 {
+		return true
+	}
+	if !contains(model.Endpoints, "chat/completions") {
+		return true
+	}
+	if !contains(model.Features, "function-calling") {
+		return true
+	}
+
+	id := strings.ToLower(model.ID)
+	return strings.HasPrefix(id, "ai_infer_test_") ||
+		strings.HasPrefix(id, "dev/") ||
+		id == "bunny" ||
+		id == "elephant"
+}
+
+func fallbackDisplayName(id string) string {
+	name := id
+	if idx := strings.Index(name, "/"); idx != -1 {
+		name = name[idx+1:]
+	}
+	return strings.ReplaceAll(name, "-", " ")
+}
+
+func contains(values []string, target string) bool {
+	return slices.Contains(values, target)
+}
+
+func supportsReasoningLevels(modelID string) bool {
+	return strings.Contains(strings.ToLower(modelID), "gpt-oss")
+}
+
+func roundCost(v float64) float64 {
+	return math.Round(v*1e5) / 1e5
+}

--- a/internal/providers/configs/novita.json
+++ b/internal/providers/configs/novita.json
@@ -1,0 +1,657 @@
+{
+  "name": "NovitaAI",
+  "id": "novita",
+  "api_key": "$NOVITA_API_KEY",
+  "api_endpoint": "https://api.novita.ai/openai/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "moonshotai/kimi-k2.5",
+  "default_small_model_id": "zai-org/glm-4.7-flash",
+  "models": [
+    {
+      "id": "deepseek/deepseek-r1-0528",
+      "name": "DeepSeek R1 0528",
+      "cost_per_1m_in": 0.7,
+      "cost_per_1m_out": 2.5,
+      "context_window": 163840,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek/deepseek-v3-0324",
+      "name": "DeepSeek V3 0324",
+      "cost_per_1m_in": 0.27,
+      "cost_per_1m_out": 1.12,
+      "context_window": 163840,
+      "default_max_tokens": 65536,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek/deepseek-v3.1",
+      "name": "DeepSeek V3.1",
+      "cost_per_1m_in": 0.27,
+      "cost_per_1m_out": 1,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek/deepseek-v3.1-terminus",
+      "name": "Deepseek V3.1 Terminus",
+      "cost_per_1m_in": 0.27,
+      "cost_per_1m_out": 1,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek/deepseek-v3.2",
+      "name": "Deepseek V3.2",
+      "cost_per_1m_in": 0.269,
+      "cost_per_1m_out": 0.4,
+      "context_window": 163840,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek/deepseek-v3.2-exp",
+      "name": "Deepseek V3.2 Exp",
+      "cost_per_1m_in": 0.27,
+      "cost_per_1m_out": 0.41,
+      "context_window": 163840,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek/deepseek-v4-flash",
+      "name": "Deepseek V4 Flash",
+      "cost_per_1m_in": 0.14,
+      "cost_per_1m_out": 0.28,
+      "context_window": 1048576,
+      "default_max_tokens": 393216,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek/deepseek-v4-pro",
+      "name": "Deepseek V4 Pro",
+      "cost_per_1m_in": 1.6,
+      "cost_per_1m_out": 3.38,
+      "context_window": 1048576,
+      "default_max_tokens": 393216,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "baidu/ernie-4.5-21B-a3b",
+      "name": "ERNIE 4.5 21B A3B",
+      "cost_per_1m_in": 0.07,
+      "cost_per_1m_out": 0.28,
+      "context_window": 120000,
+      "default_max_tokens": 8000,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "baidu/ernie-4.5-vl-28b-a3b-thinking",
+      "name": "ERNIE-4.5-VL-28B-A3B-Thinking",
+      "cost_per_1m_in": 0.39,
+      "cost_per_1m_out": 0.39,
+      "context_window": 131072,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "zai-org/glm-4.6",
+      "name": "GLM 4.6",
+      "cost_per_1m_in": 0.55,
+      "cost_per_1m_out": 2.2,
+      "context_window": 204800,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "zai-org/glm-4.6v",
+      "name": "GLM 4.6V",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 0.9,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "zai-org/glm-4.5",
+      "name": "GLM-4.5",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 2.2,
+      "context_window": 131072,
+      "default_max_tokens": 98304,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "zai-org/glm-4.7-h",
+      "name": "GLM-4.7",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 2.2,
+      "context_window": 204800,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "zai-org/glm-4.7",
+      "name": "GLM-4.7",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 2.2,
+      "context_window": 204800,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "zai-org/glm-4.7-flash",
+      "name": "GLM-4.7-Flash",
+      "cost_per_1m_in": 0.07,
+      "cost_per_1m_out": 0.4,
+      "context_window": 200000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "zai-org/glm-5",
+      "name": "GLM-5",
+      "cost_per_1m_in": 1,
+      "cost_per_1m_out": 3.2,
+      "context_window": 202800,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "zai-org/glm-5-turbo",
+      "name": "GLM-5-Turbo",
+      "cost_per_1m_in": 1.2,
+      "cost_per_1m_out": 4,
+      "context_window": 202800,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "zai-org/glm-5.1",
+      "name": "GLM-5.1",
+      "cost_per_1m_in": 1.38,
+      "cost_per_1m_out": 4.4,
+      "context_window": 204800,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "zai-org/glm-5v-turbo",
+      "name": "GLM-5V-Turbo",
+      "cost_per_1m_in": 1.2,
+      "cost_per_1m_out": 4,
+      "context_window": 204800,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "google/gemma-4-26b-a4b-it",
+      "name": "Gemma 4 26B A4B",
+      "cost_per_1m_in": 0.13,
+      "cost_per_1m_out": 0.4,
+      "context_window": 262144,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "google/gemma-4-31b-it",
+      "name": "Gemma 4 31B",
+      "cost_per_1m_in": 0.14,
+      "cost_per_1m_out": 0.4,
+      "context_window": 262144,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "kwaipilot/kat-coder-pro",
+      "name": "Kat Coder Pro",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 1.2,
+      "context_window": 256000,
+      "default_max_tokens": 128000,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "moonshotai/kimi-k2-0905",
+      "name": "Kimi K2 0905",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 2.5,
+      "context_window": 262144,
+      "default_max_tokens": 262144,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "moonshotai/kimi-k2-instruct",
+      "name": "Kimi K2 Instruct",
+      "cost_per_1m_in": 0.57,
+      "cost_per_1m_out": 2.3,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "moonshotai/kimi-k2-thinking",
+      "name": "Kimi K2 Thinking",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 2.5,
+      "context_window": 262144,
+      "default_max_tokens": 262144,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "moonshotai/kimi-k2.5",
+      "name": "Kimi K2.5",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 3,
+      "context_window": 262144,
+      "default_max_tokens": 262144,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "moonshotai/kimi-k2.6",
+      "name": "Kimi K2.6",
+      "cost_per_1m_in": 0.8,
+      "cost_per_1m_out": 3.4,
+      "context_window": 262144,
+      "default_max_tokens": 262144,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "inclusionai/ling-2.6-1t",
+      "name": "Ling-2.6-1T",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 2.5,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "inclusionai/ling-2.6-flash",
+      "name": "Ling-2.6-flash",
+      "cost_per_1m_in": 0.1,
+      "cost_per_1m_out": 0.3,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "meta-llama/llama-3.3-70b-instruct",
+      "name": "Llama 3.3 70B Instruct",
+      "cost_per_1m_in": 0.135,
+      "cost_per_1m_out": 0.4,
+      "context_window": 131072,
+      "default_max_tokens": 120000,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "minimaxai/minimax-m1-80k",
+      "name": "MiniMax M1",
+      "cost_per_1m_in": 0.55,
+      "cost_per_1m_out": 2.2,
+      "context_window": 1000000,
+      "default_max_tokens": 40000,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "minimax/minimax-m2.5",
+      "name": "MiniMax M2.5",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 1.2,
+      "context_window": 204800,
+      "default_max_tokens": 131100,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "minimax/minimax-m2.5-highspeed",
+      "name": "MiniMax M2.5-highspeed",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 2.4,
+      "context_window": 204800,
+      "default_max_tokens": 131100,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "minimax/minimax-m2.7",
+      "name": "MiniMax M2.7",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 1.2,
+      "context_window": 204800,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "minimax/minimax-m2.7-highspeed",
+      "name": "MiniMax M2.7-highspeed",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 2.4,
+      "context_window": 204800,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "minimax/minimax-m2",
+      "name": "MiniMax-M2",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 1.2,
+      "context_window": 204800,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "minimax/minimax-m2.1",
+      "name": "Minimax M2.1",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 1.2,
+      "context_window": 204800,
+      "default_max_tokens": 131072,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "openai/gpt-oss-120b",
+      "name": "OpenAI GPT OSS 120B",
+      "cost_per_1m_in": 0.05,
+      "cost_per_1m_out": 0.25,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3-235b-a22b-instruct-2507",
+      "name": "Qwen3 235B A22B Instruct 2507",
+      "cost_per_1m_in": 0.09,
+      "cost_per_1m_out": 0.58,
+      "context_window": 131072,
+      "default_max_tokens": 16384,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-235b-a22b-thinking-2507",
+      "name": "Qwen3 235B A22b Thinking 2507",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 3,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-coder-30b-a3b-instruct",
+      "name": "Qwen3 Coder 30b A3B Instruct",
+      "cost_per_1m_in": 0.07,
+      "cost_per_1m_out": 0.27,
+      "context_window": 160000,
+      "default_max_tokens": 32768,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-coder-480b-a35b-instruct",
+      "name": "Qwen3 Coder 480B A35B Instruct",
+      "cost_per_1m_in": 0.38,
+      "cost_per_1m_out": 1.55,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-coder-next",
+      "name": "Qwen3 Coder Next",
+      "cost_per_1m_in": 0.2,
+      "cost_per_1m_out": 1.5,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-max",
+      "name": "Qwen3 Max",
+      "cost_per_1m_in": 2.11,
+      "cost_per_1m_out": 8.45,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-next-80b-a3b-instruct",
+      "name": "Qwen3 Next 80B A3B Instruct",
+      "cost_per_1m_in": 0.15,
+      "cost_per_1m_out": 1.5,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-next-80b-a3b-thinking",
+      "name": "Qwen3 Next 80B A3B Thinking",
+      "cost_per_1m_in": 0.15,
+      "cost_per_1m_out": 1.5,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-vl-235b-a22b-instruct",
+      "name": "Qwen3 VL 235B A22B Instruct",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 1.5,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3-vl-235b-a22b-thinking",
+      "name": "Qwen3 VL 235B A22B Thinking",
+      "cost_per_1m_in": 0.98,
+      "cost_per_1m_out": 3.95,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3.5-122b-a10b",
+      "name": "Qwen3.5-122B-A10B",
+      "cost_per_1m_in": 0.4,
+      "cost_per_1m_out": 3.2,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3.5-27b",
+      "name": "Qwen3.5-27B",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 2.4,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3.5-35b-a3b",
+      "name": "Qwen3.5-35B-A3B",
+      "cost_per_1m_in": 0.25,
+      "cost_per_1m_out": 2,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3.5-397b-a17b",
+      "name": "Qwen3.5-397B-A17B",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 3.6,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3.6-27b",
+      "name": "Qwen3.6-27B",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 3.6,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3.6-35b-a3b",
+      "name": "Qwen3.6-35B-A3B",
+      "cost_per_1m_in": 0.248,
+      "cost_per_1m_out": 1.485,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3.7-max",
+      "name": "Qwen3.7-Max",
+      "cost_per_1m_in": 1.25,
+      "cost_per_1m_out": 3.75,
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "inclusionai/ring-2.6-1t",
+      "name": "Ring-2.6-1T",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 2.5,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "xiaomimimo/mimo-v2-flash",
+      "name": "XiaomiMiMo/MiMo-V2-Flash",
+      "cost_per_1m_in": 0.1,
+      "cost_per_1m_out": 0.3,
+      "context_window": 262144,
+      "default_max_tokens": 32000,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "xiaomimimo/mimo-v2-pro",
+      "name": "XiaomiMiMo/MiMo-V2-Pro",
+      "cost_per_1m_in": 2,
+      "cost_per_1m_out": 6,
+      "context_window": 1048576,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "xiaomimimo/mimo-v2.5-pro",
+      "name": "XiaomiMiMo/MiMo-V2.5-Pro",
+      "cost_per_1m_in": 2,
+      "cost_per_1m_out": 6,
+      "context_window": 1048576,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-vl-30b-a3b-instruct",
+      "name": "qwen/qwen3-vl-30b-a3b-instruct",
+      "cost_per_1m_in": 0.2,
+      "cost_per_1m_out": 0.7,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3-vl-30b-a3b-thinking",
+      "name": "qwen/qwen3-vl-30b-a3b-thinking",
+      "cost_per_1m_in": 0.2,
+      "cost_per_1m_out": 1,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3-vl-8b-instruct",
+      "name": "qwen/qwen3-vl-8b-instruct",
+      "cost_per_1m_in": 0.08,
+      "cost_per_1m_out": 0.5,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "zai-org/glm-4.5-air",
+      "name": "zai-org/glm-4.5-air",
+      "cost_per_1m_in": 0.13,
+      "cost_per_1m_out": 0.85,
+      "context_window": 131072,
+      "default_max_tokens": 98304,
+      "can_reason": true,
+      "supports_attachments": false
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -72,6 +72,9 @@ var nebiusConfig []byte
 //go:embed configs/neuralwatt.json
 var neuralwattConfig []byte
 
+//go:embed configs/novita.json
+var novitaAIConfig []byte
+
 //go:embed configs/openai.json
 var openAIConfig []byte
 
@@ -143,6 +146,7 @@ var providerRegistry = []ProviderFunc{
 	ioNetProvider,
 	nebiusProvider,
 	neuralwattProvider,
+	novitaAIProvider,
 	openCodeGoProvider,
 	openCodeZenProvider,
 	openRouterProvider,
@@ -254,6 +258,10 @@ func nebiusProvider() catwalk.Provider {
 
 func neuralwattProvider() catwalk.Provider {
 	return loadProviderFromConfig(neuralwattConfig)
+}
+
+func novitaAIProvider() catwalk.Provider {
+	return loadProviderFromConfig(novitaAIConfig)
 }
 
 func openAIProvider() catwalk.Provider {

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -52,6 +52,7 @@ const (
 	InferenceProviderAvian            InferenceProvider = "avian"
 	InferenceProviderNebius           InferenceProvider = "nebius"
 	InferenceProviderNeuralwatt       InferenceProvider = "neuralwatt"
+	InferenceProviderNovitaAI         InferenceProvider = "novita"
 	InferenceProviderOpenCodeZen      InferenceProvider = "opencode-zen"
 	InferenceProviderOpenCodeGo       InferenceProvider = "opencode-go"
 	InferenceProviderAlibabaSingapore InferenceProvider = "alibaba-singapore"
@@ -129,6 +130,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderAvian,
 		InferenceProviderNebius,
 		InferenceProviderNeuralwatt,
+		InferenceProviderNovitaAI,
 		InferenceProviderOpenCodeZen,
 		InferenceProviderOpenCodeGo,
 	}


### PR DESCRIPTION
## Summary
- add NovitaAI as an OpenAI-compatible provider
- generate NovitaAI provider data from `https://api.novita.ai/openai/v1/models`
- include NovitaAI in the provider registry, known providers, Taskfile generation, and scheduled update workflow

## Validation
- `git diff --check`
- `jq empty internal/providers/configs/novita.json`
- verified every provider config default large/small model exists in its model list with jq
