### PR TITLE
provider: add k3 and k3-256k models to Kimi Coding provider

### DIFF
--- a/internal/providers/configs/kimi.json
+++ b/internal/providers/configs/kimi.json
@@ -4,9 +4,33 @@
   "type": "anthropic",
   "api_key": "$KIMI_CODING_API_KEY",
   "api_endpoint": "https://api.kimi.com/coding",
-  "default_large_model_id": "kimi-for-coding",
+  "default_large_model_id": "k3",
   "default_small_model_id": "kimi-for-coding",
   "models": [
+    {
+      "id": "k3",
+      "name": "Kimi K3",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
+      "id": "k3-256k",
+      "name": "Kimi K3 256K",
+      "cost_per_1m_in": 0,
+      "cost_per_1m_out": 0,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
     {
       "id": "kimi-for-coding",
       "name": "Kimi for Coding",


### PR DESCRIPTION
Add Kimi K3 (1M context) and K3-256k (256K context) models to the kimi-coding provider config. Set K3 as the default large model.

Reference: https://www.kimi.com/code/docs/en/kimi-code/models.html

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
