### PR TITLE
feat(kenari): add new provider

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,6 +36,10 @@ jobs:
         run: go run ./cmd/avian/main.go
         continue-on-error: true
 
+      - name: Kenari
+        run: go run ./cmd/kenari/main.go
+        continue-on-error: true
+
       - name: Baseten
         run: go run ./cmd/baseten/main.go
         continue-on-error: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -66,6 +66,7 @@ tasks:
       - task: gen:cortecs
       - task: gen:huggingface
       - task: gen:ionet
+      - task: gen:kenari
       - task: gen:nebius
       - task: gen:neuralwatt
       - task: gen:opencode-go
@@ -120,6 +121,11 @@ tasks:
     desc: Generate io.net provider configurations
     cmds:
       - go run cmd/ionet/main.go
+
+  gen:kenari:
+    desc: Generate Kenari provider configurations
+    cmds:
+      - go run cmd/kenari/main.go
 
   gen:nebius:
     desc: Generate Nebius provider configurations

--- a/cmd/kenari/main.go
+++ b/cmd/kenari/main.go
@@ -1,0 +1,197 @@
+// Package main provides a command-line tool to fetch models from Kenari
+// and generate a configuration file for the provider.
+//
+// Kenari is an Indonesian LLM gateway that bills a prepaid IDR wallet
+// rather than per-token USD, so all cost fields are written as zero and
+// callers should not surface these numbers to end users.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+const (
+	apiEndpoint = "https://kenari.id/v1"
+	configPath  = "internal/providers/configs/kenari.json"
+)
+
+// Model mirrors the /v1/models response from kenari.id.
+type Model struct {
+	ID               string   `json:"id"`
+	Object           string   `json:"object"`
+	OwnedBy          string   `json:"owned_by"`
+	Endpoints        []string `json:"endpoints"`
+	ContextLength    *int64   `json:"context_length"`
+	Modalities       struct {
+		Input  []string `json:"input"`
+		Output []string `json:"output"`
+	} `json:"modalities"`
+	ToolCall         bool     `json:"tool_call"`
+	Reasoning        bool     `json:"reasoning"`
+	ReasoningToggle  bool     `json:"reasoning_toggle"`
+	ReasoningOptions []string `json:"reasoning_options"`
+	Pricing          struct {
+		Free      bool   `json:"free"`
+		Currency  string `json:"currency"`
+		Unit      string `json:"unit"`
+		Input     int64  `json:"input"`
+		Output    int64  `json:"output"`
+		CacheRead int64  `json:"cache_read"`
+	} `json:"pricing"`
+}
+
+// ModelsResponse is the top-level /v1/models response.
+type ModelsResponse struct {
+	Object string  `json:"object"`
+	Data   []Model `json:"data"`
+}
+
+func fetchModels(endpoint string) (*ModelsResponse, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, endpoint+"/models", nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Catwalk-Client/1.0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching models: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d from %s/models", resp.StatusCode, endpoint)
+	}
+
+	var out ModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &out, nil
+}
+
+func isFreeVariant(id string) bool {
+	return strings.HasSuffix(id, ":free")
+}
+
+// toCatwalkModel converts a Kenari API model into a catwalk.Model. Costs
+// are always zero because Kenari bills a prepaid IDR wallet; a USD
+// per-token figure would be invented and unstable.
+func toCatwalkModel(m Model) (catwalk.Model, bool) {
+	if m.ContextLength == nil {
+		return catwalk.Model{}, false
+	}
+	if m.Pricing.Free {
+		return catwalk.Model{}, false
+	}
+	if isFreeVariant(m.ID) {
+		return catwalk.Model{}, false
+	}
+	if !slices.Contains(m.Endpoints, "chat") {
+		return catwalk.Model{}, false
+	}
+	if !m.ToolCall {
+		return catwalk.Model{}, false
+	}
+
+	name := m.ID
+	// Catwalk uses Title-Case display names elsewhere; map dashes and
+	// capitalise. Owned-by is metadata we deliberately do not include
+	// (the original PR did not, and per the repo's "no backend names
+	// on customer surfaces" rule we keep it that way).
+	name = strings.ReplaceAll(name, "-", " ")
+	parts := strings.Fields(name)
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	name = strings.Join(parts, " ")
+
+	defaultMaxTokens := *m.ContextLength / 10
+	if defaultMaxTokens > 32768 {
+		defaultMaxTokens = 32768
+	}
+	if defaultMaxTokens < 1024 {
+		defaultMaxTokens = 1024
+	}
+
+	out := catwalk.Model{
+		ID:                 m.ID,
+		Name:               name,
+		CostPer1MIn:        0,
+		CostPer1MOut:       0,
+		CostPer1MInCached:  0,
+		CostPer1MOutCached: 0,
+		ContextWindow:      *m.ContextLength,
+		DefaultMaxTokens:   defaultMaxTokens,
+		CanReason:          m.Reasoning,
+		SupportsImages:     slices.Contains(m.Modalities.Input, "image"),
+	}
+
+	if m.Reasoning && len(m.ReasoningOptions) > 0 {
+		out.ReasoningLevels = m.ReasoningOptions
+		// Pick a middle option as the default effort. The midpoint of
+		// the list (rounded down) is the same convention the existing
+		// committed kenari.json used for the medium/low/high tiers.
+		out.DefaultReasoningEffort = m.ReasoningOptions[len(m.ReasoningOptions)/2]
+	}
+
+	return out, true
+}
+
+func main() {
+	provider := catwalk.Provider{
+		Name:                "Kenari",
+		ID:                  catwalk.InferenceProviderKenari,
+		APIKey:              "$KENARI_API_KEY",
+		APIEndpoint:         apiEndpoint,
+		Type:                catwalk.TypeOpenAICompat,
+		DefaultLargeModelID: "claude-sonnet-5",
+		DefaultSmallModelID: "deepseek-v4-flash",
+		Models:              []catwalk.Model{},
+	}
+
+	resp, err := fetchModels(apiEndpoint)
+	if err != nil {
+		log.Fatal("fetching kenari models: ", err)
+	}
+
+	for _, m := range resp.Data {
+		cm, ok := toCatwalkModel(m)
+		if !ok {
+			continue
+		}
+		provider.Models = append(provider.Models, cm)
+	}
+
+	slices.SortFunc(provider.Models, func(a, b catwalk.Model) int {
+		if a.Name == b.Name {
+			return strings.Compare(a.ID, b.ID)
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	data, err := json.MarshalIndent(provider, "", "  ")
+	if err != nil {
+		log.Fatal("marshaling provider: ", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		log.Fatal("writing config: ", err)
+	}
+
+	fmt.Printf("Generated %s with %d models\n", configPath, len(provider.Models))
+}

--- a/internal/providers/configs/kenari.json
+++ b/internal/providers/configs/kenari.json
@@ -1,0 +1,514 @@
+{
+  "name": "Kenari",
+  "id": "kenari",
+  "api_key": "$KENARI_API_KEY",
+  "api_endpoint": "https://kenari.id/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "claude-sonnet-5",
+  "default_small_model_id": "deepseek-v4-flash",
+  "models": [
+    {
+      "id": "claude-fable-5",
+      "name": "Claude Fable 5",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "claude-opus-4-7",
+      "name": "Claude Opus 4.7",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "claude-opus-4-8",
+      "name": "Claude Opus 4.8",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "claude-sonnet-5",
+      "name": "Claude Sonnet 5",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "name": "DeepSeek V4 Flash",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false,
+      "reasoning_levels": [
+        "high",
+        "xhigh"
+      ],
+      "default_reasoning_effort": "high"
+    },
+    {
+      "id": "deepseek-v4-pro",
+      "name": "DeepSeek V4 Pro",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false,
+      "reasoning_levels": [
+        "high",
+        "xhigh"
+      ],
+      "default_reasoning_effort": "high"
+    },
+    {
+      "id": "gemini-2-5-flash",
+      "name": "Gemini 2.5 Flash",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "gemini-2-5-flash-lite",
+      "name": "Gemini 2.5 Flash Lite",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "gemini-3-1-flash-lite",
+      "name": "Gemini 3.1 Flash Lite",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "minimal",
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "gemma-4-31b-it",
+      "name": "Gemma 4 31B IT",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "glm-5-1",
+      "name": "GLM-5.1",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 204800,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-5-2",
+      "name": "GLM-5.2",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false,
+      "reasoning_levels": [
+        "high",
+        "xhigh"
+      ],
+      "default_reasoning_effort": "high"
+    },
+    {
+      "id": "gpt-5-4-mini",
+      "name": "GPT-5.4 Mini",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 400000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "gpt-5-5",
+      "name": "GPT-5.5",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1050000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "gpt-5-6-luna",
+      "name": "GPT-5.6 Luna",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1050000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "gpt-5-6-sol",
+      "name": "GPT-5.6 Sol",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1050000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "gpt-5-6-terra",
+      "name": "GPT-5.6 Terra",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1050000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "gpt-oss-120b",
+      "name": "GPT-OSS 120B",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "gpt-oss-20b",
+      "name": "GPT-OSS 20B",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "grok-4-5",
+      "name": "Grok 4.5",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 500000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "grok-build-0-1",
+      "name": "Grok Build 0.1",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 256000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "kimi-k2-6",
+      "name": "Kimi K2.6",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "kimi-k2-7-code",
+      "name": "Kimi K2.7 Code",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "kimi-k3",
+      "name": "Kimi K3",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "high",
+        "max"
+      ],
+      "default_reasoning_effort": "low"
+    },
+    {
+      "id": "mimo-v2-5",
+      "name": "MiMo V2.5",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1050000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "mimo-v2-5-pro",
+      "name": "MiMo V2.5 Pro",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1050000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "minimax-m3",
+      "name": "MiniMax M3",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "nemotron-3-nano-30b-a3b",
+      "name": "Nemotron 3 Nano 30B A3B",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 256000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "nemotron-3-super-120b-a12b",
+      "name": "Nemotron 3 Super 120B A12B",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false,
+      "reasoning_levels": [
+        "low",
+        "medium"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "nemotron-3-ultra-550b-a55b",
+      "name": "Nemotron 3 Ultra 550B A55B",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false,
+      "reasoning_levels": [
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium"
+    },
+    {
+      "id": "qwen3-7-plus",
+      "name": "Qwen3.7 Plus",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/configs/kenari.json
+++ b/internal/providers/configs/kenari.json
@@ -17,7 +17,6 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "low",
         "medium",
@@ -25,11 +24,12 @@
         "xhigh",
         "max"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
     },
     {
       "id": "claude-opus-4-7",
-      "name": "Claude Opus 4.7",
+      "name": "Claude Opus 4 7",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -37,7 +37,6 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "low",
         "medium",
@@ -45,11 +44,12 @@
         "xhigh",
         "max"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
     },
     {
       "id": "claude-opus-4-8",
-      "name": "Claude Opus 4.8",
+      "name": "Claude Opus 4 8",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -57,7 +57,6 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "low",
         "medium",
@@ -65,7 +64,47 @@
         "xhigh",
         "max"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
+    },
+    {
+      "id": "claude-opus-5",
+      "name": "Claude Opus 5",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
+    },
+    {
+      "id": "claude-sonnet-4-6",
+      "name": "Claude Sonnet 4 6",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high",
+        "max"
+      ],
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
     },
     {
       "id": "claude-sonnet-5",
@@ -77,7 +116,6 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "low",
         "medium",
@@ -85,11 +123,12 @@
         "xhigh",
         "max"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
     },
     {
       "id": "deepseek-v4-flash",
-      "name": "DeepSeek V4 Flash",
+      "name": "Deepseek V4 Flash",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -97,16 +136,16 @@
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": false,
       "reasoning_levels": [
         "high",
         "xhigh"
       ],
-      "default_reasoning_effort": "high"
+      "default_reasoning_effort": "xhigh",
+      "supports_attachments": false
     },
     {
       "id": "deepseek-v4-pro",
-      "name": "DeepSeek V4 Pro",
+      "name": "Deepseek V4 Pro",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -114,16 +153,16 @@
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": false,
       "reasoning_levels": [
         "high",
         "xhigh"
       ],
-      "default_reasoning_effort": "high"
+      "default_reasoning_effort": "xhigh",
+      "supports_attachments": false
     },
     {
       "id": "gemini-2-5-flash",
-      "name": "Gemini 2.5 Flash",
+      "name": "Gemini 2 5 Flash",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -135,7 +174,7 @@
     },
     {
       "id": "gemini-2-5-flash-lite",
-      "name": "Gemini 2.5 Flash Lite",
+      "name": "Gemini 2 5 Flash Lite",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -147,7 +186,7 @@
     },
     {
       "id": "gemini-3-1-flash-lite",
-      "name": "Gemini 3.1 Flash Lite",
+      "name": "Gemini 3 1 Flash Lite",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -155,42 +194,18 @@
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "minimal",
         "low",
         "medium",
         "high"
       ],
-      "default_reasoning_effort": "medium"
-    },
-    {
-      "id": "gemma-4-31b-it",
-      "name": "Gemma 4 31B IT",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
-      "context_window": 262144,
-      "default_max_tokens": 32768,
-      "can_reason": true,
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
-      "id": "glm-5-1",
-      "name": "GLM-5.1",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
-      "context_window": 204800,
-      "default_max_tokens": 32768,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
-      "id": "glm-5-2",
-      "name": "GLM-5.2",
+      "id": "gemini-3-6-flash",
+      "name": "Gemini 3 6 Flash",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -198,24 +213,66 @@
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": false,
+      "reasoning_levels": [
+        "minimal",
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "gemma-4-31b-it",
+      "name": "Gemma 4 31b It",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 26214,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "glm-5-1",
+      "name": "Glm 5 1",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 204800,
+      "default_max_tokens": 20480,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-5-2",
+      "name": "Glm 5 2",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
       "reasoning_levels": [
         "high",
         "xhigh"
       ],
-      "default_reasoning_effort": "high"
+      "default_reasoning_effort": "xhigh",
+      "supports_attachments": false
     },
     {
       "id": "gpt-5-4-mini",
-      "name": "GPT-5.4 Mini",
+      "name": "Gpt 5 4 Mini",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
-      "context_window": 400000,
-      "default_max_tokens": 32768,
+      "context_window": 272000,
+      "default_max_tokens": 27200,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "none",
         "low",
@@ -223,19 +280,19 @@
         "high",
         "xhigh"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
     },
     {
       "id": "gpt-5-5",
-      "name": "GPT-5.5",
+      "name": "Gpt 5 5",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
-      "context_window": 1050000,
-      "default_max_tokens": 32768,
+      "context_window": 272000,
+      "default_max_tokens": 27200,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "none",
         "low",
@@ -243,19 +300,19 @@
         "high",
         "xhigh"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
     },
     {
       "id": "gpt-5-6-luna",
-      "name": "GPT-5.6 Luna",
+      "name": "Gpt 5 6 Luna",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
-      "context_window": 1050000,
+      "context_window": 365000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "none",
         "low",
@@ -264,19 +321,19 @@
         "xhigh",
         "max"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
     },
     {
       "id": "gpt-5-6-sol",
-      "name": "GPT-5.6 Sol",
+      "name": "Gpt 5 6 Sol",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
-      "context_window": 1050000,
+      "context_window": 365000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "none",
         "low",
@@ -285,19 +342,19 @@
         "xhigh",
         "max"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
     },
     {
       "id": "gpt-5-6-terra",
-      "name": "GPT-5.6 Terra",
+      "name": "Gpt 5 6 Terra",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
-      "context_window": 1050000,
+      "context_window": 365000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "none",
         "low",
@@ -306,47 +363,48 @@
         "xhigh",
         "max"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
     },
     {
       "id": "gpt-oss-120b",
-      "name": "GPT-OSS 120B",
+      "name": "Gpt Oss 120b",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
       "context_window": 131072,
-      "default_max_tokens": 32768,
+      "default_max_tokens": 13107,
       "can_reason": true,
-      "supports_attachments": false,
       "reasoning_levels": [
         "low",
         "medium",
         "high"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
     },
     {
       "id": "gpt-oss-20b",
-      "name": "GPT-OSS 20B",
+      "name": "Gpt Oss 20b",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
       "context_window": 131072,
-      "default_max_tokens": 32768,
+      "default_max_tokens": 13107,
       "can_reason": true,
-      "supports_attachments": false,
       "reasoning_levels": [
         "low",
         "medium",
         "high"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
     },
     {
       "id": "grok-4-5",
-      "name": "Grok 4.5",
+      "name": "Grok 4 5",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -354,47 +412,35 @@
       "context_window": 500000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "low",
         "medium",
         "high"
       ],
-      "default_reasoning_effort": "medium"
-    },
-    {
-      "id": "grok-build-0-1",
-      "name": "Grok Build 0.1",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
-      "context_window": 256000,
-      "default_max_tokens": 32768,
-      "can_reason": true,
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     },
     {
       "id": "kimi-k2-6",
-      "name": "Kimi K2.6",
+      "name": "Kimi K2 6",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
       "context_window": 262144,
-      "default_max_tokens": 32768,
+      "default_max_tokens": 26214,
       "can_reason": true,
       "supports_attachments": true
     },
     {
       "id": "kimi-k2-7-code",
-      "name": "Kimi K2.7 Code",
+      "name": "Kimi K2 7 Code",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
       "context_window": 262144,
-      "default_max_tokens": 32768,
+      "default_max_tokens": 26214,
       "can_reason": true,
       "supports_attachments": true
     },
@@ -408,17 +454,17 @@
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true,
       "reasoning_levels": [
         "low",
         "high",
         "max"
       ],
-      "default_reasoning_effort": "low"
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
     },
     {
       "id": "mimo-v2-5",
-      "name": "MiMo V2.5",
+      "name": "Mimo V2 5",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -430,7 +476,7 @@
     },
     {
       "id": "mimo-v2-5-pro",
-      "name": "MiMo V2.5 Pro",
+      "name": "Mimo V2 5 Pro",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -441,8 +487,20 @@
       "supports_attachments": false
     },
     {
+      "id": "minimax-m2-7",
+      "name": "Minimax M2 7",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 204800,
+      "default_max_tokens": 20480,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
       "id": "minimax-m3",
-      "name": "MiniMax M3",
+      "name": "Minimax M3",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -454,36 +512,36 @@
     },
     {
       "id": "nemotron-3-nano-30b-a3b",
-      "name": "Nemotron 3 Nano 30B A3B",
+      "name": "Nemotron 3 Nano 30b A3b",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
       "context_window": 256000,
-      "default_max_tokens": 32768,
+      "default_max_tokens": 25600,
       "can_reason": true,
       "supports_attachments": false
     },
     {
       "id": "nemotron-3-super-120b-a12b",
-      "name": "Nemotron 3 Super 120B A12B",
+      "name": "Nemotron 3 Super 120b A12b",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
       "cost_per_1m_out_cached": 0,
       "context_window": 262144,
-      "default_max_tokens": 32768,
+      "default_max_tokens": 26214,
       "can_reason": true,
-      "supports_attachments": false,
       "reasoning_levels": [
         "low",
         "medium"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
     },
     {
       "id": "nemotron-3-ultra-550b-a55b",
-      "name": "Nemotron 3 Ultra 550B A55B",
+      "name": "Nemotron 3 Ultra 550b A55b",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -491,16 +549,16 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": false,
       "reasoning_levels": [
         "medium",
         "high"
       ],
-      "default_reasoning_effort": "medium"
+      "default_reasoning_effort": "high",
+      "supports_attachments": false
     },
     {
-      "id": "qwen3-7-plus",
-      "name": "Qwen3.7 Plus",
+      "id": "qwen3-7-flash",
+      "name": "Qwen3 7 Flash",
       "cost_per_1m_in": 0,
       "cost_per_1m_out": 0,
       "cost_per_1m_in_cached": 0,
@@ -508,6 +566,56 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen3-7-plus",
+      "name": "Qwen3 7 Plus",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen3-8-max",
+      "name": "Qwen3 8 Max",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "step-3-7-flash",
+      "name": "Step 3 7 Flash",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 26214,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
       "supports_attachments": true
     }
   ]

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -69,6 +69,9 @@ var huggingFaceConfig []byte
 //go:embed configs/ionet.json
 var ioNetConfig []byte
 
+//go:embed configs/kenari.json
+var kenariConfig []byte
+
 //go:embed configs/kimi.json
 var kimiCodingConfig []byte
 
@@ -164,6 +167,7 @@ var providerRegistry = []ProviderFunc{
 	groqProvider,
 	huggingFaceProvider,
 	ioNetProvider,
+	kenariProvider,
 	nebiusProvider,
 	neuralwattProvider,
 	openCodeGoProvider,
@@ -274,6 +278,10 @@ func huggingFaceProvider() catwalk.Provider {
 
 func ioNetProvider() catwalk.Provider {
 	return loadProviderFromConfig(ioNetConfig)
+}
+
+func kenariProvider() catwalk.Provider {
+	return loadProviderFromConfig(kenariConfig)
 }
 
 func kimiCodingProvider() catwalk.Provider {

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -60,6 +60,7 @@ const (
 	InferenceProviderBaseten          InferenceProvider = "baseten"
 	InferenceProviderMoonshot         InferenceProvider = "moonshot"
 	InferenceProviderAtlasCloud       InferenceProvider = "atlascloud"
+	InferenceProviderKenari           InferenceProvider = "kenari"
 )
 
 // Provider represents an AI provider configuration.
@@ -140,6 +141,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderBaseten,
 		InferenceProviderMoonshot,
 		InferenceProviderAtlasCloud,
+		InferenceProviderKenari,
 	}
 }
 


### PR DESCRIPTION
## What

Adds [Kenari](https://kenari.id/), an Indonesian LLM gateway with an OpenAI-compatible API, as a provider.

- `internal/providers/configs/kenari.json`: 31 chat models (all support tool calling and streaming), generated from the live catalog at `GET https://kenari.id/v1/models` (public, no auth)
- Registered in `internal/providers/providers.go` (alphabetical slot)

## Details

- `type: openai-compat`, endpoint `https://kenari.id/v1`, key env `$KENARI_API_KEY`
- Costs are set to 0 like `copilot` and `kimi-coding`: Kenari bills a local-currency (IDR) wallet per token, so there is no stable USD per-token price to pin. Live pricing is on the models endpoint and https://kenari.id/models
- `context_window`, `can_reason`, `reasoning_levels`, and `supports_attachments` come from the same models endpoint
- Free-tier model variants (`:free` ids) are excluded, only the stable paid catalog is listed
- Defaults: `claude-sonnet-5` (large) / `deepseek-v4-flash` (small)

## Testing

- `go build ./...` and `go test ./...` pass (41 tests, 22 packages)
- `gofmt` clean

Docs: https://kenari.id/docs