### PR TITLE
provider: add GreenPT

### DIFF
--- a/internal/providers/configs/greenpt.json
+++ b/internal/providers/configs/greenpt.json
@@ -1,0 +1,47 @@
+{
+  "name": "GreenPT",
+  "id": "greenpt",
+  "api_key": "$GREENPT_API_KEY",
+  "api_endpoint": "https://api.greenpt.ai/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "glm-5.2",
+  "default_small_model_id": "kimi-k2.7-code",
+  "models": [
+    {
+      "id": "glm-5.2",
+      "name": "GLM-5.2",
+      "cost_per_1m_in": 1.254,
+      "cost_per_1m_out": 5.016,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.3135,
+      "context_window": 1000000,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "kimi-k2.7-code",
+      "name": "Kimi K2.7 Code",
+      "cost_per_1m_in": 0.941,
+      "cost_per_1m_out": 4.389,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.1881,
+      "context_window": 262144,
+      "default_max_tokens": 262144,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "kimi-k3",
+      "name": "Kimi K3",
+      "cost_per_1m_in": 3.762,
+      "cost_per_1m_out": 18.81,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.9405,
+      "context_window": 1000000,
+      "default_max_tokens": 100000,
+      "can_reason": true,
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -63,6 +63,9 @@ var geminiConfig []byte
 //go:embed configs/groq.json
 var groqConfig []byte
 
+//go:embed configs/greenpt.json
+var greenPTConfig []byte
+
 //go:embed configs/huggingface.json
 var huggingFaceConfig []byte
 
@@ -161,6 +164,7 @@ var providerRegistry = []ProviderFunc{
 	cortecsProvider,
 	deepSeekProvider,
 	fireworksProvider,
+	greenPTProvider,
 	groqProvider,
 	huggingFaceProvider,
 	ioNetProvider,
@@ -266,6 +270,10 @@ func geminiProvider() catwalk.Provider {
 
 func groqProvider() catwalk.Provider {
 	return loadProviderFromConfig(groqConfig)
+}
+
+func greenPTProvider() catwalk.Provider {
+	return loadProviderFromConfig(greenPTConfig)
 }
 
 func huggingFaceProvider() catwalk.Provider {

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -3,6 +3,8 @@ package providers
 import (
 	"slices"
 	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
 )
 
 func TestValidDefaultModels(t *testing.T) {
@@ -19,5 +21,25 @@ func TestValidDefaultModels(t *testing.T) {
 				t.Errorf("Default small model %q not found in provider %q", p.DefaultSmallModelID, p.Name)
 			}
 		})
+	}
+}
+
+func TestGreenPTProvider(t *testing.T) {
+	providers := GetAll()
+	idx := slices.IndexFunc(providers, func(p catwalk.Provider) bool {
+		return p.ID == catwalk.InferenceProviderGreenPT
+	})
+	if idx == -1 {
+		t.Fatal("GreenPT provider is not registered")
+	}
+
+	provider := providers[idx]
+	if provider.APIEndpoint != "https://api.greenpt.ai/v1" {
+		t.Errorf("unexpected GreenPT endpoint %q", provider.APIEndpoint)
+	}
+	for _, id := range []string{"glm-5.2", "kimi-k2.7-code", "kimi-k3"} {
+		if !slices.ContainsFunc(provider.Models, func(m catwalk.Model) bool { return m.ID == id }) {
+			t.Errorf("GreenPT model %q is not registered", id)
+		}
 	}
 }

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -25,6 +25,7 @@ const (
 	InferenceProviderAnthropic        InferenceProvider = "anthropic"
 	InferenceProviderSynthetic        InferenceProvider = "synthetic"
 	InferenceProviderGemini           InferenceProvider = "gemini"
+	InferenceProviderGreenPT          InferenceProvider = "greenpt"
 	InferenceProviderAzure            InferenceProvider = "azure"
 	InferenceProviderBedrock          InferenceProvider = "bedrock"
 	InferenceProviderBedrockEurope    InferenceProvider = "bedrock-europe"
@@ -109,6 +110,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderSynthetic,
 		InferenceProviderAnthropic,
 		InferenceProviderGemini,
+		InferenceProviderGreenPT,
 		InferenceProviderAzure,
 		InferenceProviderBedrock,
 		InferenceProviderBedrockEurope,


### PR DESCRIPTION
GreenPT is a European AI provider offering an OpenAI-compatible API from
optimized infrastructure in data centers powered by 100% renewable energy.

This adds GreenPT to Catwalk, the provider catalog consumed by Crush. It is a
functional provider integration:

- `GREENPT_API_KEY` credential discovery
- the fixed `https://api.greenpt.ai/v1` endpoint
- `glm-5.2` as the default large model
- `kimi-k2.7-code` as the default small model
- `kimi-k3` with multimodal input support
- context, output-limit, reasoning, attachment, caching, and pricing metadata

The scope stays within Catwalk and Crush's language-model contract, so GreenPT
embeddings, reranking, and speech-to-text are intentionally omitted.

Validation:

- `go test ./...`
- `git diff --check`
