### PR TITLE
chore(cerebras): replace glm-4.7 with gemma 4

### DIFF
--- a/internal/providers/configs/cerebras.json
+++ b/internal/providers/configs/cerebras.json
@@ -5,7 +5,7 @@
     "api_key": "$CEREBRAS_API_KEY",
     "api_endpoint": "https://api.cerebras.ai/v1",
     "default_large_model_id": "gpt-oss-120b",
-    "default_small_model_id": "zai-glm-4.7",
+    "default_small_model_id": "gemma-4-31b",
     "default_headers": {
         "X-Cerebras-3rd-Party-Integration": "crush"
     },
@@ -27,14 +27,20 @@
             "supports_attachments": false
         },
         {
-            "id": "zai-glm-4.7",
-            "name": "Z.ai GLM 4.7",
-            "cost_per_1m_in": 2.25,
-            "cost_per_1m_out": 2.75,
+            "id": "gemma-4-31b",
+            "name": "Gemma 4 31B",
+            "cost_per_1m_in": 0.99,
+            "cost_per_1m_out": 1.49,
             "context_window": 131072,
             "default_max_tokens": 25000,
-            "can_reason": false,
-            "supports_attachments": false,
+            "can_reason": true,
+            "reasoning_levels": [
+                "low",
+                "medium",
+                "high"
+            ],
+            "default_reasoning_effort": "medium",
+            "supports_attachments": true,
             "temperature": 1,
             "top_p": 0.95
         }


### PR DESCRIPTION
## Summary
- replace GLM 4.7 with Gemma 4 31B in the Cerebras catalog
- make Gemma 4 31B the default small model
- configure current pricing, reasoning levels, multimodal attachments, and generation defaults

## Validation
- `jq empty internal/providers/configs/cerebras.json`
- `go test ./internal/providers/...`