### PR TITLE
Fix Synthetic default small model

### DIFF
--- a/cmd/synthetic/main.go
+++ b/cmd/synthetic/main.go
@@ -160,7 +160,7 @@ func main() {
 		APIEndpoint:         "https://api.synthetic.new/openai/v1",
 		Type:                catwalk.TypeOpenAICompat,
 		DefaultLargeModelID: "hf:moonshotai/Kimi-K2.6",
-		DefaultSmallModelID: "hf:deepseek-ai/DeepSeek-V3.2",
+		DefaultSmallModelID: "syn:small:text",
 		Models:              []catwalk.Model{},
 	}
 

--- a/internal/providers/configs/synthetic.json
+++ b/internal/providers/configs/synthetic.json
@@ -5,7 +5,7 @@
   "api_endpoint": "https://api.synthetic.new/openai/v1",
   "type": "openai-compat",
   "default_large_model_id": "hf:moonshotai/Kimi-K2.6",
-  "default_small_model_id": "hf:deepseek-ai/DeepSeek-V3.2",
+  "default_small_model_id": "syn:small:text",
   "models": [
     {
       "id": "hf:zai-org/GLM-4.7",


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Synthetic's generated provider config was still pointing its default small model at `hf:deepseek-ai/DeepSeek-V3.2`, but that model is no longer present in the generated model list. This makes `TestValidDefaultModels` fail on current main.

This updates the default small model to `syn:small:text`, which is present in the current Synthetic config, and makes the same change in the generator so future updates keep the value stable.