### PR TITLE
feat: add The Grid provider

### DIFF
--- a/internal/providers/configs/thegrid.json
+++ b/internal/providers/configs/thegrid.json
@@ -1,0 +1,119 @@
+{
+  "name": "The Grid",
+  "id": "thegrid",
+  "api_key": "$THEGRID_API_KEY",
+  "api_endpoint": "https://api.thegrid.ai/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "agent-max",
+  "default_small_model_id": "text-standard",
+  "models": [
+    {
+      "id": "agent-max",
+      "name": "Agent Max",
+      "context_window": 1000000,
+      "default_max_tokens": 128000,
+      "cost_per_1m_in": 1.5885,
+      "cost_per_1m_out": 1.5885,
+      "cost_per_1m_in_cached": 1.5885,
+      "cost_per_1m_out_cached": 1.5885,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "agent-prime",
+      "name": "Agent Prime",
+      "context_window": 196608,
+      "default_max_tokens": 30000,
+      "cost_per_1m_in": 0.1422,
+      "cost_per_1m_out": 0.1422,
+      "cost_per_1m_in_cached": 0.1422,
+      "cost_per_1m_out_cached": 0.1422,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "agent-standard",
+      "name": "Agent Standard",
+      "context_window": 128000,
+      "default_max_tokens": 16000,
+      "cost_per_1m_in": 0.02,
+      "cost_per_1m_out": 0.02,
+      "cost_per_1m_in_cached": 0.02,
+      "cost_per_1m_out_cached": 0.02,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "code-max",
+      "name": "Code Max",
+      "context_window": 1000000,
+      "default_max_tokens": 128000,
+      "cost_per_1m_in": 1.7553,
+      "cost_per_1m_out": 1.7553,
+      "cost_per_1m_in_cached": 1.7553,
+      "cost_per_1m_out_cached": 1.7553,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "code-prime",
+      "name": "Code Prime",
+      "context_window": 196608,
+      "default_max_tokens": 30000,
+      "cost_per_1m_in": 0.1493,
+      "cost_per_1m_out": 0.1493,
+      "cost_per_1m_in_cached": 0.1493,
+      "cost_per_1m_out_cached": 0.1493,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "code-standard",
+      "name": "Code Standard",
+      "context_window": 128000,
+      "default_max_tokens": 16000,
+      "cost_per_1m_in": 0.0288,
+      "cost_per_1m_out": 0.0288,
+      "cost_per_1m_in_cached": 0.0288,
+      "cost_per_1m_out_cached": 0.0288,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "text-max",
+      "name": "Text Max",
+      "context_window": 1000000,
+      "default_max_tokens": 128000,
+      "cost_per_1m_in": 1.68,
+      "cost_per_1m_out": 1.68,
+      "cost_per_1m_in_cached": 1.68,
+      "cost_per_1m_out_cached": 1.68,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "text-prime",
+      "name": "Text Prime",
+      "context_window": 196608,
+      "default_max_tokens": 30000,
+      "cost_per_1m_in": 0.1017,
+      "cost_per_1m_out": 0.1017,
+      "cost_per_1m_in_cached": 0.1017,
+      "cost_per_1m_out_cached": 0.1017,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "text-standard",
+      "name": "Text Standard",
+      "context_window": 128000,
+      "default_max_tokens": 16000,
+      "cost_per_1m_in": 0.03,
+      "cost_per_1m_out": 0.03,
+      "cost_per_1m_in_cached": 0.03,
+      "cost_per_1m_out_cached": 0.03,
+      "can_reason": true,
+      "supports_attachments": false
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -108,6 +108,9 @@ var scalewayConfig []byte
 //go:embed configs/synthetic.json
 var syntheticConfig []byte
 
+//go:embed configs/thegrid.json
+var theGridConfig []byte
+
 //go:embed configs/vercel.json
 var vercelConfig []byte
 
@@ -171,6 +174,7 @@ var providerRegistry = []ProviderFunc{
 	openRouterProvider,
 	qiniuCloudProvider,
 	scalewayProvider,
+	theGridProvider,
 	vercelProvider,
 	veniceProvider,
 	vertexAIProvider,
@@ -326,6 +330,10 @@ func scalewayProvider() catwalk.Provider {
 
 func syntheticProvider() catwalk.Provider {
 	return loadProviderFromConfig(syntheticConfig)
+}
+
+func theGridProvider() catwalk.Provider {
+	return loadProviderFromConfig(theGridConfig)
 }
 
 func vercelProvider() catwalk.Provider {

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -60,6 +60,7 @@ const (
 	InferenceProviderBaseten          InferenceProvider = "baseten"
 	InferenceProviderMoonshot         InferenceProvider = "moonshot"
 	InferenceProviderAtlasCloud       InferenceProvider = "atlascloud"
+	InferenceProviderTheGrid          InferenceProvider = "thegrid"
 )
 
 // Provider represents an AI provider configuration.
@@ -140,6 +141,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderBaseten,
 		InferenceProviderMoonshot,
 		InferenceProviderAtlasCloud,
+		InferenceProviderTheGrid,
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds The Grid as an OpenAI-compatible provider with 9 models: `internal/providers/configs/thegrid.json`, its registration in `internal/providers/providers.go`, and the `InferenceProvider` constant in `pkg/catwalk/provider.go` — the same three-file shape as #373.

The Grid is an OpenAI-compatible inference platform ([docs](https://docs.thegrid.ai), API base `https://api.thegrid.ai/v1`). These records are generated from the same source of truth that drives our live `/v1/models` endpoint, so the values in this PR match what the API enforces.

## How these values are derived

Grid models differ from single-model providers in ways that affect the values here:

- Each model id routes across a pool of underlying models rather than naming one. Published limits are the **guaranteed floor** across that pool — the minimum every pooled model accepts — so requests within the published limits never fail on limit grounds.
- The max input limit is a real, independently enforced cap. It is **not** derivable as `context − max output`.
- Pricing is uniform across token types: input, output, and cached tokens bill at the same rate, so `cost_per_1m_in`, `cost_per_1m_out`, and both cached figures are equal by design rather than by omission. The published figure is the trailing 7-day volume-weighted average of the live spot price; we refresh it whenever we update these records.
- `type` is `openai-compat` and `api_key` is `$THEGRID_API_KEY`, matching how the other third-party OpenAI-compatible providers in `configs/` declare themselves.
- `supports_attachments` is true only on the `*-max` tier, which is what `architecture.input_modalities` reports in our catalog; the prime and standard tiers are text-only.

## Models

| model | context | max input | max output | USD / 1M tokens (in = out) |
| --- | ---: | ---: | ---: | ---: |
| `agent-max` | 1,000,000 | 922,000 | 128,000 | 1.5885 |
| `agent-prime` | 196,608 | 120,000 | 30,000 | 0.1422 |
| `agent-standard` | 128,000 | 120,000 | 16,000 | 0.02 |
| `code-max` | 1,000,000 | 922,000 | 128,000 | 1.7553 |
| `code-prime` | 196,608 | 120,000 | 30,000 | 0.1493 |
| `code-standard` | 128,000 | 120,000 | 16,000 | 0.0288 |
| `text-max` | 1,000,000 | 922,000 | 128,000 | 1.68 |
| `text-prime` | 196,608 | 120,000 | 30,000 | 0.1017 |
| `text-standard` | 128,000 | 120,000 | 16,000 | 0.03 |

`default_large_model_id` is `agent-max` and `default_small_model_id` is `text-standard`.

## Verification

- `go build ./...`, `go vet ./...`, and `go test ./...` all pass on this branch (Go 1.26), and `gofmt -l ./internal ./pkg` is clean.
- `TestValidDefaultModels/The_Grid` passes both default model ids resolve within the models array.
- Confirmed the embedded config decodes into `catwalk.Provider` with every field populated (no JSON key silently missing a struct tag): `type=openai-compat`, `endpoint=https://api.thegrid.ai/v1`, `key=$THEGRID_API_KEY`, 9 models with limits, prices, and capability flags all set.
- Live values are checkable without auth: `curl -sS https://api.thegrid.ai/v1/models`.

These entries are maintained by an automated generator with daily reconciliation against the published registry, so drift is caught and corrected promptly. Happy to add a `cmd/thegrid` generator and wire it into the auto-update workflow (the #463 shape) if you'd prefer these refreshed automatically rather than by PR.
