### PR TITLE
feat: add The Grid provider

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -78,6 +78,10 @@ jobs:
         run: go run ./cmd/synthetic/main.go
         continue-on-error: true
 
+      - name: The Grid
+        run: go run ./cmd/thegrid/main.go
+        continue-on-error: true
+
       - name: Pioneer
         run: go run ./cmd/pioneer/main.go
         continue-on-error: true

--- a/cmd/thegrid/main.go
+++ b/cmd/thegrid/main.go
@@ -1,0 +1,185 @@
+// Package main provides a command-line tool to fetch instruments from The Grid
+// and generate a configuration file for the provider.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+// Pricing is The Grid's price for an instrument. Instruments are market
+// priced and quoted at a single rate that applies to both input and output
+// tokens, so prompt and completion always carry the same value.
+type Pricing struct {
+	USDPer1MTokens float64 `json:"usd_per_1m_tokens"`
+}
+
+// Architecture describes the modalities an instrument accepts and returns.
+type Architecture struct {
+	InputModalities  []string `json:"input_modalities"`
+	OutputModalities []string `json:"output_modalities"`
+}
+
+// Reasoning describes an instrument's reasoning support.
+type Reasoning struct {
+	DefaultEffort    string   `json:"default_effort"`
+	DefaultEnabled   bool     `json:"default_enabled"`
+	SupportedEfforts []string `json:"supported_efforts"`
+}
+
+// Model represents an instrument from The Grid's models API.
+type Model struct {
+	ID                  string       `json:"id"`
+	DisplayName         string       `json:"display_name"`
+	Architecture        Architecture `json:"architecture"`
+	Attachments         bool         `json:"attachments"`
+	ContextLength       int64        `json:"context_length"`
+	MaxCompletionTokens int64        `json:"max_completion_tokens"`
+	Pricing             Pricing      `json:"pricing"`
+	Reasoning           *Reasoning   `json:"reasoning"`
+	ToolCall            bool         `json:"tool_call"`
+}
+
+// ModelsResponse is the response structure for The Grid's models API.
+type ModelsResponse struct {
+	Data []Model `json:"data"`
+}
+
+func roundCost(v float64) float64 {
+	return math.Round(v*1e5) / 1e5
+}
+
+func fetchTheGridModels(apiEndpoint string) (*ModelsResponse, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequestWithContext(context.Background(), "GET", apiEndpoint+"/models", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating models request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Catwalk-Client/1.0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching models: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, body)
+	}
+
+	var mr ModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&mr); err != nil {
+		return nil, fmt.Errorf("decoding models response: %w", err)
+	}
+
+	return &mr, nil
+}
+
+func main() {
+	theGridProvider := catwalk.Provider{
+		Name:                "The Grid",
+		ID:                  catwalk.InferenceProviderTheGrid,
+		APIKey:              "$THEGRID_API_KEY",
+		APIEndpoint:         "https://api.thegrid.ai/v1",
+		Type:                catwalk.TypeOpenAICompat,
+		DefaultLargeModelID: "agent-max",
+		DefaultSmallModelID: "text-standard",
+		Models:              []catwalk.Model{},
+	}
+
+	modelsResp, err := fetchTheGridModels(theGridProvider.APIEndpoint)
+	if err != nil {
+		log.Fatal("Error fetching The Grid models:", err)
+	}
+
+	for _, model := range modelsResp.Data {
+		// Skip non-text instruments.
+		if !slices.Contains(model.Architecture.InputModalities, "text") ||
+			!slices.Contains(model.Architecture.OutputModalities, "text") {
+			continue
+		}
+
+		// Require tool support, as Crush drives tool calls.
+		if !model.ToolCall {
+			continue
+		}
+
+		if model.Pricing.USDPer1MTokens <= 0 {
+			fmt.Printf("Skipping instrument %s: no price\n", model.ID)
+			continue
+		}
+
+		// A single market rate covers both directions, and The Grid does not
+		// quote a separate cached rate, so all four costs carry it.
+		cost := roundCost(model.Pricing.USDPer1MTokens)
+
+		// DefaultMaxTokens: use half of max_completion_tokens when available,
+		// capped at 15% of context_length; otherwise 10% of context_length.
+		// This matches the heuristic used by the other generators, and avoids
+		// instruments whose ceiling equals their whole context window
+		// defaulting to an output budget the size of the context.
+		var defaultMaxTokens int64
+		if model.MaxCompletionTokens > 0 {
+			maxFromOutput := model.MaxCompletionTokens / 2
+			maxAt15Pct := (model.ContextLength * 15) / 100
+			if maxFromOutput <= maxAt15Pct {
+				defaultMaxTokens = maxFromOutput
+			} else {
+				defaultMaxTokens = model.ContextLength / 10
+			}
+		} else {
+			defaultMaxTokens = model.ContextLength / 10
+		}
+
+		m := catwalk.Model{
+			ID:                 model.ID,
+			Name:               strings.TrimPrefix(model.DisplayName, "The Grid: "),
+			CostPer1MIn:        cost,
+			CostPer1MOut:       cost,
+			CostPer1MInCached:  cost,
+			CostPer1MOutCached: cost,
+			ContextWindow:      model.ContextLength,
+			DefaultMaxTokens:   defaultMaxTokens,
+			SupportsImages:     model.Attachments || slices.Contains(model.Architecture.InputModalities, "image"),
+		}
+
+		if model.Reasoning != nil {
+			m.CanReason = model.Reasoning.DefaultEnabled || len(model.Reasoning.SupportedEfforts) > 0
+			m.ReasoningLevels = model.Reasoning.SupportedEfforts
+			m.DefaultReasoningEffort = model.Reasoning.DefaultEffort
+		}
+
+		theGridProvider.Models = append(theGridProvider.Models, m)
+	}
+
+	slices.SortFunc(theGridProvider.Models, func(a catwalk.Model, b catwalk.Model) int {
+		if a.Name == b.Name {
+			return strings.Compare(a.ID, b.ID)
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	data, err := json.MarshalIndent(theGridProvider, "", "  ")
+	if err != nil {
+		log.Fatal("Error marshaling The Grid provider:", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile("internal/providers/configs/thegrid.json", data, 0o600); err != nil {
+		log.Fatal("Error writing The Grid provider config:", err)
+	}
+
+	fmt.Printf("Generated thegrid.json with %d instruments\n", len(theGridProvider.Models))
+}

--- a/cmd/thegrid/main.go
+++ b/cmd/thegrid/main.go
@@ -46,7 +46,7 @@ type Model struct {
 	Attachments         bool         `json:"attachments"`
 	ContextLength       int64        `json:"context_length"`
 	MaxCompletionTokens int64        `json:"max_completion_tokens"`
-	Pricing             Pricing      `json:"pricing"`
+	Pricing             *Pricing     `json:"pricing"`
 	Reasoning           *Reasoning   `json:"reasoning"`
 	ToolCall            bool         `json:"tool_call"`
 }
@@ -104,6 +104,8 @@ func main() {
 		log.Fatal("Error fetching The Grid models:", err)
 	}
 
+	var unpriced int
+
 	for _, model := range modelsResp.Data {
 		// Skip non-text instruments.
 		if !slices.Contains(model.Architecture.InputModalities, "text") ||
@@ -116,14 +118,20 @@ func main() {
 			continue
 		}
 
-		if model.Pricing.USDPer1MTokens <= 0 {
-			fmt.Printf("Skipping instrument %s: no price\n", model.ID)
-			continue
+		// The Grid is market priced and its catalog serves `pricing: null` when
+		// the rate cache is cold, so an absent price is a normal transient state
+		// rather than a reason to drop the instrument. Emit it with a zero cost,
+		// which is what catwalk already carries for unpriced models elsewhere.
+		// Dropping them instead would regenerate this provider with no models at
+		// all the next time the catalog is unpriced.
+		var cost float64
+		if model.Pricing != nil && model.Pricing.USDPer1MTokens > 0 {
+			// A single market rate covers both directions, and The Grid does not
+			// quote a separate cached rate, so all four costs carry it.
+			cost = roundCost(model.Pricing.USDPer1MTokens)
+		} else {
+			unpriced++
 		}
-
-		// A single market rate covers both directions, and The Grid does not
-		// quote a separate cached rate, so all four costs carry it.
-		cost := roundCost(model.Pricing.USDPer1MTokens)
 
 		// DefaultMaxTokens: use half of max_completion_tokens when available,
 		// capped at 15% of context_length; otherwise 10% of context_length.
@@ -182,4 +190,7 @@ func main() {
 	}
 
 	fmt.Printf("Generated thegrid.json with %d instruments\n", len(theGridProvider.Models))
+	if unpriced > 0 {
+		fmt.Printf("%d of them carried no published price and were written with a zero cost\n", unpriced)
+	}
 }

--- a/internal/providers/configs/thegrid.json
+++ b/internal/providers/configs/thegrid.json
@@ -1,0 +1,316 @@
+{
+  "name": "The Grid",
+  "id": "thegrid",
+  "api_key": "$THEGRID_API_KEY",
+  "api_endpoint": "https://api.thegrid.ai/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "agent-max",
+  "default_small_model_id": "text-standard",
+  "models": [
+    {
+      "id": "agent-max",
+      "name": "Agent Max",
+      "cost_per_1m_in": 1.5195,
+      "cost_per_1m_out": 1.5195,
+      "cost_per_1m_in_cached": 1.5195,
+      "cost_per_1m_out_cached": 1.5195,
+      "context_window": 1000000,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "supports_attachments": true
+    },
+    {
+      "id": "agent-prime",
+      "name": "Agent Prime",
+      "cost_per_1m_in": 0.1335,
+      "cost_per_1m_out": 0.1335,
+      "cost_per_1m_in_cached": 0.1335,
+      "cost_per_1m_out_cached": 0.1335,
+      "context_window": 196608,
+      "default_max_tokens": 19660,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "agent-standard",
+      "name": "Agent Standard",
+      "cost_per_1m_in": 0.0402,
+      "cost_per_1m_out": 0.0402,
+      "cost_per_1m_in_cached": 0.0402,
+      "cost_per_1m_out_cached": 0.0402,
+      "context_window": 128000,
+      "default_max_tokens": 12800,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "bytedance-pro-latest",
+      "name": "ByteDance Pro Latest",
+      "cost_per_1m_in": 0.1932,
+      "cost_per_1m_out": 0.1932,
+      "cost_per_1m_in_cached": 0.1932,
+      "cost_per_1m_out_cached": 0.1932,
+      "context_window": 262144,
+      "default_max_tokens": 26214,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "supports_attachments": false
+    },
+    {
+      "id": "claude-opus-latest",
+      "name": "Claude Opus Latest",
+      "cost_per_1m_in": 1.5308,
+      "cost_per_1m_out": 1.5308,
+      "cost_per_1m_in_cached": 1.5308,
+      "cost_per_1m_out_cached": 1.5308,
+      "context_window": 1000000,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "default_reasoning_effort": "high",
+      "supports_attachments": true
+    },
+    {
+      "id": "code-max",
+      "name": "Code Max",
+      "cost_per_1m_in": 1.5876,
+      "cost_per_1m_out": 1.5876,
+      "cost_per_1m_in_cached": 1.5876,
+      "cost_per_1m_out_cached": 1.5876,
+      "context_window": 1000000,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "supports_attachments": true
+    },
+    {
+      "id": "code-prime",
+      "name": "Code Prime",
+      "cost_per_1m_in": 0.1286,
+      "cost_per_1m_out": 0.1286,
+      "cost_per_1m_in_cached": 0.1286,
+      "cost_per_1m_out_cached": 0.1286,
+      "context_window": 196608,
+      "default_max_tokens": 19660,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "code-standard",
+      "name": "Code Standard",
+      "cost_per_1m_in": 0.0297,
+      "cost_per_1m_out": 0.0297,
+      "cost_per_1m_in_cached": 0.0297,
+      "cost_per_1m_out_cached": 0.0297,
+      "context_window": 128000,
+      "default_max_tokens": 12800,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "deepseek-pro-latest",
+      "name": "DeepSeek Pro Latest",
+      "cost_per_1m_in": 0.3181,
+      "cost_per_1m_out": 0.3181,
+      "cost_per_1m_in_cached": 0.3181,
+      "cost_per_1m_out_cached": 0.3181,
+      "context_window": 1000000,
+      "default_max_tokens": 100000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "supports_attachments": false
+    },
+    {
+      "id": "glm-latest",
+      "name": "GLM Latest",
+      "cost_per_1m_in": 0.3383,
+      "cost_per_1m_out": 0.3383,
+      "cost_per_1m_in_cached": 0.3383,
+      "cost_per_1m_out_cached": 0.3383,
+      "context_window": 1000000,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "supports_attachments": false
+    },
+    {
+      "id": "gpt-sol-latest",
+      "name": "GPT Sol Latest",
+      "cost_per_1m_in": 1.4545,
+      "cost_per_1m_out": 1.4545,
+      "cost_per_1m_in_cached": 1.4545,
+      "cost_per_1m_out_cached": 1.4545,
+      "context_window": 1000000,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "supports_attachments": true
+    },
+    {
+      "id": "gemini-pro-latest",
+      "name": "Gemini Pro Latest",
+      "cost_per_1m_in": 0.5887,
+      "cost_per_1m_out": 0.5887,
+      "cost_per_1m_in_cached": 0.5887,
+      "cost_per_1m_out_cached": 0.5887,
+      "context_window": 1000000,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "supports_attachments": true
+    },
+    {
+      "id": "kimi-latest",
+      "name": "Kimi Latest",
+      "cost_per_1m_in": 0.7163,
+      "cost_per_1m_out": 0.7163,
+      "cost_per_1m_in_cached": 0.7163,
+      "cost_per_1m_out_cached": 0.7163,
+      "context_window": 1048576,
+      "default_max_tokens": 104857,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "high",
+        "max"
+      ],
+      "default_reasoning_effort": "max",
+      "supports_attachments": true
+    },
+    {
+      "id": "minimax-latest",
+      "name": "MiniMax Latest",
+      "cost_per_1m_in": 0.1063,
+      "cost_per_1m_out": 0.1063,
+      "cost_per_1m_in_cached": 0.1063,
+      "cost_per_1m_out_cached": 0.1063,
+      "context_window": 1000000,
+      "default_max_tokens": 100000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "supports_attachments": false
+    },
+    {
+      "id": "text-max",
+      "name": "Text Max",
+      "cost_per_1m_in": 1.6257,
+      "cost_per_1m_out": 1.6257,
+      "cost_per_1m_in_cached": 1.6257,
+      "cost_per_1m_out_cached": 1.6257,
+      "context_window": 1000000,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "supports_attachments": true
+    },
+    {
+      "id": "text-prime",
+      "name": "Text Prime",
+      "cost_per_1m_in": 0.1009,
+      "cost_per_1m_out": 0.1009,
+      "cost_per_1m_in_cached": 0.1009,
+      "cost_per_1m_out_cached": 0.1009,
+      "context_window": 196608,
+      "default_max_tokens": 19660,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    },
+    {
+      "id": "text-standard",
+      "name": "Text Standard",
+      "cost_per_1m_in": 0.0302,
+      "cost_per_1m_out": 0.0302,
+      "cost_per_1m_in_cached": 0.0302,
+      "cost_per_1m_out_cached": 0.0302,
+      "context_window": 128000,
+      "default_max_tokens": 12800,
+      "can_reason": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "default_reasoning_effort": "medium",
+      "supports_attachments": false
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -111,6 +111,9 @@ var scalewayConfig []byte
 //go:embed configs/synthetic.json
 var syntheticConfig []byte
 
+//go:embed configs/thegrid.json
+var theGridConfig []byte
+
 //go:embed configs/vercel.json
 var vercelConfig []byte
 
@@ -175,6 +178,7 @@ var providerRegistry = []ProviderFunc{
 	openRouterProvider,
 	qiniuCloudProvider,
 	scalewayProvider,
+	theGridProvider,
 	vercelProvider,
 	veniceProvider,
 	vertexAIProvider,
@@ -334,6 +338,10 @@ func scalewayProvider() catwalk.Provider {
 
 func syntheticProvider() catwalk.Provider {
 	return loadProviderFromConfig(syntheticConfig)
+}
+
+func theGridProvider() catwalk.Provider {
+	return loadProviderFromConfig(theGridConfig)
 }
 
 func vercelProvider() catwalk.Provider {

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -60,6 +60,7 @@ const (
 	InferenceProviderBaseten          InferenceProvider = "baseten"
 	InferenceProviderMoonshot         InferenceProvider = "moonshot"
 	InferenceProviderAtlasCloud       InferenceProvider = "atlascloud"
+	InferenceProviderTheGrid          InferenceProvider = "thegrid"
 )
 
 // Provider represents an AI provider configuration.
@@ -140,6 +141,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderBaseten,
 		InferenceProviderMoonshot,
 		InferenceProviderAtlasCloud,
+		InferenceProviderTheGrid,
 	}
 }
 


### PR DESCRIPTION
Adds [The Grid](https://thegrid.ai) as a provider.

**Disclosure:** I work on The Grid.

This replaces #480, which was opened from a personal fork I can't push to. That branch is 148 commits behind `main`, and its `govulncheck` failure came from the stale dependency set it carried rather than from anything in the change. Rebuilt on current `main` here; `govulncheck` reports **No vulnerabilities found**. Happy for #480 to be closed in favour of this.

### What The Grid is

A spot market for inference. Instrument ids name a task type and a quality tier — `text-standard`, `code-prime`, `agent-max` — rather than a fixed model, plus lab-scoped markets like `claude-opus-latest`. Each request is filled by whichever supplier is competitive at the time, so **the model that serves a request differs from the instrument requested**.

### Generated, not hand-written

That last point is why this PR adds `cmd/thegrid` rather than a static config. Prices are set by a live market, so a hand-maintained JSON is stale almost immediately — concretely, `agent-max` moved from `1.5885` to `1.5532` to `1.5195` per 1M tokens over the course of preparing this change.

`cmd/thegrid/main.go` follows `cmd/atlascloud` and reads `GET /v1/models` (public, no key required), and it's wired into `.github/workflows/update.yml` alongside the other generators, so the entry refreshes every six hours without anyone touching it.

The generator picks up per-instrument metadata the API publishes:

- `reasoning_levels` and `default_reasoning_effort` from the instrument's `reasoning` block
- `supports_attachments` from `attachments` / `input_modalities` — image input is available on the `max` tier and most lab-scoped instruments, not on `standard` or `prime`
- a single market rate applied to all four cost fields, since The Grid quotes one price covering both directions and does not quote a separate cached rate

`default_max_tokens` uses the same heuristic as `cmd/atlascloud` — half of `max_completion_tokens`, capped at 15% of context, else 10% of context. That matters here because a couple of instruments report a completion ceiling equal to their whole context window, and taking it literally would default to an output budget the size of the context.

### Checks

`go build`, `go vet`, `go test ./...` and `gofmt` all clean; `govulncheck ./...` reports no vulnerabilities. Config regenerated from the live API immediately before committing.
