### PR TITLE
fix(neuralwatt): expose full reasoning scale

### DIFF
--- a/cmd/neuralwatt/main.go
+++ b/cmd/neuralwatt/main.go
@@ -55,6 +55,13 @@ type ModelsResponse struct {
 	Data []NeuralwattModel `json:"data"`
 }
 
+// glm52Prefix matches GLM-5.2 and its aliases (e.g. glm-5.2-fast). Neuralwatt
+// only exposes reasoning effort levels for the GLM-5.2 family atm and accepts
+// the full scale but normalises intermediate values to three distinct
+// behaviours, so we expose only those. Other models, if added with reasoning
+// support in the future, fall back to a reasonable default scale.
+const glm52Prefix = "glm-5.2"
+
 func roundCost(v float64) float64 {
 	return math.Round(v*1e5) / 1e5
 }
@@ -152,9 +159,14 @@ func main() {
 
 		var reasoningLevels []string
 		var defaultReasoning string
-		if meta.Capabilities.ReasoningEffort {
-			reasoningLevels = []string{"minimal", "low", "medium", "high", "xhigh", "max"}
-			defaultReasoning = "high"
+		if meta.Capabilities.Reasoning && meta.Capabilities.ReasoningEffort {
+			if strings.HasPrefix(model.ID, glm52Prefix) {
+				reasoningLevels = []string{"minimal", "high", "xhigh"}
+				defaultReasoning = "xhigh"
+			} else {
+				reasoningLevels = []string{"low", "medium", "high"}
+				defaultReasoning = "medium"
+			}
 		}
 
 		name := meta.DisplayName

--- a/cmd/neuralwatt/main.go
+++ b/cmd/neuralwatt/main.go
@@ -55,13 +55,6 @@ type ModelsResponse struct {
 	Data []NeuralwattModel `json:"data"`
 }
 
-// glm52Prefix matches GLM-5.2 and its aliases (e.g. glm-5.2-fast). Neuralwatt
-// only exposes reasoning effort levels for the GLM-5.2 family atm and accepts
-// the full scale but normalises intermediate values to three distinct
-// behaviours, so we expose only those. Other models, if added with reasoning
-// support in the future, fall back to a reasonable default scale.
-const glm52Prefix = "glm-5.2"
-
 func roundCost(v float64) float64 {
 	return math.Round(v*1e5) / 1e5
 }
@@ -160,7 +153,7 @@ func main() {
 		var reasoningLevels []string
 		var defaultReasoning string
 		if meta.Capabilities.Reasoning && meta.Capabilities.ReasoningEffort {
-			if strings.HasPrefix(model.ID, glm52Prefix) {
+			if strings.HasPrefix(model.ID, "glm-5.2") {
 				reasoningLevels = []string{"minimal", "high", "xhigh"}
 				defaultReasoning = "xhigh"
 			} else {

--- a/cmd/neuralwatt/main.go
+++ b/cmd/neuralwatt/main.go
@@ -153,8 +153,8 @@ func main() {
 		var reasoningLevels []string
 		var defaultReasoning string
 		if meta.Capabilities.ReasoningEffort {
-			reasoningLevels = []string{"low", "medium", "high"}
-			defaultReasoning = "medium"
+			reasoningLevels = []string{"minimal", "low", "medium", "high", "xhigh", "max"}
+			defaultReasoning = "high"
 		}
 
 		name := meta.DisplayName

--- a/internal/providers/configs/neuralwatt.json
+++ b/internal/providers/configs/neuralwatt.json
@@ -18,11 +18,11 @@
       "default_max_tokens": 104856,
       "can_reason": true,
       "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
+        "minimal",
+        "high",
+        "xhigh"
       ],
-      "default_reasoning_effort": "medium",
+      "default_reasoning_effort": "xhigh",
       "supports_attachments": false
     },
     {
@@ -35,12 +35,6 @@
       "context_window": 1048560,
       "default_max_tokens": 104856,
       "can_reason": false,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_effort": "medium",
       "supports_attachments": false
     },
     {
@@ -54,11 +48,11 @@
       "default_max_tokens": 19998,
       "can_reason": true,
       "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
+        "minimal",
+        "high",
+        "xhigh"
       ],
-      "default_reasoning_effort": "medium",
+      "default_reasoning_effort": "xhigh",
       "supports_attachments": false
     },
     {
@@ -71,12 +65,6 @@
       "context_window": 199984,
       "default_max_tokens": 19998,
       "can_reason": false,
-      "reasoning_levels": [
-        "low",
-        "medium",
-        "high"
-      ],
-      "default_reasoning_effort": "medium",
       "supports_attachments": false
     },
     {


### PR DESCRIPTION
The generator hardcoded low/medium/high levels for reasoning-capable models, but Neuralwatt now supports all the levels and, when needed, normalizes intermediate values to the right level.

Requires merging https://github.com/charmbracelet/openai-go/pull/1 first, then updating and merging https://github.com/charmbracelet/fantasy/pull/285, so I'm opening this as a draft for now.
 
Assisted-by: Crush:glm-5.2
