### PR TITLE
feat(vertexai): add gemini-3.5-flash model

### DIFF
--- a/internal/providers/configs/vertexai.json
+++ b/internal/providers/configs/vertexai.json
@@ -8,6 +8,20 @@
   "default_small_model_id": "gemini-3-flash-preview",
   "models": [
     {
+      "id": "gemini-3.5-flash",
+      "name": "Gemini 3.5 Flash",
+      "cost_per_1m_in": 1.5,
+      "cost_per_1m_out": 9,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 1,
+      "context_window": 1048576,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "reasoning_levels": ["minimal", "low", "medium", "high"],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
       "id": "gemini-3.1-pro-preview",
       "name": "Gemini 3.1 Pro (Regular)",
       "cost_per_1m_in": 2,


### PR DESCRIPTION
This PR adds \`gemini-3.5-flash\` to the Vertex AI configuration. The model ID was sourced from the Google Cloud Vertex AI documentation, and the pricing/capabilities are copied to mirror the existing AI Studio config.