### PR TITLE
chore(model): add gemini 3.7 flash

### DIFF
--- a/internal/providers/configs/gemini.json
+++ b/internal/providers/configs/gemini.json
@@ -8,6 +8,20 @@
   "default_small_model_id": "gemini-3-flash-preview",
   "models": [
     {
+      "id": "gemini-3.7-flash",
+      "name": "Gemini 3.7 Flash",
+      "cost_per_1m_in": 0.75,
+      "cost_per_1m_out": 3.75,
+      "cost_per_1m_in_cached": 0.075,
+      "cost_per_1m_out_cached": 3.75,
+      "context_window": 1048576,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "reasoning_levels": ["minimal", "low", "medium", "high"],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
       "id": "gemini-3.6-flash",
       "name": "Gemini 3.6 Flash",
       "cost_per_1m_in": 1.5,


### PR DESCRIPTION
Added new model 'Gemini 3.7 Flash' with pricing and capabilities, to `gemini.json` configuration.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have **NOTE** created a discussion that was approved by a maintainer (for new features), but seems like an easy-to-agree-upon change.
- [x] Tested locally by manually adding the provider to my local configuration
