### PR TITLE
fix: add missing providers to KnownProviders

### DIFF
--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -3,6 +3,8 @@ package providers
 import (
 	"slices"
 	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
 )
 
 func TestValidDefaultModels(t *testing.T) {
@@ -19,5 +21,23 @@ func TestValidDefaultModels(t *testing.T) {
 				t.Errorf("Default small model %q not found in provider %q", p.DefaultSmallModelID, p.Name)
 			}
 		})
+	}
+}
+
+func TestKnownProvidersMatchesRegistry(t *testing.T) {
+	known := catwalk.KnownProviders()
+
+	registered := make([]catwalk.InferenceProvider, 0, len(providerRegistry))
+	for _, p := range GetAll() {
+		registered = append(registered, p.ID)
+		if !slices.Contains(known, p.ID) {
+			t.Errorf("Provider %q is registered but missing from catwalk.KnownProviders()", p.ID)
+		}
+	}
+
+	for _, id := range known {
+		if !slices.Contains(registered, id) {
+			t.Errorf("Provider %q is in catwalk.KnownProviders() but is not registered", id)
+		}
 	}
 }

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -60,6 +60,8 @@ const (
 	InferenceProviderBaseten          InferenceProvider = "baseten"
 	InferenceProviderMoonshot         InferenceProvider = "moonshot"
 	InferenceProviderAtlasCloud       InferenceProvider = "atlascloud"
+	InferenceProviderCoralBricks      InferenceProvider = "coralbricks"
+	InferenceProviderScaleway         InferenceProvider = "scaleway"
 )
 
 // Provider represents an AI provider configuration.
@@ -115,6 +117,7 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderVertexAI,
 		InferenceProviderXAI,
 		InferenceProviderZAI,
+		InferenceProviderDeepSeek,
 		InferenceProviderZhipu,
 		InferenceProviderZhipuCoding,
 		InferenceProviderGROQ,
@@ -130,16 +133,21 @@ func KnownProviders() []InferenceProvider {
 		InferenceProviderVercel,
 		InferenceProviderMiniMax,
 		InferenceProviderMiniMaxChina,
+		InferenceProviderIoNet,
 		InferenceProviderQiniuCloud,
 		InferenceProviderAvian,
 		InferenceProviderNebius,
 		InferenceProviderNeuralwatt,
 		InferenceProviderOpenCodeZen,
 		InferenceProviderOpenCodeGo,
+		InferenceProviderAlibabaSingapore,
+		InferenceProviderAlibabaUS,
 		InferenceProviderFireworks,
 		InferenceProviderBaseten,
 		InferenceProviderMoonshot,
 		InferenceProviderAtlasCloud,
+		InferenceProviderCoralBricks,
+		InferenceProviderScaleway,
 	}
 }
 


### PR DESCRIPTION
`catwalk.KnownProviders()` returns 35 providers. `embedded.GetAll()` returns 41. The six it leaves out are `deepseek`, `ionet`, `alibaba-singapore`, `alibaba-us`, `coralbricks` and `scaleway`.

All six are in `providerRegistry` in `internal/providers/providers.go` with embedded configs, so the catalog serves them, but the slice returned by `KnownProviders()` in `pkg/catwalk/provider.go:106-144` never picked them up. `InferenceProviderDeepSeek`, `InferenceProviderIoNet`, `InferenceProviderAlibabaSingapore` and `InferenceProviderAlibabaUS` are declared in the constant block right above it and just not listed. `coralbricks` and `scaleway` have no constant at all.

Everywhere else the constant and the `KnownProviders` entry move together: atlascloud (#463), moonshot (#325), fireworks (#373) and baseten each added both in one commit, and the Lambda (#79) and z.ai coding (#66) removals took both out. These six missed the second half.

This adds `InferenceProviderCoralBricks` and `InferenceProviderScaleway`, then puts all six into `KnownProviders` at the position that mirrors the constant block, so the two lists read in the same order. `KnownProviders()` now returns 41.

`TestKnownProvidersMatchesRegistry` in `internal/providers/providers_test.go` checks both directions, since a stale entry left behind after a provider is dropped is the same class of bug as a missing one.

Verified on macOS arm64 with the go 1.26.6 toolchain from `go.mod`. The test on the branch with `pkg/catwalk/provider.go` reverted to main:

```
$ go test ./internal/providers/ -run TestKnownProvidersMatchesRegistry -v
    providers_test.go:34: Provider "alibaba-singapore" is registered but missing from catwalk.KnownProviders()
    providers_test.go:34: Provider "alibaba-us" is registered but missing from catwalk.KnownProviders()
    providers_test.go:34: Provider "coralbricks" is registered but missing from catwalk.KnownProviders()
    providers_test.go:34: Provider "deepseek" is registered but missing from catwalk.KnownProviders()
    providers_test.go:34: Provider "ionet" is registered but missing from catwalk.KnownProviders()
    providers_test.go:34: Provider "scaleway" is registered but missing from catwalk.KnownProviders()
--- FAIL: TestKnownProvidersMatchesRegistry (0.01s)
```

And with the fix in place:

```
$ go test ./...
ok      charm.land/catwalk/internal/providers   0.251s

$ go build ./... && go vet ./...
(clean)

$ golangci-lint run ./...          # v2.13.1, repo .golangci.yml
0 issues.

$ golangci-lint fmt --diff ./...   # gofumpt + goimports
(no diff)
```
