### PR TITLE
chore: add glm-5.3-flash to zai provider

### DIFF
--- a/internal/providers/configs/zai.json
+++ b/internal/providers/configs/zai.json
@@ -8,6 +8,23 @@
   "default_small_model_id": "glm-5-turbo",
   "models": [
     {
+      "id": "glm-5.3-flash",
+      "name": "GLM-5.3 Flash",
+      "cost_per_1m_in": 0.15,
+      "cost_per_1m_out": 0.5,
+      "cost_per_1m_in_cached": 0.03,
+      "context_window": 1000000,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "high",
+        "xhigh"
+      ],
+      "default_reasoning_effort": "xhigh",
+      "supports_attachments": true
+    },
+    {
       "id": "glm-5.3",
       "name": "GLM-5.3",
       "cost_per_1m_in": 1.4,


### PR DESCRIPTION
## What

Adds the `glm-5.3-flash` model entry to the `zai` provider catalog.

## Why

Z.ai now serves `glm-5.3-flash` on the GLM Coding Plan endpoint (`https://api.z.ai/api/coding/paas/v4`), but the catalog has no entry for it, so downstream clients (e.g. Crush) don't show the model in their picker even though the API accepts it.

Verified against the live endpoint with a Coding Plan key:

- `GET /v1/models` lists `glm-5.3-flash`
- `POST /v1/chat/completions` with `model: "glm-5.3-flash"` returns 200 (and returns `reasoning_content`, confirming always-on thinking)

## Specs

Per the [official docs](https://docs.z.ai/guides/vlm/glm-5.3-flash):

| Field | Value |
| --- | --- |
| Context window | 1,000,000 |
| Max output tokens | 131,072 (128K) |
| Pricing (list) | $0.15 / M in, $0.50 / M out, $0.03 / M cached in |
| Thinking | Cannot be disabled (`thinking.type: enabled` only); recommended `reasoning_effort: max` — mapped to `low/high/xhigh` + default `xhigh`, matching the existing `glm-5.3` entry |
| Multimodal | Native image/video/file input → `supports_attachments: true` |

Other aggregator catalogs in this repo (openrouter, vercel, fireworks, cortecs, aihubmix, venice, opencode-go) already include `glm-5.3-flash`; this brings the `zai` catalog in line.

Note: `zhipu-coding.json` appears to be missing it as well, but I could only verify the international z.ai endpoint, so I left it out of this PR.

💘 Generated with Crush