### PR TITLE
feat: add LLM Tech provider

### DIFF
--- a/internal/providers/configs/llmtech.json
+++ b/internal/providers/configs/llmtech.json
@@ -1,0 +1,23 @@
+{
+  "name": "LLM Tech",
+  "id": "llmtech",
+  "api_key": "$LLMTECH_API_KEY",
+  "api_endpoint": "https://api.llmtech.eu/v1",
+  "type": "openai",
+  "default_large_model_id": "unsloth/Qwen3.8-27B-NVFP4",
+  "default_small_model_id": "unsloth/Qwen3.8-27B-NVFP4",
+  "models": [
+    {
+      "id": "unsloth/Qwen3.8-27B-NVFP4",
+      "name": "Qwen3.8 27B (NVFP4)",
+      "cost_per_1m_in": 0.25,
+      "cost_per_1m_out": 2.09,
+      "cost_per_1m_in_cached": 0.04,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 262144,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds LLM Tech as a provider config.

LLM Tech serves open-weight models from dedicated GPUs inside the EU, with no US cloud in the path and no prompt retention. The API is OpenAI compatible, so this is a config file only, in the same shape as the existing `scaleway.json` and `cortecs.json` entries.

Currently one model: Qwen3.8-27B in NVFP4, 262,144 context, tool calling, image input, prompt caching. Prices in the file are the published rates at https://llmtech.eu/pricing and match the entry in models.dev.

Verified before opening: `curl https://api.llmtech.eu/v1/models` returns the model with `context_length: 262144`, and the JSON parses against the same field set used by the other configs.
