### PR TITLE
feat(gemini): add 3.x flash lite models

### DIFF
--- a/internal/providers/configs/gemini.json
+++ b/internal/providers/configs/gemini.json
@@ -50,6 +50,20 @@
       "supports_attachments": true
     },
     {
+      "id": "gemini-3.5-flash-lite",
+      "name": "Gemini 3.5 Flash-Lite",
+      "cost_per_1m_in": 0.3,
+      "cost_per_1m_out": 2.5,
+      "cost_per_1m_in_cached": 0.03,
+      "cost_per_1m_out_cached": 2.5,
+      "context_window": 1048576,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "reasoning_levels": ["minimal", "low", "medium", "high"],
+      "default_reasoning_effort": "minimal",
+      "supports_attachments": true
+    },
+    {
       "id": "gemini-3.1-pro-preview-customtools",
       "name": "Gemini 3.1 Pro",
       "cost_per_1m_in": 2,
@@ -61,6 +75,20 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "gemini-3.1-flash-lite",
+      "name": "Gemini 3.1 Flash-Lite",
+      "cost_per_1m_in": 0.25,
+      "cost_per_1m_out": 1.5,
+      "cost_per_1m_in_cached": 0.025,
+      "cost_per_1m_out_cached": 1.5,
+      "context_window": 1048576,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "reasoning_levels": ["minimal", "low", "medium", "high"],
+      "default_reasoning_effort": "minimal",
       "supports_attachments": true
     },
     {

--- a/internal/providers/configs/gemini.json
+++ b/internal/providers/configs/gemini.json
@@ -17,7 +17,7 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "reasoning_levels": ["minimal", "low", "medium", "high"],
+      "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
       "supports_attachments": true
     },


### PR DESCRIPTION
Added flash lite (3.5, 3.1) models, update supported reasoning levels of 3.7 flash
docs: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/thinking

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
- [x] Tested locally by manually adding the provider to my local configuration