### PR TITLE
feat(coralbricks): add GLM 5.3 Flash

### DIFF
--- a/internal/providers/configs/coralbricks.json
+++ b/internal/providers/configs/coralbricks.json
@@ -20,6 +20,18 @@
       "supports_attachments": false
     },
     {
+      "id": "glm-5.3-flash-fp4",
+      "name": "GLM 5.3 Flash",
+      "cost_per_1m_in": 0.15,
+      "cost_per_1m_out": 0.5,
+      "cost_per_1m_in_cached": 0,
+      "cost_per_1m_out_cached": 0,
+      "context_window": 1048576,
+      "default_max_tokens": 32768,
+      "can_reason": true,
+      "supports_attachments": true
+    },
+    {
       "id": "kimi-k3",
       "name": "Kimi K3",
       "cost_per_1m_in": 3,


### PR DESCRIPTION
Adds GLM 5.3 Flash (`glm-5.3-flash-fp4`) to the CoralBricks provider config — a cheap, fast 1M-context model we launched this week.

| field | value |
|---|---|
| context | 1,048,576 (1M) |
| input | $0.15 / M |
| output | $0.50 / M |
| cached input | free |
| reasoning | yes |
| attachments | yes (vision) |

Verified live against the gateway with a chat smoke and an image-input smoke (the API returns `image_tokens`, so `supports_attachments: true` is accurate). `go build ./internal/providers/...` is green. Defaults are unchanged.

Thanks again for merging #502 — CoralBricks has been live in Crush since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)