### PR TITLE
feat(moonshot): add kimi k3 model

### DIFF
--- a/internal/providers/configs/moonshot.json
+++ b/internal/providers/configs/moonshot.json
@@ -4,9 +4,21 @@
   "api_key": "$MOONSHOT_API_KEY",
   "api_endpoint": "https://api.moonshot.ai/v1",
   "type": "openai-compat",
-  "default_large_model_id": "kimi-k2.7-code",
-  "default_small_model_id": "kimi-k2.5",
+  "default_large_model_id": "kimi-k3",
+  "default_small_model_id": "kimi-k2.7-code",
   "models": [
+    {
+      "id": "kimi-k3",
+      "name": "Kimi K3",
+      "cost_per_1m_in": 3,
+      "cost_per_1m_out": 15,
+      "cost_per_1m_in_cached": 0.30,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": true
+    },
     {
       "id": "kimi-k2.7-code",
       "name": "Kimi K2.7 Code",


### PR DESCRIPTION
## Summary

Adds the new **Kimi K3** model to the Moonshot provider configuration:

- New `kimi-k3` model: 1M context window, 128K max output tokens, reasoning + attachments support, $3/M input, $15/M output ($0.30/M cached input)
- `kimi-k3` is now the default large model (previously `kimi-k2.7-code`)
- `kimi-k2.7-code` is now the default small model (previously `kimi-k2.5`)

## Changes

- `internal/providers/configs/moonshot.json`: add `kimi-k3` model entry, update `default_large_model_id` and `default_small_model_id`

---

Signed-off-by: GitHub Copilot <copilot@github.com>