### PR TITLE
feat: add StepFun as a dedicated provider

### DIFF
--- a/internal/providers/configs/stepfun.json
+++ b/internal/providers/configs/stepfun.json
@@ -1,0 +1,47 @@
+{
+  "name": "StepFun",
+  "id": "stepfun",
+  "type": "openai-compat",
+  "api_key": "$STEPFUN_API_KEY",
+  "api_endpoint": "https://api.stepfun.com/v1",
+  "default_large_model_id": "step-3.7-flash",
+  "default_small_model_id": "step-3.5-flash",
+  "models": [
+    {
+      "id": "step-3.5-flash",
+      "name": "Step 3.5 Flash",
+      "cost_per_1m_in": 0.09,
+      "cost_per_1m_out": 0.3,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.02,
+      "context_window": 262144,
+      "default_max_tokens": 8192,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "step-3.7-flash",
+      "name": "Step 3.7 Flash",
+      "cost_per_1m_in": 0.2,
+      "cost_per_1m_out": 1.15,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.04,
+      "context_window": 256000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -90,6 +90,9 @@ var qiniuCloudConfig []byte
 //go:embed configs/synthetic.json
 var syntheticConfig []byte
 
+//go:embed configs/stepfun.json
+var stepfunConfig []byte
+
 //go:embed configs/vercel.json
 var vercelConfig []byte
 
@@ -147,6 +150,7 @@ var providerRegistry = []ProviderFunc{
 	openCodeZenProvider,
 	openRouterProvider,
 	qiniuCloudProvider,
+	stepfunProvider,
 	vercelProvider,
 	veniceProvider,
 	vertexAIProvider,
@@ -278,6 +282,10 @@ func qiniuCloudProvider() catwalk.Provider {
 
 func syntheticProvider() catwalk.Provider {
 	return loadProviderFromConfig(syntheticConfig)
+}
+
+func stepfunProvider() catwalk.Provider {
+	return loadProviderFromConfig(stepfunConfig)
 }
 
 func vercelProvider() catwalk.Provider {

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -55,6 +55,7 @@ const (
 	InferenceProviderOpenCodeZen      InferenceProvider = "opencode-zen"
 	InferenceProviderOpenCodeGo       InferenceProvider = "opencode-go"
 	InferenceProviderAlibabaSingapore InferenceProvider = "alibaba-singapore"
+	InferenceProviderStepFun        InferenceProvider = "stepfun"
 )
 
 // Provider represents an AI provider configuration.
@@ -131,6 +132,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderNeuralwatt,
 		InferenceProviderOpenCodeZen,
 		InferenceProviderOpenCodeGo,
+		InferenceProviderStepFun,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add StepFun (stepfun.com) as a first-class provider with their OpenAI-compatible API endpoint.
- Include Step 3.5 Flash and Step 3.7 Flash models.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `TestValidDefaultModels/StepFun` passes

💘 Generated with Crush

Assisted-by: Crush:accounts/fireworks/routers/kimi-k2p6-turbo