### PR TITLE
ci: push images to Artifact Registry on dev

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,11 +11,14 @@ jobs:
     with:
       go_version: stable
       upload_artifacts: false
+      gcp_enabled: true
     secrets:
       docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
       docker_token: ${{ secrets.DOCKERHUB_TOKEN }}
       goreleaser_key: ${{ secrets.GORELEASER_KEY }}
       gh_pat: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      gcp_wif_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+      gcp_service_account: ${{ secrets.GCP_DEPLOYER_SA }}
 
   deploy:
     name: Run deploy workflow

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,7 @@ nightly:
 dockers:
   - image_templates:
       - "ghcr.io/charmbracelet/{{ .ProjectName }}:v{{ .Version }}-arm64"
+      - "us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-arm64"
     goarch: arm64
     build_flag_templates:
       - --platform=linux/arm64
@@ -48,6 +49,7 @@ dockers:
     use: buildx
   - image_templates:
       - "ghcr.io/charmbracelet/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-amd64"
     goarch: amd64
     build_flag_templates:
       - --platform=linux/amd64
@@ -73,6 +75,10 @@ docker_manifests:
     image_templates:
       - "ghcr.io/charmbracelet/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "ghcr.io/charmbracelet/{{ .ProjectName }}:v{{ .Version }}-arm64"
+  - name_template: "us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:{{ .Commit }}{{ if .IsNightly }}-devel{{ end }}"
+    image_templates:
+      - "us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-arm64"
   - name_template: "{{ if .IsNightly }}ghcr.io/charmbracelet/{{ .ProjectName }}:nightly{{ end }}"
     image_templates:
       - "ghcr.io/charmbracelet/{{ .ProjectName }}:v{{ .Version }}-amd64"


### PR DESCRIPTION
On push to main, also push the catwalk image to Google Artifact Registry
(devel-416316/charm) in addition to ghcr.io. Enables the dev Cloud Run
migration to consume an auto-built `<sha>-devel` image.
- .goreleaser.yaml: dual-push arm64/amd64 to AR + AR docker_manifest
- .github/workflows/nightly.yml: enable `gcp_enabled` and pass WIF secrets
Depends on charmbracelet/meta#293 (merge that first).