### PR TITLE
fix: only push to Artifact Registry on nightly builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,7 +35,7 @@ nightly:
 dockers:
   - image_templates:
       - "ghcr.io/charmbracelet/{{ .ProjectName }}:v{{ .Version }}-arm64"
-      - "us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-arm64"
+      - "{{ if .IsNightly }}us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-arm64{{ end }}"
     goarch: arm64
     build_flag_templates:
       - --platform=linux/arm64
@@ -49,7 +49,7 @@ dockers:
     use: buildx
   - image_templates:
       - "ghcr.io/charmbracelet/{{ .ProjectName }}:v{{ .Version }}-amd64"
-      - "us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "{{ if .IsNightly }}us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-amd64{{ end }}"
     goarch: amd64
     build_flag_templates:
       - --platform=linux/amd64
@@ -75,10 +75,10 @@ docker_manifests:
     image_templates:
       - "ghcr.io/charmbracelet/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "ghcr.io/charmbracelet/{{ .ProjectName }}:v{{ .Version }}-arm64"
-  - name_template: "us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:{{ .Commit }}{{ if .IsNightly }}-devel{{ end }}"
+  - name_template: "{{ if .IsNightly }}us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:{{ .Commit }}-devel{{ end }}"
     image_templates:
-      - "us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-amd64"
-      - "us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-arm64"
+      - "{{ if .IsNightly }}us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}us-east1-docker.pkg.dev/devel-416316/charm/{{ .ProjectName }}:v{{ .Version }}-arm64{{ end }}"
   - name_template: "{{ if .IsNightly }}ghcr.io/charmbracelet/{{ .ProjectName }}:nightly{{ end }}"
     image_templates:
       - "ghcr.io/charmbracelet/{{ .ProjectName }}:v{{ .Version }}-amd64"


### PR DESCRIPTION
Prod tag releases (deploy production / release.yml) were failing because
.goreleaser.yaml pushed arch images and a manifest to Artifact Registry
unconditionally, but the prod release workflow has no GCP auth (only the dev
nightly path does).
Gate all Artifact Registry image and manifest templates behind `.IsNightly`,
so:
- nightly/dev builds push to AR as before (used by Cloud Run on dev),
- prod tag releases push to ghcr.io only, restoring pre-migration behavior.
Fixes the v0.44.27 release failure.