### PR TITLE
feat: add Corti provider

### DIFF
--- a/internal/providers/configs/corti.json
+++ b/internal/providers/configs/corti.json
@@ -1,0 +1,40 @@
+{
+  "name": "Corti",
+  "id": "corti",
+  "api_key": "$CORTI_BEARER",
+  "api_endpoint": "https://ai.eu.corti.app/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "corti-s1",
+  "default_small_model_id": "corti-s1-mini",
+  "models": [
+    {
+      "id": "corti-s1",
+      "name": "Corti S1",
+      "cost_per_1m_in": 2,
+      "cost_per_1m_out": 8,
+      "cost_per_1m_in_cached": 0.2,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 16384,
+      "can_reason": true,
+      "reasoning_levels": [
+        "high",
+        "max"
+      ],
+      "default_reasoning_effort": "high",
+      "supports_attachments": false
+    },
+    {
+      "id": "corti-s1-mini",
+      "name": "Corti S1 Mini",
+      "cost_per_1m_in": 1,
+      "cost_per_1m_out": 4,
+      "cost_per_1m_in_cached": 0.1,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 16384,
+      "can_reason": true,
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -51,6 +51,9 @@ var coralBricksConfig []byte
 //go:embed configs/copilot.json
 var copilotConfig []byte
 
+//go:embed configs/corti.json
+var cortiConfig []byte
+
 //go:embed configs/cortecs.json
 var cortecsConfig []byte
 
@@ -162,6 +165,7 @@ var providerRegistry = []ProviderFunc{
 	chutesProvider,
 	coralBricksProvider,
 	copilotProvider,
+	cortiProvider,
 	cortecsProvider,
 	deepSeekProvider,
 	fireworksProvider,
@@ -254,6 +258,10 @@ func coralBricksProvider() catwalk.Provider {
 
 func copilotProvider() catwalk.Provider {
 	return loadProviderFromConfig(copilotConfig)
+}
+
+func cortiProvider() catwalk.Provider {
+	return loadProviderFromConfig(cortiConfig)
 }
 
 func cortecsProvider() catwalk.Provider {

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -60,6 +60,7 @@ const (
 	InferenceProviderBaseten          InferenceProvider = "baseten"
 	InferenceProviderMoonshot         InferenceProvider = "moonshot"
 	InferenceProviderAtlasCloud       InferenceProvider = "atlascloud"
+	InferenceProviderCorti            InferenceProvider = "corti"
 )
 
 // Provider represents an AI provider configuration.
@@ -140,6 +141,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderBaseten,
 		InferenceProviderMoonshot,
 		InferenceProviderAtlasCloud,
+		InferenceProviderCorti,
 	}
 }
 


### PR DESCRIPTION
Adds Corti — a first-party lab serving frontier reasoning models on sovereign EU infrastructure through an OpenAI-compatible API.

## Changes

| File | |
|---|---|
| `internal/providers/configs/corti.json` | Provider config with 2 models |
| `internal/providers/providers.go` | Embed + var + registry entry + provider func |
| `pkg/catwalk/provider.go` | `InferenceProviderCorti` const + `KnownProviders()` |

## Provider

| | |
|---|---|
| Endpoint | `https://ai.eu.corti.app/v1` |
| Type | `openai-compat` |
| Env | `$CORTI_BEARER` |
| Docs | https://docs.corti.ai |

## Models

| Model | Reasoning | Effort levels | Context | Max tokens | In | Out | Cache read | Attachments |
|---|---|---|---|---|---|---|---|---|
| `corti-s1` | yes | `high`, `max` | 262,144 | 16,384 | $2 | $8 | $0.20 | no |
| `corti-s1-mini` | yes | none | 262,144 | 16,384 | $1 | $4 | $0.10 | yes |

Defaults: `corti-s1` (large), `corti-s1-mini` (small).

Reasoning is always-on for both models. `corti-s1` supports effort levels `high` and `max`; `corti-s1-mini` has no effort control. The `-instant` variants (no reasoning) and other models from the API are not included in this PR.

## Data sources

- `GET https://ai.eu.corti.app/v1/models` (live, no auth required)
- https://docs.corti.ai/models/models

## Disclosure

I am affiliated with Corti — this adds our own product.