### PR TITLE
chore: add direct Mistral provider

### DIFF
--- a/internal/providers/configs/mistral.json
+++ b/internal/providers/configs/mistral.json
@@ -1,0 +1,144 @@
+{
+  "name": "Mistral",
+  "id": "mistral",
+  "type": "openai-compat",
+  "api_key": "$MISTRAL_API_KEY",
+  "api_endpoint": "https://api.mistral.ai/v1",
+  "default_large_model_id": "mistral-medium-3.5",
+  "default_small_model_id": "mistral-small-2603",
+  "models": [
+    {
+      "id": "magistral-medium-2509",
+      "name": "Magistral Medium 1.2",
+      "cost_per_1m_in": 2,
+      "cost_per_1m_out": 5,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 16384,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "mistral-medium-3.5",
+      "name": "Mistral Medium 3.5",
+      "cost_per_1m_in": 1.5,
+      "cost_per_1m_out": 7.5,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 256000,
+      "default_max_tokens": 25600,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "mistral-large-2512",
+      "name": "Mistral Large 3",
+      "cost_per_1m_in": 0.5,
+      "cost_per_1m_out": 1.5,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 16384
+    },
+    {
+      "id": "magistral-small-2509",
+      "name": "Magistral Small",
+      "cost_per_1m_in": 0.5,
+      "cost_per_1m_out": 1.5,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 16384,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "devstral-2512",
+      "name": "Devstral 2",
+      "cost_per_1m_in": 0.4,
+      "cost_per_1m_out": 2,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 256000,
+      "default_max_tokens": 25600
+    },
+    {
+      "id": "codestral-2508",
+      "name": "Codestral",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 0.9,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 32000,
+      "default_max_tokens": 16384
+    },
+    {
+      "id": "mistral-small-2603",
+      "name": "Mistral Small 4",
+      "cost_per_1m_in": 0.1,
+      "cost_per_1m_out": 0.3,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 16384,
+      "supports_attachments": true
+    },
+    {
+      "id": "devstral-small-2505",
+      "name": "Devstral Small 2",
+      "cost_per_1m_in": 0.1,
+      "cost_per_1m_out": 0.3,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 16384
+    },
+    {
+      "id": "ministral-14b-2512",
+      "name": "Ministral 14B",
+      "cost_per_1m_in": 0.2,
+      "cost_per_1m_out": 0.2,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 16384
+    },
+    {
+      "id": "ministral-8b-2512",
+      "name": "Ministral 8B",
+      "cost_per_1m_in": 0.15,
+      "cost_per_1m_out": 0.15,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 16384
+    },
+    {
+      "id": "ministral-3b-2512",
+      "name": "Ministral 3B",
+      "cost_per_1m_in": 0.04,
+      "cost_per_1m_out": 0.04,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 16384
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -66,6 +66,9 @@ var miniMaxConfig []byte
 //go:embed configs/minimax-china.json
 var miniMaxChinaConfig []byte
 
+//go:embed configs/mistral.json
+var mistralConfig []byte
+
 //go:embed configs/nebius.json
 var nebiusConfig []byte
 
@@ -127,6 +130,7 @@ var providerRegistry = []ProviderFunc{
 	kimiCodingProvider,
 	miniMaxProvider,
 	miniMaxChinaProvider,
+	mistralProvider,
 	syntheticProvider,
 
 	// The remaining will be in alphabetical order.
@@ -250,6 +254,10 @@ func miniMaxProvider() catwalk.Provider {
 
 func miniMaxChinaProvider() catwalk.Provider {
 	return loadProviderFromConfig(miniMaxChinaConfig)
+}
+
+func mistralProvider() catwalk.Provider {
+	return loadProviderFromConfig(mistralConfig)
 }
 
 func nebiusProvider() catwalk.Provider {


### PR DESCRIPTION
## Summary

- Adds `internal/providers/configs/mistral.json` as a new first-class provider hitting `https://api.mistral.ai/v1` (uses `$MISTRAL_API_KEY`)
- Registers it in `providers.go` alongside the other main providers
- 11 models included:
  - **Mistral Medium 3.5** (default large, reasoning, 256k ctx, $1.5/$7.5/1M)
  - **Magistral Medium 1.2** and **Magistral Small** (reasoning models, $2/$5 and $0.5/$1.5)
  - **Mistral Large 3** ($0.5/$1.5)
  - **Devstral 2** (agentic coding, 256k ctx, $0.4/$2) and **Devstral Small 2**
  - **Codestral** (code completion, 32k ctx, $0.3/$0.9)
  - **Mistral Small 4** (default small, multimodal, $0.1/$0.3)
  - **Ministral 14B / 8B / 3B** (edge models)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/providers/...` — 37 tests pass
- [ ] Verify with a live `$MISTRAL_API_KEY` that model IDs resolve correctly