### PR TITLE
feat(cerebras): remove deprecated qwen-3-235b model

### DIFF
--- a/internal/providers/configs/cerebras.json
+++ b/internal/providers/configs/cerebras.json
@@ -5,7 +5,7 @@
     "api_key": "$CEREBRAS_API_KEY",
     "api_endpoint": "https://api.cerebras.ai/v1",
     "default_large_model_id": "gpt-oss-120b",
-    "default_small_model_id": "qwen-3-235b-a22b-instruct-2507",
+    "default_small_model_id": "zai-glm-4.7",
     "default_headers": {
         "X-Cerebras-3rd-Party-Integration": "crush"
     },
@@ -24,16 +24,6 @@
                 "high"
             ],
             "default_reasoning_effort": "medium",
-            "supports_attachments": false
-        },
-        {
-            "id": "qwen-3-235b-a22b-instruct-2507",
-            "name": "Qwen 3 235B Instruct",
-            "cost_per_1m_in": 0.6,
-            "cost_per_1m_out": 1.2,
-            "context_window": 131072,
-            "default_max_tokens": 25000,
-            "can_reason": false,
             "supports_attachments": false
         },
         {


### PR DESCRIPTION
## Summary
- remove the deprecated `qwen-3-235b-a22b-instruct-2507` Cerebras catalog entry
- promote `zai-glm-4.7` to the default small Cerebras model

## Testing
- `jq empty internal/providers/configs/cerebras.json`