### PR TITLE
fix(providers): correct deepseek-v4 reasoning levels per DeepSeek docs

### DIFF
--- a/cmd/opencode-go/main.go
+++ b/cmd/opencode-go/main.go
@@ -104,7 +104,7 @@ func main() {
 		if goModel.Reasoning {
 			switch {
 			case strings.Contains(goModel.ID, "deepseek-v4"):
-				reasoningLevels = []string{"high", "xhigh"}
+				reasoningLevels = []string{"low", "high", "max"}
 				defaultReasoningEffort = "high"
 			default:
 				reasoningLevels = []string{"low", "medium", "high"}

--- a/cmd/opencode-zen/main.go
+++ b/cmd/opencode-zen/main.go
@@ -168,7 +168,7 @@ func main() {
 
 				switch {
 				case strings.Contains(zenModel.ID, "deepseek-v4"):
-					reasoningLevels = []string{"high", "xhigh"}
+					reasoningLevels = []string{"low", "high", "max"}
 					defaultReasoningEffort = "high"
 				default:
 					reasoningLevels = []string{"low", "medium", "high"}

--- a/cmd/vercel/main.go
+++ b/cmd/vercel/main.go
@@ -157,7 +157,10 @@ func main() {
 			case strings.HasPrefix(model.ID, "anthropic/"):
 				reasoningLevels = []string{"none", "minimal", "low", "medium", "high", "xhigh"}
 				defaultReasoning = "medium"
-			case strings.HasPrefix(model.ID, "deepseek/deepseek-v4") || model.ID == "zai/glm-5.2":
+			case strings.HasPrefix(model.ID, "deepseek/deepseek-v4"):
+				reasoningLevels = []string{"low", "high", "max"}
+				defaultReasoning = "high"
+			case model.ID == "zai/glm-5.2":
 				reasoningLevels = []string{"high", "xhigh"}
 				defaultReasoning = "high"
 			default:

--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -18,8 +18,9 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
+        "low",
         "high",
-        "xhigh"
+        "max"
       ],
       "default_reasoning_effort": "high",
       "supports_attachments": false
@@ -35,8 +36,9 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
+        "low",
         "high",
-        "xhigh"
+        "max"
       ],
       "default_reasoning_effort": "high",
       "supports_attachments": false

--- a/internal/providers/configs/opencode-go.json
+++ b/internal/providers/configs/opencode-go.json
@@ -18,8 +18,9 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
+        "low",
         "high",
-        "xhigh"
+        "max"
       ],
       "default_reasoning_effort": "high",
       "supports_attachments": false
@@ -35,8 +36,9 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
+        "low",
         "high",
-        "xhigh"
+        "max"
       ],
       "default_reasoning_effort": "high",
       "supports_attachments": false

--- a/internal/providers/configs/opencode-zen.json
+++ b/internal/providers/configs/opencode-zen.json
@@ -234,8 +234,9 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
+        "low",
         "high",
-        "xhigh"
+        "max"
       ],
       "default_reasoning_effort": "high",
       "supports_attachments": false
@@ -251,8 +252,9 @@
       "default_max_tokens": 128000,
       "can_reason": true,
       "reasoning_levels": [
+        "low",
         "high",
-        "xhigh"
+        "max"
       ],
       "default_reasoning_effort": "high",
       "supports_attachments": false
@@ -268,8 +270,9 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
+        "low",
         "high",
-        "xhigh"
+        "max"
       ],
       "default_reasoning_effort": "high",
       "supports_attachments": false

--- a/internal/providers/configs/vercel.json
+++ b/internal/providers/configs/vercel.json
@@ -405,8 +405,9 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
+        "low",
         "high",
-        "xhigh"
+        "max"
       ],
       "default_reasoning_effort": "high",
       "supports_attachments": false
@@ -422,8 +423,9 @@
       "default_max_tokens": 384000,
       "can_reason": true,
       "reasoning_levels": [
+        "low",
         "high",
-        "xhigh"
+        "max"
       ],
       "default_reasoning_effort": "high",
       "supports_attachments": false
@@ -439,8 +441,9 @@
       "default_max_tokens": 1048600,
       "can_reason": true,
       "reasoning_levels": [
+        "low",
         "high",
-        "xhigh"
+        "max"
       ],
       "default_reasoning_effort": "high",
       "supports_attachments": false


### PR DESCRIPTION
DeepSeek's API only accepts reasoning effort low/high/max for deepseek-v4 models.

See https://api-docs.deepseek.com/guides/thinking_mode

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
