### PR TITLE
chore: add daoxe provider

### DIFF
--- a/internal/providers/configs/daoxe.json
+++ b/internal/providers/configs/daoxe.json
@@ -1,0 +1,164 @@
+{
+  "name": "DaoXE",
+  "id": "daoxe",
+  "api_key": "$DAOXE_API_KEY",
+  "api_endpoint": "https://daoxe.com/v1",
+  "type": "openai-compat",
+  "default_large_model_id": "claude-sonnet-4-6",
+  "default_small_model_id": "claude-haiku-4-5-20251001",
+  "models": [
+    {
+      "id": "claude-sonnet-4-6",
+      "name": "Claude Sonnet 4.6",
+      "cost_per_1m_in": 3,
+      "cost_per_1m_out": 15,
+      "cost_per_1m_in_cached": 3.75,
+      "cost_per_1m_out_cached": 0.3,
+      "context_window": 1000000,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    {
+      "id": "grok-4.3",
+      "name": "Grok 4.3",
+      "cost_per_1m_in": 1.25,
+      "cost_per_1m_out": 2.5,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.2,
+      "context_window": 1000000,
+      "default_max_tokens": 30000,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    {
+      "id": "gemini-3.1-pro-preview",
+      "name": "Gemini 3.1 Pro Preview",
+      "cost_per_1m_in": 2,
+      "cost_per_1m_out": 12,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.2,
+      "context_window": 1048576,
+      "default_max_tokens": 65536,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    {
+      "id": "grok-4.5",
+      "name": "Grok 4.5",
+      "cost_per_1m_in": 2,
+      "cost_per_1m_out": 6,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.5,
+      "context_window": 500000,
+      "default_max_tokens": 500000,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    {
+      "id": "gpt-5.4",
+      "name": "GPT-5.4",
+      "cost_per_1m_in": 2.5,
+      "cost_per_1m_out": 15,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.25,
+      "context_window": 1050000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    {
+      "id": "claude-haiku-4-5-20251001",
+      "name": "Claude Haiku 4.5",
+      "cost_per_1m_in": 1,
+      "cost_per_1m_out": 5,
+      "cost_per_1m_in_cached": 5,
+      "cost_per_1m_out_cached": 0.1,
+      "context_window": 200000,
+      "default_max_tokens": 64000,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    {
+      "id": "kimi-k2.5",
+      "name": "Kimi K2.5",
+      "cost_per_1m_in": 0.6,
+      "cost_per_1m_out": 3,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.1,
+      "context_window": 262144,
+      "default_max_tokens": 262144,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    {
+      "id": "claude-opus-4-8",
+      "name": "Claude Opus 4.8",
+      "cost_per_1m_in": 5,
+      "cost_per_1m_out": 25,
+      "cost_per_1m_in_cached": 6.25,
+      "cost_per_1m_out_cached": 0.5,
+      "context_window": 1000000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    {
+      "id": "gpt-5.5",
+      "name": "GPT-5.5",
+      "cost_per_1m_in": 5,
+      "cost_per_1m_out": 30,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0.5,
+      "context_window": 1050000,
+      "default_max_tokens": 128000,
+      "can_reason": true,
+      "supports_attachments": true,
+      "reasoning_levels": [
+        "low",
+        "medium",
+        "high"
+      ]
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -48,6 +48,9 @@ var chutesConfig []byte
 //go:embed configs/coralbricks.json
 var coralBricksConfig []byte
 
+//go:embed configs/daoxe.json
+var daoxeConfig []byte
+
 //go:embed configs/copilot.json
 var copilotConfig []byte
 
@@ -163,6 +166,7 @@ var providerRegistry = []ProviderFunc{
 	coralBricksProvider,
 	copilotProvider,
 	cortecsProvider,
+	daoxeProvider,
 	deepSeekProvider,
 	fireworksProvider,
 	groqProvider,
@@ -254,6 +258,10 @@ func coralBricksProvider() catwalk.Provider {
 
 func copilotProvider() catwalk.Provider {
 	return loadProviderFromConfig(copilotConfig)
+}
+
+func daoxeProvider() catwalk.Provider {
+	return loadProviderFromConfig(daoxeConfig)
 }
 
 func cortecsProvider() catwalk.Provider {


### PR DESCRIPTION
## What

Adds **DaoXE** as an inference provider — an OpenAI-compatible multi-model
gateway (Claude, GPT, Gemini, Grok, Kimi and more behind a single key).

Endpoint `https://daoxe.com/v1`, key `$DAOXE_API_KEY`, type `openai-compat`.
Default models: `claude-sonnet-4-6` (large) and `claude-haiku-4-5-20251001` (small).

Disclosure: I'm affiliated with DaoXE. Model data comes from DaoXE's published
catalog on models.dev (`providers/daoxe`), so every id / context window / cost
below is already public and independently verifiable there.

## Follows the existing pattern

- `internal/providers/configs/daoxe.json` (mirrors the other `openai-compat` configs, e.g. coralbricks)
- `//go:embed` + `daoxeProvider()` + `providerRegistry` entry in `internal/providers/providers.go`

## Verified

- `go build ./...` clean
- `go test ./internal/providers/` green (validates default model ids resolve)
- `gofmt` / `go vet` clean

One mapping note: catwalk's `cost_per_1m_in_cached` = cache *write* and
`cost_per_1m_out_cached` = cache *read* (per the comment in cmd/vercel/main.go);
values were mapped from models.dev's `cache_write` / `cache_read` accordingly.
`default_reasoning_effort` is intentionally omitted — models.dev publishes the
effort levels but not a default, and I didn't want to guess.
