### PR TITLE
fix(basten): correct (override) Kimi K3 max token value

### DIFF
--- a/cmd/baseten/main.go
+++ b/cmd/baseten/main.go
@@ -156,6 +156,9 @@ func main() {
 		case "zai-org/GLM-5.2", "moonshotai/Kimi-K2.7-Code":
 			// Reasoning burns tokens fast on these models; cap output.
 			maxTokens = 32768
+		case "moonshotai/Kimi-K3":
+			// API advertises 1048576 but the chat endpoint rejects max_tokens above 262144.
+			maxTokens = 262144
 		}
 
 		m := catwalk.Model{

--- a/internal/providers/configs/baseten.json
+++ b/internal/providers/configs/baseten.json
@@ -136,7 +136,7 @@
       "cost_per_1m_in_cached": 0.3,
       "cost_per_1m_out_cached": 0,
       "context_window": 1048576,
-      "default_max_tokens": 1048576,
+      "default_max_tokens": 262144,
       "can_reason": true,
       "reasoning_levels": [
         "low",


### PR DESCRIPTION
This corrects the max tokens for the Kimi K3 endpoint. The /models endpoint advertises `1048576`, but the correct value (as reported in the server's error messages) is `262144`. I've confirmed this works locally.