### PR TITLE
chore: add coralbricks provider

### DIFF
--- a/internal/providers/configs/coralbricks.json
+++ b/internal/providers/configs/coralbricks.json
@@ -4,9 +4,21 @@
   "api_key": "$CORALBRICKS_API_KEY",
   "api_endpoint": "https://inference.coralbricks.ai/v1",
   "type": "openai-compat",
-  "default_large_model_id": "glm-5.2-fp4",
+  "default_large_model_id": "glm-5.3-fp4",
   "default_small_model_id": "gpt-oss-120b",
   "models": [
+    {
+      "id": "glm-5.3-fp4",
+      "name": "GLM 5.3",
+      "cost_per_1m_in": 1.12,
+      "cost_per_1m_out": 4.4,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
     {
       "id": "glm-5.2-fp4",
       "name": "GLM 5.2",

--- a/internal/providers/configs/coralbricks.json
+++ b/internal/providers/configs/coralbricks.json
@@ -20,18 +20,6 @@
       "supports_attachments": false
     },
     {
-      "id": "glm-5.2-fp4",
-      "name": "GLM 5.2",
-      "cost_per_1m_in": 1.12,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
-      "context_window": 1048576,
-      "default_max_tokens": 32768,
-      "can_reason": true,
-      "supports_attachments": false
-    },
-    {
       "id": "kimi-k3",
       "name": "Kimi K3",
       "cost_per_1m_in": 3,

--- a/internal/providers/configs/coralbricks.json
+++ b/internal/providers/configs/coralbricks.json
@@ -1,0 +1,47 @@
+{
+  "name": "CoralBricks",
+  "id": "coralbricks",
+  "api_key": "$CORALBRICKS_API_KEY",
+  "api_endpoint": "https://inference.coralbricks.ai/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "glm-5.2-fp4",
+  "default_small_model_id": "gpt-oss-120b",
+  "models": [
+    {
+      "id": "glm-5.2-fp4",
+      "name": "GLM 5.2",
+      "cost_per_1m_in": 1.12,
+      "cost_per_1m_out": 4.4,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "kimi-k3",
+      "name": "Kimi K3",
+      "cost_per_1m_in": 3,
+      "cost_per_1m_out": 15,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "gpt-oss-120b",
+      "name": "GPT-OSS 120B",
+      "cost_per_1m_in": 0.12,
+      "cost_per_1m_out": 0.6,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 131072,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -45,6 +45,9 @@ var cerebrasConfig []byte
 //go:embed configs/chutes.json
 var chutesConfig []byte
 
+//go:embed configs/coralbricks.json
+var coralBricksConfig []byte
+
 //go:embed configs/copilot.json
 var copilotConfig []byte
 
@@ -157,6 +160,7 @@ var providerRegistry = []ProviderFunc{
 	bedrockEuropeProvider,
 	cerebrasProvider,
 	chutesProvider,
+	coralBricksProvider,
 	copilotProvider,
 	cortecsProvider,
 	deepSeekProvider,
@@ -242,6 +246,10 @@ func cerebrasProvider() catwalk.Provider {
 
 func chutesProvider() catwalk.Provider {
 	return loadProviderFromConfig(chutesConfig)
+}
+
+func coralBricksProvider() catwalk.Provider {
+	return loadProviderFromConfig(coralBricksConfig)
 }
 
 func copilotProvider() catwalk.Provider {


### PR DESCRIPTION
## What

Adds **CoralBricks** as an inference provider — an OpenAI-compatible gateway serving open models with up to 1M context.

Models: GLM 5.2 (`glm-5.2-fp4`), Kimi K3 (`kimi-k3`), GPT-OSS 120B (`gpt-oss-120b`). Endpoint `https://inference.coralbricks.ai/v1`, key `$CORALBRICKS_API_KEY`, type `openai-compat`.

Notable: `cost_per_1m_in_cached: 0` on every model — cached input tokens are free on the gateway.

## Follows the existing pattern

- `internal/providers/configs/coralbricks.json` (mirrors the other `openai-compat` configs)
- `//go:embed` + `coralBricksProvider()` + `providerRegistry` entry in `internal/providers/providers.go`

## Verified

- `go build ./...` clean
- `go test ./internal/providers/` green
- Confirmed the provider loads via `GetAll()` with 3 models, correct endpoint, and free cached-input pricing

Pricing source: https://www.coralbricks.ai/pricing. Reasoning is declared (`can_reason: true`); per-request effort levels are intentionally omitted for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)