### PR TITLE
chore: add glm-5.3 and glm-5.3-flash to fireworks

### DIFF
--- a/internal/providers/configs/fireworks.json
+++ b/internal/providers/configs/fireworks.json
@@ -46,6 +46,34 @@
       "supports_attachments": false
     },
     {
+      "id": "accounts/fireworks/models/glm-5p3",
+      "name": "GLM-5.3",
+      "cost_per_1m_in": 1.40,
+      "cost_per_1m_out": 4.40,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.26,
+      "context_window": 1048576,
+      "default_max_tokens": 262144,
+      "can_reason": true,
+      "reasoning_levels": ["low", "high", "max"],
+      "default_reasoning_effort": "max",
+      "supports_attachments": false
+    },
+    {
+      "id": "accounts/fireworks/models/glm-5p3-flash",
+      "name": "GLM-5.3 Flash",
+      "cost_per_1m_in": 0.15,
+      "cost_per_1m_out": 0.50,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.029,
+      "context_window": 1048576,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": ["low", "high", "max"],
+      "default_reasoning_effort": "max",
+      "supports_attachments": true
+    },
+    {
       "id": "accounts/fireworks/models/kimi-k3",
       "name": "Kimi K3",
       "cost_per_1m_in": 3.00,


### PR DESCRIPTION
Both models ship with cached pricing and reasoning support; only the Flash variant accepts image attachments.

Assisted-by: Crush:deepseek-v4-flash-0731