### PR TITLE
feat: add Infersia provider

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -58,6 +58,10 @@ jobs:
         run: go run ./cmd/huggingface/main.go
         continue-on-error: true
 
+      - name: Infersia
+        run: go run ./cmd/infersia/main.go
+        continue-on-error: true
+
       - name: io.net
         run: go run ./cmd/ionet/main.go
         continue-on-error: true

--- a/cmd/infersia/main.go
+++ b/cmd/infersia/main.go
@@ -40,7 +40,8 @@ type Pricing struct {
 
 // Architecture describes the modalities a model accepts.
 type Architecture struct {
-	InputModalities []string `json:"input_modalities"`
+	InputModalities  []string `json:"input_modalities"`
+	OutputModalities []string `json:"output_modalities"`
 }
 
 // ModelsResponse is the response structure for the Infersia models API.
@@ -128,6 +129,14 @@ func main() {
 		// The ":free" variants are rate-limited rather than differently
 		// capable, and listing both would show the same model twice.
 		if strings.HasSuffix(model.ID, ":free") {
+			continue
+		}
+
+		// Crush sends chat completions, so only models that return text
+		// belong in this list. The catalogue also carries rerankers, which
+		// answer a different endpoint entirely — listing one here would put
+		// a model in the picker that returns 404 to everything Crush sends.
+		if !slices.Contains(model.Architecture.OutputModalities, "text") {
 			continue
 		}
 

--- a/cmd/infersia/main.go
+++ b/cmd/infersia/main.go
@@ -1,0 +1,173 @@
+// Package main provides a command-line tool to fetch models from Infersia
+// and generate a configuration file for the provider.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+// Model represents a model from the Infersia API. The feed is
+// OpenRouter-shaped, so per-token prices arrive as strings.
+type Model struct {
+	ID                  string       `json:"id"`
+	Name                string       `json:"name"`
+	ContextLength       int64        `json:"context_length"`
+	MaxCompletionTokens int64        `json:"max_completion_tokens"`
+	Pricing             Pricing      `json:"pricing"`
+	Architecture        Architecture `json:"architecture"`
+	SupportedParameters []string     `json:"supported_parameters"`
+}
+
+// Pricing contains per-token prices as decimal strings.
+type Pricing struct {
+	Prompt         string `json:"prompt"`
+	Completion     string `json:"completion"`
+	InputCacheRead string `json:"input_cache_read"`
+}
+
+// Architecture describes the modalities a model accepts.
+type Architecture struct {
+	InputModalities []string `json:"input_modalities"`
+}
+
+// ModelsResponse is the response structure for the Infersia models API.
+type ModelsResponse struct {
+	Data []Model `json:"data"`
+}
+
+// reasoningLevels holds the effort values that were measured to change
+// behaviour on a given model. Infersia's /v1/models advertises that
+// reasoning_effort is accepted but not which values are meaningful, and
+// several models accept the full OpenAI set while treating most of it as
+// inert. Listing only the levels that do something keeps Crush from
+// offering a choice that has no effect.
+var reasoningLevels = map[string][]string{
+	"deepseek/deepseek-v4-flash-0731": {"none", "max"},
+}
+
+// defaultReasoningEffort is the level a model starts at. DeepSeek V4 Flash
+// ships with thinking disabled, so "none" matches the endpoint's own default
+// rather than opting every Crush user into slower, costlier responses.
+var defaultReasoningEffort = map[string]string{
+	"deepseek/deepseek-v4-flash-0731": "none",
+}
+
+func fetchInfersiaModels() (*ModelsResponse, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, _ := http.NewRequestWithContext(
+		context.Background(),
+		"GET",
+		"https://api.infersia.com/v1/models",
+		nil,
+	)
+	req.Header.Set("User-Agent", "Crush-Client/1.0")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err //nolint:wrapcheck
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, body)
+	}
+	var mr ModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&mr); err != nil {
+		return nil, err //nolint:wrapcheck
+	}
+	return &mr, nil
+}
+
+// perMillion converts a per-token price string to dollars per million tokens.
+// An unparseable or absent price yields 0 rather than failing the run, which
+// matches how the other generators treat missing fields.
+//
+// The result is rounded to six decimal places purely to strip binary
+// floating-point residue: 0.00000005 * 1e6 is 0.049999999999999996, which
+// serialises verbatim and reads as noise. Six places is deliberate — the
+// cheapest cached-input rate here is $0.006/M and rounding to two would
+// report $0.05/M as $0.05 but $0.035/M as $0.04, a 14% overstatement.
+func perMillion(price string) float64 {
+	v, err := strconv.ParseFloat(strings.TrimSpace(price), 64)
+	if err != nil {
+		return 0
+	}
+	return math.Round(v*1_000_000*1e6) / 1e6
+}
+
+func main() {
+	modelsResp, err := fetchInfersiaModels()
+	if err != nil {
+		log.Fatal("Error fetching Infersia models:", err)
+	}
+
+	infersiaProvider := catwalk.Provider{
+		Name:                "Infersia",
+		ID:                  catwalk.InferenceProviderInfersia,
+		APIKey:              "$INFERSIA_API_KEY",
+		APIEndpoint:         "https://api.infersia.com/v1",
+		Type:                catwalk.TypeOpenAICompat,
+		DefaultLargeModelID: "deepseek/deepseek-v4-flash-0731",
+		DefaultSmallModelID: "qwen/qwen3-8b",
+		Models:              []catwalk.Model{},
+	}
+
+	for _, model := range modelsResp.Data {
+		// The ":free" variants are rate-limited rather than differently
+		// capable, and listing both would show the same model twice.
+		if strings.HasSuffix(model.ID, ":free") {
+			continue
+		}
+
+		canReason := slices.Contains(model.SupportedParameters, "reasoning_effort")
+
+		m := catwalk.Model{
+			ID:                     model.ID,
+			Name:                   model.Name,
+			CostPer1MIn:            perMillion(model.Pricing.Prompt),
+			CostPer1MOut:           perMillion(model.Pricing.Completion),
+			CostPer1MInCached:      perMillion(model.Pricing.InputCacheRead),
+			CostPer1MOutCached:     0,
+			ContextWindow:          model.ContextLength,
+			DefaultMaxTokens:       model.MaxCompletionTokens,
+			CanReason:              canReason,
+			ReasoningLevels:        reasoningLevels[model.ID],
+			DefaultReasoningEffort: defaultReasoningEffort[model.ID],
+			SupportsImages:         slices.Contains(model.Architecture.InputModalities, "image"),
+		}
+
+		infersiaProvider.Models = append(infersiaProvider.Models, m)
+	}
+
+	slices.SortFunc(infersiaProvider.Models, func(a, b catwalk.Model) int {
+		if a.Name == b.Name {
+			return strings.Compare(a.ID, b.ID)
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	// Save the JSON in internal/providers/configs/infersia.json
+	data, err := json.MarshalIndent(infersiaProvider, "", "  ")
+	if err != nil {
+		log.Fatal("Error marshaling Infersia provider:", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile("internal/providers/configs/infersia.json", data, 0o600); err != nil {
+		log.Fatal("Error writing Infersia provider config:", err)
+	}
+
+	fmt.Printf("Generated infersia.json with %d models\n", len(infersiaProvider.Models))
+}

--- a/cmd/infersia/main.go
+++ b/cmd/infersia/main.go
@@ -132,11 +132,22 @@ func main() {
 			continue
 		}
 
-		// Crush sends chat completions, so only models that return text
-		// belong in this list. The catalogue also carries rerankers, which
-		// answer a different endpoint entirely — listing one here would put
-		// a model in the picker that returns 404 to everything Crush sends.
-		if !slices.Contains(model.Architecture.OutputModalities, "text") {
+		// Crush sends chat completions, so a model belongs in this list only
+		// if it takes text in AND returns text out. Both sides are load-bearing.
+		//
+		// Testing the output alone was not enough. It correctly rejected the
+		// rerankers this filter was written for, but speech-to-text is
+		// audio->text: its output modality IS text, so it passed, and Crush
+		// would have listed a transcription model, sent it a chat completion
+		// and got a 404 — with a context window of 448, which is a decoder-token
+		// ceiling for one 30-second audio chunk and has nothing to do with a
+		// prompt.
+		//
+		// A two-sided test rather than a skip-list of known-bad modalities: a
+		// skip-list is what let this through, and it fails open on whatever
+		// modality comes next.
+		if !slices.Contains(model.Architecture.InputModalities, "text") ||
+			!slices.Contains(model.Architecture.OutputModalities, "text") {
 			continue
 		}
 

--- a/internal/providers/configs/infersia.json
+++ b/internal/providers/configs/infersia.json
@@ -59,18 +59,6 @@
       "default_max_tokens": 32768,
       "can_reason": false,
       "supports_attachments": true
-    },
-    {
-      "id": "stepfun-ai/step-3.7-flash",
-      "name": "Step 3.7 Flash",
-      "cost_per_1m_in": 0.18,
-      "cost_per_1m_out": 1.05,
-      "cost_per_1m_in_cached": 0.036,
-      "cost_per_1m_out_cached": 0,
-      "context_window": 262144,
-      "default_max_tokens": 32768,
-      "can_reason": false,
-      "supports_attachments": true
     }
   ]
 }

--- a/internal/providers/configs/infersia.json
+++ b/internal/providers/configs/infersia.json
@@ -10,9 +10,9 @@
     {
       "id": "deepseek/deepseek-v4-flash-0731",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.02,
-      "cost_per_1m_out": 0.04,
-      "cost_per_1m_in_cached": 0.006,
+      "cost_per_1m_in": 0.1,
+      "cost_per_1m_out": 0.2,
+      "cost_per_1m_in_cached": 0.02,
       "cost_per_1m_out_cached": 0,
       "context_window": 1048576,
       "default_max_tokens": 32768,

--- a/internal/providers/configs/infersia.json
+++ b/internal/providers/configs/infersia.json
@@ -1,0 +1,76 @@
+{
+  "name": "Infersia",
+  "id": "infersia",
+  "api_key": "$INFERSIA_API_KEY",
+  "api_endpoint": "https://api.infersia.com/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "deepseek/deepseek-v4-flash-0731",
+  "default_small_model_id": "qwen/qwen3-8b",
+  "models": [
+    {
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "name": "DeepSeek V4 Flash",
+      "cost_per_1m_in": 0.02,
+      "cost_per_1m_out": 0.04,
+      "cost_per_1m_in_cached": 0.006,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "none",
+        "max"
+      ],
+      "default_reasoning_effort": "none",
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-14b",
+      "name": "Qwen3 14B",
+      "cost_per_1m_in": 0.09,
+      "cost_per_1m_out": 0.22,
+      "cost_per_1m_in_cached": 0.0225,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 131072,
+      "default_max_tokens": 16384,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3-8b",
+      "name": "Qwen3 8B",
+      "cost_per_1m_in": 0.05,
+      "cost_per_1m_out": 0.15,
+      "cost_per_1m_in_cached": 0.0125,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 40960,
+      "default_max_tokens": 8192,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "qwen/qwen3.6-35b-a3b",
+      "name": "Qwen3.6 35B A3B",
+      "cost_per_1m_in": 0.1,
+      "cost_per_1m_out": 0.9,
+      "cost_per_1m_in_cached": 0.025,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "stepfun-ai/step-3.7-flash",
+      "name": "Step 3.7 Flash",
+      "cost_per_1m_in": 0.18,
+      "cost_per_1m_out": 1.05,
+      "cost_per_1m_in_cached": 0.036,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": false,
+      "supports_attachments": true
+    }
+  ]
+}

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -50,6 +50,7 @@ const (
 	InferenceProviderIoNet            InferenceProvider = "ionet"
 	InferenceProviderQiniuCloud       InferenceProvider = "qiniucloud"
 	InferenceProviderAvian            InferenceProvider = "avian"
+	InferenceProviderInfersia         InferenceProvider = "infersia"
 	InferenceProviderNebius           InferenceProvider = "nebius"
 	InferenceProviderNeuralwatt       InferenceProvider = "neuralwatt"
 	InferenceProviderOpenCodeZen      InferenceProvider = "opencode-zen"
@@ -132,6 +133,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderMiniMaxChina,
 		InferenceProviderQiniuCloud,
 		InferenceProviderAvian,
+		InferenceProviderInfersia,
 		InferenceProviderNebius,
 		InferenceProviderNeuralwatt,
 		InferenceProviderOpenCodeZen,


### PR DESCRIPTION
Adds [Infersia](https://infersia.com) as a provider, with a generator so it stays current on the six-hourly schedule rather than being a static config.

Infersia serves open-weight models (DeepSeek, Qwen, StepFun) over an OpenAI-compatible API. Two things that may be relevant to Crush users:

- **Full context windows.** DeepSeek V4 Flash is served at its complete 1,048,576 tokens rather than a truncated slice. For a coding agent the context ceiling tends to be the first wall you hit, and it arrives as a hard error rather than a slowdown.
- **Published quantisation.** Every endpoint states the precision it is served at, so a model that behaves differently from elsewhere has a visible reason.

## Changes

| File | |
|---|---|
| `cmd/infersia/main.go` | Generator, modelled on `cmd/avian` |
| `internal/providers/configs/infersia.json` | Generated by running the above — not hand-written |
| `pkg/catwalk/provider.go` | `InferenceProviderInfersia` + `KnownProviders` |
| `.github/workflows/update.yml` | Adds the step, alphabetically before io.net |

## Why a generator rather than a static config

A launch discount is running on our side until 10 August. A hand-written config would have advertised promotional pricing indefinitely after it expired — wrong in the direction that wastes your users' trust rather than ours. The generator reads the public `/v1/models` feed, so the six-hourly job corrects it without anyone remembering to.

The feed needs **no API key** — `curl https://api.infersia.com/v1/models` returns the full catalogue anonymously — so the workflow step runs unattended like the others.

## Notes on two fields

**`reasoning_levels`** comes from a small explicit map rather than being inferred. Our feed advertises that `reasoning_effort` is accepted but not which values are meaningful, and DeepSeek V4 Flash accepts the full OpenAI set while only `none` and `max` actually change behaviour — measured against the live endpoint, not read off a spec sheet. Listing `low`/`medium`/`high` would offer a choice that does nothing. `default_reasoning_effort` is `none` because that is the endpoint's own default; defaulting to thinking would make every Crush session slower and dearer than the user asked for.

**`:free` variants are skipped.** `qwen/qwen3-8b:free` is the same model as `qwen/qwen3-8b` under a daily token cap, so listing both would show a duplicate with a misleading $0 price.

## Testing

Run against the current toolchain from `mise.toml`:

- `go build ./...`, `go vet ./...`, `go test ./...` — pass
- `golangci-lint run ./cmd/infersia/...` — 0 issues
- `gofumpt -l` — clean
- `go run ./cmd/infersia/main.go` — regenerates the committed config byte-for-byte

One caveat worth stating: `golangci-lint run ./...` reports `typecheck` errors on `pkg/catwalk/client.go` in my environment, from a local Go toolchain mismatch (`go1.26.3` vs `go tool` `go1.26.2`). Those appear on files this PR doesn't touch and disappear with `GOROOT` set explicitly, so I believe they're mine and not real — flagging rather than quietly omitting.

---

**Disclosure:** I work on Infersia, so this is a vendor-submitted listing. Happy to adjust anything, including dropping the generator and shipping a static config if you'd prefer fewer moving parts.
