### PR TITLE
fix(providers): correct reasoning levels for Qwen3.8 and GLM-5.3-Flash models

### DIFF
--- a/internal/providers/configs/opencode-go.json
+++ b/internal/providers/configs/opencode-go.json
@@ -145,10 +145,10 @@
       "can_reason": true,
       "reasoning_levels": [
         "low",
-        "medium",
-        "high"
+        "high",
+        "max"
       ],
-      "default_reasoning_effort": "medium",
+      "default_reasoning_effort": "high",
       "supports_attachments": true
     },
     {
@@ -578,7 +578,7 @@
       "reasoning_levels": [
         "low",
         "medium",
-        "high"
+        "xhigh"
       ],
       "default_reasoning_effort": "medium",
       "supports_attachments": true
@@ -596,9 +596,9 @@
       "reasoning_levels": [
         "low",
         "medium",
-        "high"
+        "xhigh"
       ],
-      "default_reasoning_effort": "medium",
+      "default_reasoning_effort": "xhigh",
       "supports_attachments": true
     }
   ]


### PR DESCRIPTION
Fixes #558

## What

Corrects `reasoning_levels` (and where needed `default_reasoning_effort`) for three models in the `opencode-go` provider config, so the listed values match what the upstream APIs actually accept:

| Model | Before | After | Default |
|---|---|---|---|
| `glm-5.3-flash` | `low, medium, high` | `low, high, max` | `medium` → `high` |
| `qwen3.8-flash` | `low, medium, high` | `low, medium, xhigh` | `medium` (unchanged) |
| `qwen3.8-max` | `low, medium, high` | `low, medium, xhigh` | `medium` → `xhigh` |

## Why

Requests using the removed levels are rejected upstream. Concretely, `glm-5.3-flash` fails with:

```
[1210] This model always engages in thinking and cannot be disabled;
please use low, high, or max
```

which hits users of catalog consumers (e.g. Crush) as soon as the default `medium` is applied.

## Sources

- GLM-5.3-Flash: https://docs.z.ai/guides/llm/glm-5.3 and https://github.com/zai-org/GLM-5 (levels: low, high, max; default max; thinking cannot be disabled)
- Qwen3.8 family: https://docs.qwencloud.com/developer-guides/text-generation/thinking (per-model values; `qwen3.8-max`: low/medium/xhigh, default xhigh) and https://github.com/QwenLM/Qwen3.8-Flash-Next/

`qwen3.8-max` was included because it had the same stale triple and its official default is documented as `xhigh`.