### PR TITLE
feat(config): allow env var CATWALK_PORT to override the port

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module charm.land/catwalk
 go 1.25.11
 
 require (
+	github.com/caarlos0/env/v11 v11.4.1
 	github.com/charmbracelet/x/etag v0.2.0
 	github.com/charmbracelet/x/exp/strings v0.1.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/caarlos0/env/v11 v11.4.1 h1:fYwH0sWEsBSMPG7t4e/PEfTFzrWrpjyygXyUnWiSwEw=
+github.com/caarlos0/env/v11 v11.4.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/x/etag v0.2.0 h1:Euj1VkheoHfTYA9y+TCwkeXF/hN8Fb9l4LqZl79pt04=

--- a/main.go
+++ b/main.go
@@ -4,11 +4,13 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
 
 	"charm.land/catwalk/internal/providers"
+	"github.com/caarlos0/env/v11"
 	"github.com/charmbracelet/x/etag"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -78,7 +80,16 @@ func providersHandlerDeprecated(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
+type config struct {
+	Port int `env:"CATWALK_PORT" envDefault:"8080"`
+}
+
 func main() {
+	var cfg config
+	if err := env.Parse(&cfg); err != nil {
+		log.Fatal(fmt.Errorf("parse config: %w", err))
+	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/providers", providersHandler)
 	mux.HandleFunc("/providers", providersHandlerDeprecated)
@@ -86,15 +97,16 @@ func main() {
 	mux.HandleFunc("/healthz", health)
 	mux.Handle("/metrics", promhttp.Handler())
 
+	addr := fmt.Sprintf(":%d", cfg.Port)
 	server := &http.Server{
-		Addr:         ":8080",
+		Addr:         addr,
 		Handler:      mux,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
 		IdleTimeout:  60 * time.Second,
 	}
 
-	log.Println("Server starting on :8080")
+	log.Println("Server starting on", addr)
 	if err := server.ListenAndServe(); err != nil {
 		log.Fatal("Server failed to start:", err)
 	}


### PR DESCRIPTION
This allows the port to be overridden with `CATWALK_PORT` in the environment.