### PR TITLE
ci: deploy releases to prod Cloud Run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,42 @@ jobs:
               "app": "catwalk",
               "image": "ghcr.io/charmbracelet/catwalk:${{ github.ref_name }}"
             }
+
+  deploy-cloud-run:
+    name: Deploy to Cloud Run (prod)
+    runs-on: ubuntu-latest
+    needs: [goreleaser]
+    permissions:
+      id-token: write # for GCP Workload Identity Federation
+      contents: read
+    steps:
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        name: gcp auth
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PROD_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_PROD_DEPLOYER_SA }}
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        name: setup gcloud
+      - uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+        name: setup crane
+      - name: copy image ghcr -> prod artifact registry
+        run: |
+          gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
+          crane copy \
+            ghcr.io/charmbracelet/catwalk:${{ github.ref_name }} \
+            us-east1-docker.pkg.dev/infra-415616/charm/catwalk:${{ github.ref_name }}
+      - name: deploy to cloud run
+        run: |
+          gcloud run deploy catwalk \
+            --project=infra-415616 \
+            --region=us-east1 \
+            --image=us-east1-docker.pkg.dev/infra-415616/charm/catwalk:${{ github.ref_name }} \
+            --quiet
+      - name: verify
+        run: |
+          sleep 10
+          for host in catwalk.charm.sh catwalk.charm.land; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "https://$host/health")
+            [ "$code" = "200" ] || { echo "$host health=$code"; exit 1; }
+            echo "$host health=200"
+          done

--- a/.github/workflows/sync-cloud-run.yml
+++ b/.github/workflows/sync-cloud-run.yml
@@ -1,0 +1,53 @@
+name: sync cloud run
+
+# Manual escape hatch: copies a released image from ghcr to the prod
+# Artifact Registry and deploys it to Cloud Run. Same steps as the
+# deploy-cloud-run release job — use when a release deploy needs to be
+# re-run or rolled back to a specific tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to deploy (e.g. v0.51.27)"
+        required: true
+        type: string
+
+jobs:
+  sync-cloud-run:
+    name: Deploy to Cloud Run (prod)
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for GCP Workload Identity Federation
+      contents: read
+    steps:
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        name: gcp auth
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PROD_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_PROD_DEPLOYER_SA }}
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        name: setup gcloud
+      - uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+        name: setup crane
+      - name: copy image ghcr -> prod artifact registry
+        run: |
+          gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
+          crane copy \
+            ghcr.io/charmbracelet/catwalk:${{ inputs.tag }} \
+            us-east1-docker.pkg.dev/infra-415616/charm/catwalk:${{ inputs.tag }}
+      - name: deploy to cloud run
+        run: |
+          gcloud run deploy catwalk \
+            --project=infra-415616 \
+            --region=us-east1 \
+            --image=us-east1-docker.pkg.dev/infra-415616/charm/catwalk:${{ inputs.tag }} \
+            --quiet
+      - name: verify
+        run: |
+          sleep 10
+          for host in catwalk.charm.sh catwalk.charm.land; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "https://$host/health")
+            [ "$code" = "200" ] || { echo "$host health=$code"; exit 1; }
+            echo "$host health=200"
+          done


### PR DESCRIPTION
Since the prod catwalk domains moved to Cloud Run, releases deploy GKE (via infra-prod) while the Cloud Run service has relied on an ad-hoc sync process, leaving a drift window between a release and it actually serving.

This adds a `deploy-cloud-run` job to the release workflow: `crane copy` ghcr → prod Artifact Registry, `gcloud run deploy`, then a health check on both hosts. Auth is keyless WIF (new repo secrets `GCP_PROD_WIF_PROVIDER` / `GCP_PROD_DEPLOYER_SA`), mirroring the existing dev nightly wiring — but the prod WIF provider is scoped to this repo only, and the deployer SA has only `artifactregistry.writer`, `run.developer`, and `actAs` on the runtime SA.

Notes:
- The existing `deploy` (GKE) job is untouched; it goes away only when GKE catwalk is decommissioned.
- A failed job ≠ outage: Cloud Run keeps serving the previous revision; worst case we fall back to the manual sync.
- GCP setup (WIF pool/provider, deployer SA, bindings) is already in place; first real run will be the next release.

- Also adds a dispatchable `sync cloud run` workflow — same steps with a tag input, as a manual re-run/rollback escape hatch (and the initial end-to-end test vehicle).
