### PR TITLE
chore(kimi): add kimi-for-coding-highspeed

### DIFF
--- a/internal/providers/configs/kimi.json
+++ b/internal/providers/configs/kimi.json
@@ -18,6 +18,18 @@
       "default_max_tokens": 32768,
       "can_reason": true,
       "supports_attachments": true
+    },
+    {
+      "id": "kimi-for-coding-highspeed",
+      "name": "Kimi for Coding Highspeed",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
     }
   ]
 }


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## Description

Add `kimi-for-coding-highspeed` model to the Kimi Code (`kimi-coding`) provider.

This change adds the model entry so Crush users can select the Highspeed variant from the model list.

## Model information

- Provider: Kimi
- Model ID: `kimi-for-coding-highspeed`
- Display name: `Kimi For Coding Highspeed`

## References

- https://www.kimi.com/code/docs/en/#switch-model
- https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents

The model ID is documented by Kimi Code and can be configured directly in third-party coding agents. According to the documentation, the Highspeed variant provides the same coding capability as `kimi-for-coding` with improved response speed.