### PR TITLE
Set the `supports_attachments` field true in minimax-m3 providers

### DIFF
--- a/internal/providers/configs/minimax.json
+++ b/internal/providers/configs/minimax.json
@@ -15,7 +15,8 @@
       "cost_per_1m_in_cached": 0.12,
       "cost_per_1m_out_cached": 0.375,
       "context_window": 1000000,
-      "default_max_tokens": 512000
+      "default_max_tokens": 512000,
+      "supports_attachments": true
     },
     {
       "id": "MiniMax-M2.7-highspeed",

--- a/internal/providers/configs/opencode-go.json
+++ b/internal/providers/configs/opencode-go.json
@@ -4,8 +4,8 @@
   "api_key": "$OPENCODE_API_KEY",
   "api_endpoint": "https://opencode.ai/zen/go/v1",
   "type": "openai-compat",
-  "default_large_model_id": "minimax-m2.7",
-  "default_small_model_id": "minimax-m2.7",
+  "default_large_model_id": "minimax-m3",
+  "default_small_model_id": "minimax-m3",
   "models": [
     {
       "id": "deepseek-v4-flash",
@@ -327,7 +327,7 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "supports_attachments": true
     },
     {
       "id": "qwen3.5-plus",


### PR DESCRIPTION
In the Opencode Go Provider, the minimax-m3 model is entered as not supporting image input, even though it supports it. 
This PR fixes that

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
