### PR TITLE
chore(openai): add gpt-6 astra

### DIFF
--- a/internal/providers/configs/openai.json
+++ b/internal/providers/configs/openai.json
@@ -8,6 +8,20 @@
   "default_small_model_id": "gpt-5.6-luna",
   "models": [
     {
+      "id": "gpt-6-astra",
+      "name": "GPT-6 Astra",
+      "cost_per_1m_in": 10,
+      "cost_per_1m_out": 50,
+      "cost_per_1m_in_cached": 12.5,
+      "cost_per_1m_out_cached": 1,
+      "context_window": 1050000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
       "id": "gpt-5.6-sol",
       "name": "GPT-5.6 Sol",
       "cost_per_1m_in": 4,


### PR DESCRIPTION
Heads-up that this is now available for everyone _yet_, but will be in the coming days:

> GPT‑6 Astra is rolling out today for enterprises in our [Trusted Access Program⁠](https://openai-dotcom-preview.vercel.app/form/enterprise-trusted-access-for-cyber/), with access through API and our Plus, Pro, Business and Enterprise plans coming in the coming days.

https://developers.openai.com/api/docs/models/gpt-6-astra