### PR TITLE
feat: add CheapestInference provider

### DIFF
--- a/internal/providers/configs/cheapestinference.json
+++ b/internal/providers/configs/cheapestinference.json
@@ -1,0 +1,85 @@
+{
+  "name": "CheapestInference",
+  "id": "cheapestinference",
+  "api_key": "$CHEAPESTINFERENCE_API_KEY",
+  "api_endpoint": "https://api.cheapestinference.com/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "kimi-k2.7",
+  "default_small_model_id": "deepseek-v4-flash",
+  "models": [
+    {
+      "id": "kimi-k2.7",
+      "name": "Kimi K2.7",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "kimi-k2.6",
+      "name": "Kimi K2.6",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "glm-5.2",
+      "name": "GLM 5.2",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 202752,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "reasoning_levels": ["high", "max"],
+      "default_reasoning_effort": "high",
+      "supports_attachments": false
+    },
+    {
+      "id": "minimax-m3",
+      "name": "MiniMax M3",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "name": "DeepSeek V4 Flash",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "mimo-v2.5",
+      "name": "MiMo v2.5",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -39,6 +39,9 @@ var bedrockEuropeConfig []byte
 //go:embed configs/cerebras.json
 var cerebrasConfig []byte
 
+//go:embed configs/cheapestinference.json
+var cheapestInferenceConfig []byte
+
 //go:embed configs/chutes.json
 var chutesConfig []byte
 
@@ -152,6 +155,7 @@ var providerRegistry = []ProviderFunc{
 	bedrockUnitedStatesProvider,
 	bedrockEuropeProvider,
 	cerebrasProvider,
+	cheapestInferenceProvider,
 	chutesProvider,
 	copilotProvider,
 	cortecsProvider,
@@ -230,6 +234,10 @@ func bedrockEuropeProvider() catwalk.Provider {
 
 func cerebrasProvider() catwalk.Provider {
 	return loadProviderFromConfig(cerebrasConfig)
+}
+
+func cheapestInferenceProvider() catwalk.Provider {
+	return loadProviderFromConfig(cheapestInferenceConfig)
 }
 
 func chutesProvider() catwalk.Provider {


### PR DESCRIPTION
Adds **CheapestInference** (https://cheapestinference.com) as an `openai-compat` provider.

It sells flat-monthly unlimited-token subscriptions (no per-token billing), so all `cost_per_1m_*` fields are `0` — users bring their own subscriber key via `$CHEAPESTINFERENCE_API_KEY`. Six open-weights models with the ids the API actually serves: `kimi-k2.7`, `kimi-k2.6`, `glm-5.2`, `minimax-m3`, `deepseek-v4-flash`, `mimo-v2.5` (context windows per the provider docs at https://docs.cheapestinference.com/getting-started/models/).

Wired into `providers.go` (embed + registry, alphabetical position). JSON validated; field names match `pkg/catwalk.Model`.