### PR TITLE
chore(cerebras): replace gemma 4 with qwen 3.8

### DIFF
--- a/internal/providers/configs/cerebras.json
+++ b/internal/providers/configs/cerebras.json
@@ -5,7 +5,7 @@
     "api_key": "$CEREBRAS_API_KEY",
     "api_endpoint": "https://api.cerebras.ai/v1",
     "default_large_model_id": "gpt-oss-120b",
-    "default_small_model_id": "gemma-4-31b",
+    "default_small_model_id": "qwen-3.8-27b",
     "default_headers": {
         "X-Cerebras-3rd-Party-Integration": "crush"
     },
@@ -25,24 +25,6 @@
             ],
             "default_reasoning_effort": "medium",
             "supports_attachments": false
-        },
-        {
-            "id": "gemma-4-31b",
-            "name": "Gemma 4 31B",
-            "cost_per_1m_in": 0.99,
-            "cost_per_1m_out": 1.49,
-            "context_window": 131072,
-            "default_max_tokens": 25000,
-            "can_reason": true,
-            "reasoning_levels": [
-                "low",
-                "medium",
-                "high"
-            ],
-            "default_reasoning_effort": "medium",
-            "supports_attachments": true,
-            "temperature": 1,
-            "top_p": 0.95
         },
         {
             "id": "qwen-3.8-27b",

--- a/internal/providers/configs/cerebras.json
+++ b/internal/providers/configs/cerebras.json
@@ -43,6 +43,25 @@
             "supports_attachments": true,
             "temperature": 1,
             "top_p": 0.95
+        },
+        {
+            "id": "qwen-3.8-27b",
+            "name": "Qwen 3.8 27B",
+            "cost_per_1m_in": 0.99,
+            "cost_per_1m_out": 1.49,
+            "context_window": 65536,
+            "default_max_tokens": 25000,
+            "can_reason": true,
+            "reasoning_levels": [
+                "none",
+                "low",
+                "medium",
+                "high"
+            ],
+            "default_reasoning_effort": "high",
+            "supports_attachments": true,
+            "temperature": 1,
+            "top_p": 0.95
         }
     ]
 }


### PR DESCRIPTION
## Summary

- remove Gemma 4 31B from the Cerebras model list
- add qwen-3.8-27b and make it the default small model
- configure vision, tool use, and none/low/medium/high reasoning with high as the default
- use the Cerebras 65,536-token context and $0.99/$1.49 per million token pricing
- retain the 25,000 default completion cap so Crush keeps prompt headroom below the model 32,768-token maximum

## Validation

- jq empty internal/providers/configs/cerebras.json
- go test ./internal/providers/...