### PR TITLE
chore: add hubris provider

### DIFF
--- a/internal/providers/configs/hubris.json
+++ b/internal/providers/configs/hubris.json
@@ -1,0 +1,473 @@
+{
+  "name": "Hubris",
+  "id": "hubris",
+  "api_key": "$HUBRIS_API_KEY",
+  "api_endpoint": "https://api.hubris.pw/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "anthropic/claude-sonnet-5",
+  "default_small_model_id": "google/gemini-3.7-flash",
+  "models": [
+    {
+      "id": "anthropic/claude-sonnet-5",
+      "name": "Claude Sonnet 5",
+      "cost_per_1m_in": 2.9187,
+      "cost_per_1m_out": 14.5937,
+      "cost_per_1m_in_cached": 3.6484,
+      "cost_per_1m_out_cached": 0.2918,
+      "context_window": 1000000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "anthropic/claude-opus-5",
+      "name": "Claude Opus 5",
+      "cost_per_1m_in": 7.2968,
+      "cost_per_1m_out": 36.4843,
+      "cost_per_1m_in_cached": 9.1211,
+      "cost_per_1m_out_cached": 0.7297,
+      "context_window": 1000000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "anthropic/claude-haiku-4.5",
+      "name": "Claude Haiku 4.5",
+      "cost_per_1m_in": 1.4594,
+      "cost_per_1m_out": 7.2968,
+      "cost_per_1m_in_cached": 1.8242,
+      "cost_per_1m_out_cached": 0.146,
+      "context_window": 200000,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "anthropic/claude-fable-5.1",
+      "name": "Claude Fable 5.1",
+      "cost_per_1m_in": 14.5937,
+      "cost_per_1m_out": 72.9686,
+      "cost_per_1m_in_cached": 18.2422,
+      "cost_per_1m_out_cached": 0.3648,
+      "context_window": 1000000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "anthropic/claude-opus-4.8",
+      "name": "Claude Opus 4.8",
+      "cost_per_1m_in": 7.2968,
+      "cost_per_1m_out": 36.4843,
+      "cost_per_1m_in_cached": 9.1211,
+      "cost_per_1m_out_cached": 0.7297,
+      "context_window": 1000000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "anthropic/claude-sonnet-4.6",
+      "name": "Claude Sonnet 4.6",
+      "cost_per_1m_in": 4.3781,
+      "cost_per_1m_out": 21.8906,
+      "cost_per_1m_in_cached": 5.4726,
+      "cost_per_1m_out_cached": 0.4378,
+      "context_window": 1000000,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "openai/gpt-5.6-luna",
+      "name": "GPT-5.6 Luna",
+      "cost_per_1m_in": 0.2918,
+      "cost_per_1m_out": 1.7512,
+      "cost_per_1m_in_cached": 0.3648,
+      "cost_per_1m_out_cached": 0.0292,
+      "context_window": 1050000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "openai/gpt-5.6-sol",
+      "name": "GPT-5.6 Sol",
+      "cost_per_1m_in": 2.9187,
+      "cost_per_1m_out": 14.5937,
+      "cost_per_1m_in_cached": 3.6484,
+      "cost_per_1m_out_cached": 0.2918,
+      "context_window": 1050000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "openai/gpt-5.6-terra",
+      "name": "GPT-5.6 Terra",
+      "cost_per_1m_in": 2.9187,
+      "cost_per_1m_out": 17.5125,
+      "cost_per_1m_in_cached": 3.6484,
+      "cost_per_1m_out_cached": 0.2918,
+      "context_window": 1050000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "openai/gpt-6-astra",
+      "name": "GPT-6 Astra",
+      "cost_per_1m_in": 14.5937,
+      "cost_per_1m_out": 72.9686,
+      "cost_per_1m_in_cached": 18.2422,
+      "cost_per_1m_out_cached": 1.4594,
+      "context_window": 1050000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "openai/gpt-5.5",
+      "name": "GPT-5.5",
+      "cost_per_1m_in": 7.2968,
+      "cost_per_1m_out": 43.7811,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.7297,
+      "context_window": 1050000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "openai/gpt-5-mini",
+      "name": "GPT-5 Mini",
+      "cost_per_1m_in": 0.3648,
+      "cost_per_1m_out": 2.9187,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.0365,
+      "context_window": 400000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "openai/gpt-4o-mini",
+      "name": "GPT-4o-mini",
+      "cost_per_1m_in": 0.2189,
+      "cost_per_1m_out": 0.8757,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.1095,
+      "context_window": 128000,
+      "default_max_tokens": 16384,
+      "can_reason": false,
+      "supports_attachments": true
+    },
+    {
+      "id": "google/gemini-3.7-flash",
+      "name": "Gemini 3.7 Flash",
+      "cost_per_1m_in": 1.0945,
+      "cost_per_1m_out": 5.4726,
+      "cost_per_1m_in_cached": 0.0609,
+      "cost_per_1m_out_cached": 0.1095,
+      "context_window": 1048576,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "google/gemini-3.8-flash",
+      "name": "Gemini 3.8 Flash",
+      "cost_per_1m_in": 1.0945,
+      "cost_per_1m_out": 5.4726,
+      "cost_per_1m_in_cached": 0.0609,
+      "cost_per_1m_out_cached": 0.1095,
+      "context_window": 1048576,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "google/gemini-3.5-flash",
+      "name": "Gemini 3.5 Flash",
+      "cost_per_1m_in": 2.189,
+      "cost_per_1m_out": 13.1344,
+      "cost_per_1m_in_cached": 0.1216,
+      "cost_per_1m_out_cached": 0.2189,
+      "context_window": 1048576,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "google/gemini-2.5-flash",
+      "name": "Gemini 2.5 Flash",
+      "cost_per_1m_in": 0.4378,
+      "cost_per_1m_out": 3.6484,
+      "cost_per_1m_in_cached": 0.1216,
+      "cost_per_1m_out_cached": 0.0438,
+      "context_window": 1048576,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "name": "DeepSeek V4 Flash 0731",
+      "cost_per_1m_in": 0.0948,
+      "cost_per_1m_out": 0.2626,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.0233,
+      "context_window": 1310720,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek/deepseek-v4-pro-0813",
+      "name": "DeepSeek V4 Pro 0813",
+      "cost_per_1m_in": 1.6355,
+      "cost_per_1m_out": 4.9065,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.0545,
+      "context_window": 1048576,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "z-ai/glm-5.3-flash",
+      "name": "GLM 5.3 Flash",
+      "cost_per_1m_in": 0.1095,
+      "cost_per_1m_out": 0.3648,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.0219,
+      "context_window": 1310720,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "z-ai/glm-5.3",
+      "name": "GLM 5.3",
+      "cost_per_1m_in": 2.0432,
+      "cost_per_1m_out": 6.4213,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.2043,
+      "context_window": 1310720,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "moonshotai/kimi-k3",
+      "name": "Kimi K3",
+      "cost_per_1m_in": 4.3781,
+      "cost_per_1m_out": 21.8906,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.4378,
+      "context_window": 1048576,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "x-ai/grok-4.6",
+      "name": "Grok 4.6",
+      "cost_per_1m_in": 2.9187,
+      "cost_per_1m_out": 8.7562,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.7297,
+      "context_window": 500000,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3.8-max-0902",
+      "name": "Qwen3.8 Max (0902)",
+      "cost_per_1m_in": 2.9187,
+      "cost_per_1m_out": 8.7562,
+      "cost_per_1m_in_cached": 3.6484,
+      "cost_per_1m_out_cached": 0.3648,
+      "context_window": 1000000,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "qwen/qwen3.8-flash",
+      "name": "Qwen3.8 Flash",
+      "cost_per_1m_in": 0.2189,
+      "cost_per_1m_out": 0.6859,
+      "cost_per_1m_in_cached": 0.2918,
+      "cost_per_1m_out_cached": 0.0233,
+      "context_window": 1000000,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    },
+    {
+      "id": "minimax/minimax-m3",
+      "name": "MiniMax M3",
+      "cost_per_1m_in": 0.4378,
+      "cost_per_1m_out": 1.7512,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.0875,
+      "context_window": 1048576,
+      "default_max_tokens": 131072,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": true
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -69,6 +69,9 @@ var groqConfig []byte
 //go:embed configs/huggingface.json
 var huggingFaceConfig []byte
 
+//go:embed configs/hubris.json
+var hubrisConfig []byte
+
 //go:embed configs/ionet.json
 var ioNetConfig []byte
 
@@ -167,6 +170,7 @@ var providerRegistry = []ProviderFunc{
 	fireworksProvider,
 	groqProvider,
 	huggingFaceProvider,
+	hubrisProvider,
 	ioNetProvider,
 	nebiusProvider,
 	neuralwattProvider,
@@ -278,6 +282,10 @@ func groqProvider() catwalk.Provider {
 
 func huggingFaceProvider() catwalk.Provider {
 	return loadProviderFromConfig(huggingFaceConfig)
+}
+
+func hubrisProvider() catwalk.Provider {
+	return loadProviderFromConfig(hubrisConfig)
 }
 
 func ioNetProvider() catwalk.Provider {


### PR DESCRIPTION
## What

Adds **Hubris** as an inference provider — an OpenAI-compatible LLM gateway (https://hubris.pw) billed in Russian rubles, serving OpenAI, Anthropic, Google, DeepSeek, Qwen, Z.ai, Moonshot, xAI and MiniMax models behind one key.

Endpoint `https://api.hubris.pw/v1`, key `$HUBRIS_API_KEY`, type `openai-compat`. Model ids keep the full `vendor/model` form used by the gateway (e.g. `anthropic/claude-sonnet-5`) — there is no alias resolution on the Hubris side.

26 models included (the most used ones from the catalog): Claude Sonnet 5 / Opus 5 / Haiku 4.5 / Fable 5.1, GPT-5.6 Luna / Sol / Terra, GPT-6 Astra, GPT-5.5, GPT-5 mini, Gemini 3.7 / 3.8 / 3.5 / 2.5 Flash, DeepSeek V4 Flash / Pro, GLM 5.3 / 5.3 Flash, Kimi K3, Grok 4.6, Qwen 3.8 Max / Flash, MiniMax M3, and others.

## Follows the existing pattern

- `internal/providers/configs/hubris.json` (mirrors the other `openai-compat` configs)
- `//go:embed` + `hubrisProvider()` + `providerRegistry` entry in `internal/providers/providers.go` (alphabetical, between Hugging Face and io.net)

## Pricing

Hubris publishes prices in RUB per million tokens (https://hubris.pw/models). The USD figures here are those public rates converted at the Bank of Russia rate on 2026-09-05 (86.5857 RUB/USD), rounded to 4 decimals. `cost_per_1m_in_cached` = cache write, `cost_per_1m_out_cached` = cache read, per `CRUSH.md`; models without a cache-write price on Hubris have `0` there.

## Verified

- `bun validate`-equivalent schema check is not applicable here; the JSON was generated from the live Hubris catalog and every `default_*_model_id` is present in `models` (matches `TestValidDefaultModels`).
- I could not run `go test ./...` locally (no Go toolchain on this machine) — relying on CI for the build/test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)