### PR TITLE
provider: add Gondola

### DIFF
--- a/internal/providers/configs/gondola.json
+++ b/internal/providers/configs/gondola.json
@@ -1,0 +1,443 @@
+{
+  "name": "Gondola",
+  "id": "gondola",
+  "api_key": "$GONDOLA_API_KEY",
+  "api_endpoint": "https://api.gondola-ai.com/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "kimi-k3",
+  "default_small_model_id": "deepseek-v4-flash",
+  "models": [
+    {
+      "id": "deepseek-v4-flash",
+      "name": "DeepSeek V4 Flash 0423",
+      "cost_per_1m_in": 0.042228,
+      "cost_per_1m_out": 0.08415,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.008568,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek-v4-pro",
+      "name": "DeepSeek V4 Pro",
+      "cost_per_1m_in": 0.5049,
+      "cost_per_1m_out": 1.010106,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.10098,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek-v3.2",
+      "name": "DeepSeek V3.2",
+      "cost_per_1m_in": 0.10098,
+      "cost_per_1m_out": 0.14688,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.04896,
+      "context_window": 160000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "claude-sonnet-5",
+      "name": "Claude Sonnet 5",
+      "cost_per_1m_in": 0.918,
+      "cost_per_1m_out": 4.59,
+      "cost_per_1m_in_cached": 1.1475,
+      "cost_per_1m_out_cached": 0.0918,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "claude-opus-4-8",
+      "name": "Claude Opus 4.8",
+      "cost_per_1m_in": 1.836,
+      "cost_per_1m_out": 9.18,
+      "cost_per_1m_in_cached": 2.295,
+      "cost_per_1m_out_cached": 0.1836,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "claude-opus-4-8-fast",
+      "name": "Claude Opus 4.8 (Fast)",
+      "cost_per_1m_in": 3.672,
+      "cost_per_1m_out": 18.36,
+      "cost_per_1m_in_cached": 4.59,
+      "cost_per_1m_out_cached": 0.3672,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "gemini-3-1-pro-preview",
+      "name": "Gemini 3.1 Pro Preview",
+      "cost_per_1m_in": 0.765,
+      "cost_per_1m_out": 4.59,
+      "cost_per_1m_in_cached": 0.153,
+      "cost_per_1m_out_cached": 0.153,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "gemini-3-5-flash",
+      "name": "Gemini 3.5 Flash",
+      "cost_per_1m_in": 0.4743,
+      "cost_per_1m_out": 2.8917,
+      "cost_per_1m_in_cached": 0.026316,
+      "cost_per_1m_out_cached": 0.04743,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "grok-4-5",
+      "name": "Grok 4.5",
+      "cost_per_1m_in": 0.69462,
+      "cost_per_1m_out": 2.0808,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.10404,
+      "context_window": 500000,
+      "default_max_tokens": 32000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "kimi-k2-7-code",
+      "name": "Kimi K2.7 Code",
+      "cost_per_1m_in": 0.2295,
+      "cost_per_1m_out": 1.071,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.04896,
+      "context_window": 256000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "kimi-k3",
+      "name": "Kimi K3",
+      "cost_per_1m_in": 1.1475,
+      "cost_per_1m_out": 5.7375,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.11475,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "openai-gpt-oss-120b",
+      "name": "OpenAI GPT OSS 120B",
+      "cost_per_1m_in": 0.02142,
+      "cost_per_1m_out": 0.0918,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 16384,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "llama-3.3-70b",
+      "name": "Llama 3.3 70B",
+      "cost_per_1m_in": 0.2142,
+      "cost_per_1m_out": 0.8568,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 4096,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "mistral-small-3-2-24b-instruct",
+      "name": "Mistral Small 3.2 24B Instruct",
+      "cost_per_1m_in": 0.028687,
+      "cost_per_1m_out": 0.0765,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 256000,
+      "default_max_tokens": 16384,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "google-gemma-3-27b-it",
+      "name": "Google Gemma 3 27B Instruct",
+      "cost_per_1m_in": 0.03672,
+      "cost_per_1m_out": 0.0612,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 198000,
+      "default_max_tokens": 16384,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "nvidia-nemotron-3-ultra-550b-a55b",
+      "name": "NVIDIA Nemotron 3 Ultra",
+      "cost_per_1m_in": 0.19125,
+      "cost_per_1m_out": 0.95625,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.057375,
+      "context_window": 256000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "minimax-m27",
+      "name": "MiniMax M2.7",
+      "cost_per_1m_in": 0.11475,
+      "cost_per_1m_out": 0.459,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.021038,
+      "context_window": 198000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "xiaomi-mimo-v2-5",
+      "name": "MiMo-V2.5",
+      "cost_per_1m_in": 0.1224,
+      "cost_per_1m_out": 0.612,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.02448,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "hermes-3-llama-3.1-405b",
+      "name": "Hermes 3 Llama 3.1 405b",
+      "cost_per_1m_in": 0.3366,
+      "cost_per_1m_out": 0.918,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 16384,
+      "can_reason": false,
+      "supports_attachments": false
+    },
+    {
+      "id": "venice-uncensored-1-2",
+      "name": "Venice Uncensored 1.2",
+      "cost_per_1m_in": 0.0612,
+      "cost_per_1m_out": 0.2754,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 8192,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "venice-uncensored-role-play",
+      "name": "Venice Role Play Uncensored",
+      "cost_per_1m_in": 0.153,
+      "cost_per_1m_out": 0.612,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 128000,
+      "default_max_tokens": 4096,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "gemma-4-uncensored",
+      "name": "Gemma 4 Uncensored",
+      "cost_per_1m_in": 0.049725,
+      "cost_per_1m_out": 0.153,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 256000,
+      "default_max_tokens": 8192,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "claude-opus-5",
+      "name": "Claude Opus 5",
+      "cost_per_1m_in": 1.836,
+      "cost_per_1m_out": 9.18,
+      "cost_per_1m_in_cached": 2.295,
+      "cost_per_1m_out_cached": 0.1836,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "claude-opus-5-fast",
+      "name": "Claude Opus 5 (Fast)",
+      "cost_per_1m_in": 3.672,
+      "cost_per_1m_out": 18.36,
+      "cost_per_1m_in_cached": 4.59,
+      "cost_per_1m_out_cached": 0.3672,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "claude-fable-5",
+      "name": "Claude Fable 5",
+      "cost_per_1m_in": 3.672,
+      "cost_per_1m_out": 18.36,
+      "cost_per_1m_in_cached": 4.59,
+      "cost_per_1m_out_cached": 0.3672,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "gemini-3-7-flash",
+      "name": "Gemini 3.7 Flash",
+      "cost_per_1m_in": 0.57375,
+      "cost_per_1m_out": 2.86875,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.057375,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "grok-4-6",
+      "name": "Grok 4.6",
+      "cost_per_1m_in": 0.69462,
+      "cost_per_1m_out": 2.0808,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.17442,
+      "context_window": 500000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "openai-gpt-56-terra",
+      "name": "GPT-5.6 Terra",
+      "cost_per_1m_in": 0.95625,
+      "cost_per_1m_out": 5.7375,
+      "cost_per_1m_in_cached": 1.195313,
+      "cost_per_1m_out_cached": 0.095625,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "deepseek-v4-pro-0813",
+      "name": "DeepSeek V4 Pro 0813",
+      "cost_per_1m_in": 0.52938,
+      "cost_per_1m_out": 1.5147,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.10098,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": false
+    },
+    {
+      "id": "kimi-k3-fast-api",
+      "name": "Kimi K3 (Fast)",
+      "cost_per_1m_in": 1.377,
+      "cost_per_1m_out": 6.885,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.1377,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -60,6 +60,9 @@ var fireworksConfig []byte
 //go:embed configs/gemini.json
 var geminiConfig []byte
 
+//go:embed configs/gondola.json
+var gondolaConfig []byte
+
 //go:embed configs/groq.json
 var groqConfig []byte
 
@@ -161,6 +164,7 @@ var providerRegistry = []ProviderFunc{
 	cortecsProvider,
 	deepSeekProvider,
 	fireworksProvider,
+	gondolaProvider,
 	groqProvider,
 	huggingFaceProvider,
 	ioNetProvider,
@@ -262,6 +266,10 @@ func fireworksProvider() catwalk.Provider {
 
 func geminiProvider() catwalk.Provider {
 	return loadProviderFromConfig(geminiConfig)
+}
+
+func gondolaProvider() catwalk.Provider {
+	return loadProviderFromConfig(gondolaConfig)
 }
 
 func groqProvider() catwalk.Provider {

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -60,6 +60,7 @@ const (
 	InferenceProviderBaseten          InferenceProvider = "baseten"
 	InferenceProviderMoonshot         InferenceProvider = "moonshot"
 	InferenceProviderAtlasCloud       InferenceProvider = "atlascloud"
+	InferenceProviderGondola          InferenceProvider = "gondola"
 )
 
 // Provider represents an AI provider configuration.
@@ -140,6 +141,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderBaseten,
 		InferenceProviderMoonshot,
 		InferenceProviderAtlasCloud,
+		InferenceProviderGondola,
 	}
 }
 


### PR DESCRIPTION
Adds [Gondola](https://gondola-ai.com) as a provider.

Gondola is an OpenAI-compatible gateway that resells Venice AI inference below list price, metered per request and settled in USDC on Base. No subscription, no minimum. Venice is the supply, so the model ids are identical to the existing `venice` provider and Crush users can switch between the two without touching model names.

### What is in here

- `internal/providers/configs/gondola.json`, 30 models
- the `//go:embed` + accessor + `providerRegistry` entry in `internal/providers/providers.go` (alphabetical section)
- `InferenceProviderGondola` in the const block and `KnownProviders()`, following #463

Defaults are `kimi-k3` (large) and `deepseek-v4-flash` (small).

Coverage is frontier (Claude Opus 5, Claude Fable 5, GPT-5.6 Terra, Gemini 3.7 Flash, Grok 4.6), coding (Kimi K3, DeepSeek V4 Pro and Flash), cheap workhorses, and an uncensored line.

### Where the numbers come from

Everything is generated from the public catalog at `https://api.gondola-ai.com/v1/models`, which needs no auth if you want to check it:

```
curl -s https://api.gondola-ai.com/v1/models | jq '.data[] | select(.id=="claude-opus-5")'
```

Two things worth flagging because they are easy to get wrong:

- `default_max_tokens` is the completion cap Gondola actually **serves**, not the base model's headline cap. Advertising a ceiling the gateway will not serve breaks harness compaction, so these are the real numbers.
- The cached fields follow the semantics in `anthropic.json`, where `claude-opus-5` is `in: 5`, `in_cached: 6.25`, `out_cached: 0.5`. So `cost_per_1m_in_cached` is the cache **write** price and `cost_per_1m_out_cached` is the cache **read** price. They are populated only where Venice prices that tier, and left at 0 otherwise.

### Auto-refresh

Gondola is a marketplace, so prices move with supply rather than being fixed by a vendor. I would rather this not go stale in your repo.

I am happy to follow the #463 shape and add `cmd/gondola/main.go` plus the `Taskfile.yaml` task and the `update.yml` step, so the config regenerates every 6 hours like the other providers. I left it out of this PR to keep the first one reviewable. Say the word and I will push it here.
