### PR TITLE
ci: authenticate crane to ghcr for the Cloud Run deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
     permissions:
       id-token: write # for GCP Workload Identity Federation
       contents: read
+      packages: read # pull the release image from ghcr
     steps:
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         name: gcp auth
@@ -56,6 +57,8 @@ jobs:
         name: setup crane
       - name: copy image ghcr -> prod artifact registry
         run: |
+          crane auth login ghcr.io -u ${{ github.actor }} --password-stdin \
+            <<< "${{ secrets.GITHUB_TOKEN }}"
           gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
           crane copy \
             ghcr.io/charmbracelet/catwalk:${{ github.ref_name }} \

--- a/.github/workflows/sync-cloud-run.yml
+++ b/.github/workflows/sync-cloud-run.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       id-token: write # for GCP Workload Identity Federation
       contents: read
+      packages: read # pull the release image from ghcr
     steps:
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         name: gcp auth
@@ -32,6 +33,8 @@ jobs:
         name: setup crane
       - name: copy image ghcr -> prod artifact registry
         run: |
+          crane auth login ghcr.io -u ${{ github.actor }} --password-stdin \
+            <<< "${{ secrets.GITHUB_TOKEN }}"
           gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
           crane copy \
             ghcr.io/charmbracelet/catwalk:${{ inputs.tag }} \


### PR DESCRIPTION
First dispatch of `sync cloud run` failed at the copy step: `DENIED: requested access to the resource is denied` fetching the ghcr manifest — the package is private and the runner had no ghcr credentials (GCP auth was fine). Fix: `packages: read` on the job + `crane auth login ghcr.io` with the built-in `GITHUB_TOKEN`. Applied to both the release job and the sync workflow.
