### PR TITLE
Add SiliconFlow providers

### DIFF
--- a/internal/providers/configs/siliconflow-cn.json
+++ b/internal/providers/configs/siliconflow-cn.json
@@ -1,0 +1,32 @@
+{
+  "name": "SiliconFlow CN",
+  "id": "siliconflow-cn",
+  "type": "openai-compat",
+  "api_key": "$SILICONFLOW_CN_API_KEY",
+  "api_endpoint": "https://api.siliconflow.cn/v1",
+  "default_large_model_id": "Pro/zai-org/GLM-5.1",
+  "default_small_model_id": "Qwen/Qwen3.6-27B",
+  "models": [
+    {
+      "id": "Pro/zai-org/GLM-5.1",
+      "name": "GLM-5.1 (Pro)",
+      "cost_per_1m_in": 6,
+      "cost_per_1m_out": 24,
+      "cost_per_1m_in_cached": 1.3,
+      "context_window": 202752,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "Qwen/Qwen3.6-27B",
+      "name": "Qwen3.6-27B",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 4.8,
+      "context_window": 262144,
+      "default_max_tokens": 131072,
+      "can_reason": false,
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/configs/siliconflow.json
+++ b/internal/providers/configs/siliconflow.json
@@ -1,0 +1,32 @@
+{
+  "name": "SiliconFlow",
+  "id": "siliconflow",
+  "type": "openai-compat",
+  "api_key": "$SILICONFLOW_API_KEY",
+  "api_endpoint": "https://api.siliconflow.com/v1",
+  "default_large_model_id": "Pro/zai-org/GLM-5.1",
+  "default_small_model_id": "Qwen/Qwen3.6-27B",
+  "models": [
+    {
+      "id": "Pro/zai-org/GLM-5.1",
+      "name": "GLM-5.1",
+      "cost_per_1m_in": 1.4,
+      "cost_per_1m_out": 4.4,
+      "cost_per_1m_in_cached": 0.26,
+      "context_window": 202752,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "Qwen/Qwen3.6-27B",
+      "name": "Qwen3.6-27B",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 3.2,
+      "context_window": 262144,
+      "default_max_tokens": 131072,
+      "can_reason": false,
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -90,6 +90,12 @@ var qiniuCloudConfig []byte
 //go:embed configs/scaleway.json
 var scalewayConfig []byte
 
+//go:embed configs/siliconflow.json
+var siliconFlowConfig []byte
+
+//go:embed configs/siliconflow-cn.json
+var siliconFlowCNConfig []byte
+
 //go:embed configs/synthetic.json
 var syntheticConfig []byte
 
@@ -151,6 +157,8 @@ var providerRegistry = []ProviderFunc{
 	openRouterProvider,
 	qiniuCloudProvider,
 	scalewayProvider,
+	siliconFlowProvider,
+	siliconFlowCNProvider,
 	vercelProvider,
 	veniceProvider,
 	vertexAIProvider,
@@ -282,6 +290,14 @@ func qiniuCloudProvider() catwalk.Provider {
 
 func scalewayProvider() catwalk.Provider {
 	return loadProviderFromConfig(scalewayConfig)
+}
+
+func siliconFlowProvider() catwalk.Provider {
+	return loadProviderFromConfig(siliconFlowConfig)
+}
+
+func siliconFlowCNProvider() catwalk.Provider {
+	return loadProviderFromConfig(siliconFlowCNConfig)
 }
 
 func syntheticProvider() catwalk.Provider {

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -3,6 +3,8 @@ package providers
 import (
 	"slices"
 	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
 )
 
 func TestValidDefaultModels(t *testing.T) {
@@ -17,6 +19,62 @@ func TestValidDefaultModels(t *testing.T) {
 			}
 			if !slices.Contains(modelIds, p.DefaultSmallModelID) {
 				t.Errorf("Default small model %q not found in provider %q", p.DefaultSmallModelID, p.Name)
+			}
+		})
+	}
+}
+
+func TestSiliconFlowProvidersRegistered(t *testing.T) {
+	tests := []struct {
+		id          catwalk.InferenceProvider
+		name        string
+		apiEndpoint string
+	}{
+		{
+			id:          "siliconflow-cn",
+			name:        "SiliconFlow CN",
+			apiEndpoint: "https://api.siliconflow.cn/v1",
+		},
+		{
+			id:          "siliconflow",
+			name:        "SiliconFlow",
+			apiEndpoint: "https://api.siliconflow.com/v1",
+		},
+	}
+
+	providersByID := make(map[catwalk.InferenceProvider]catwalk.Provider)
+	for _, p := range GetAll() {
+		providersByID[p.ID] = p
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.id), func(t *testing.T) {
+			p, ok := providersByID[tt.id]
+			if !ok {
+				t.Fatalf("Provider %q was not registered", tt.id)
+			}
+			if p.Name != tt.name {
+				t.Fatalf("Provider name = %q, want %q", p.Name, tt.name)
+			}
+			if p.APIEndpoint != tt.apiEndpoint {
+				t.Fatalf("API endpoint = %q, want %q", p.APIEndpoint, tt.apiEndpoint)
+			}
+			if p.Type != catwalk.TypeOpenAICompat {
+				t.Fatalf("Provider type = %q, want %q", p.Type, catwalk.TypeOpenAICompat)
+			}
+			if len(p.Models) == 0 {
+				t.Fatal("Provider has no models")
+			}
+
+			modelIDs := make([]string, 0, len(p.Models))
+			for _, m := range p.Models {
+				modelIDs = append(modelIDs, m.ID)
+			}
+			if !slices.Contains(modelIDs, p.DefaultLargeModelID) {
+				t.Fatalf("Default large model %q not found", p.DefaultLargeModelID)
+			}
+			if !slices.Contains(modelIDs, p.DefaultSmallModelID) {
+				t.Fatalf("Default small model %q not found", p.DefaultSmallModelID)
 			}
 		})
 	}

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -55,6 +55,8 @@ const (
 	InferenceProviderOpenCodeZen      InferenceProvider = "opencode-zen"
 	InferenceProviderOpenCodeGo       InferenceProvider = "opencode-go"
 	InferenceProviderAlibabaSingapore InferenceProvider = "alibaba-singapore"
+	InferenceProviderSiliconFlow      InferenceProvider = "siliconflow"
+	InferenceProviderSiliconFlowCN    InferenceProvider = "siliconflow-cn"
 )
 
 // Provider represents an AI provider configuration.
@@ -131,6 +133,8 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderNeuralwatt,
 		InferenceProviderOpenCodeZen,
 		InferenceProviderOpenCodeGo,
+		InferenceProviderSiliconFlow,
+		InferenceProviderSiliconFlowCN,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add SiliconFlow CN and international SiliconFlow provider configs.
- Register both providers in the Catwalk embedded provider list.
- Add coverage to ensure both SiliconFlow providers are present, OpenAI-compatible, and have valid default models.

## Details

This adds two independent SiliconFlow API platforms:

- `siliconflow-cn`: `https://api.siliconflow.cn/v1`, API key `$SILICONFLOW_CN_API_KEY`
- `siliconflow`: `https://api.siliconflow.com/v1`, API key `$SILICONFLOW_API_KEY`

Both providers use OpenAI-compatible APIs and include current default model choices for large and small model slots.

## Test

```sh
go test ./internal/providers -run TestSiliconFlowProvidersRegistered -count=1
go test ./internal/providers -count=1
go test ./... -count=1
```

## Related

SiliconFlow task: https://github.com/siliconflow/siliconflow-open-source-tasks/issues/3