### PR TITLE
feat: pricing overrides

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -21,17 +21,31 @@
 - File permissions: Use 0o600 for sensitive config files
 - Always format code with `gofumpt`
 
-## Model cost fields
+## Model pricing
 
-The cached cost fields in provider configs are counterintuitive:
+Model pricing lives in a nested `pricing` object and is in **dollars per
+1M tokens**:
 
-- `cost_per_1m_in_cached` = cache **creation** (write) price
-- `cost_per_1m_out_cached` = cache **read** price
+```json
+"pricing": {
+  "input": 10,
+  "output": 50,
+  "cache_create": 12.5,
+  "cache_hit": 0.25
+}
+```
+
+Provider pages usually quote per-million prices (e.g. "$3/M") — that is
+exactly what goes in the config.
+
+- `cache_create` = cache **creation** (write) price
+- `cache_hit` = cache **read** price
 
 Providers usually advertise a single discounted "cached" price (e.g.
 "$0.044/M cached") — that is the cache **read** price, so it goes in
-`cost_per_1m_out_cached`. Leave `cost_per_1m_in_cached` at 0 unless the
-provider explicitly prices cache writes (Anthropic-style).
+`cache_hit`. Omit `cache_create` (or leave it at 0) unless the provider
+explicitly prices cache writes (Anthropic-style). Zero-valued cache fields
+are omitted from the configs.
 
 ## Adding more provider commands
 

--- a/cmd/aihubmix/main.go
+++ b/cmd/aihubmix/main.go
@@ -104,7 +104,7 @@ func parseFloat(p *float64) float64 {
 	if p == nil {
 		return 0
 	}
-	return roundCost(*p)
+	return *p
 }
 
 func calculateMaxTokens(contextLength, maxOutput, factor int64) int64 {
@@ -155,12 +155,14 @@ func main() {
 		maxTokens := calculateMaxTokens(model.ContextLength, model.MaxOutput, maxTokensFactor)
 
 		aiHubMixProvider.Models = append(aiHubMixProvider.Models, catwalk.Model{
-			ID:                     model.ModelID,
-			Name:                   model.ModelName,
-			CostPer1MIn:            parseFloat(model.Pricing.Input),
-			CostPer1MOut:           parseFloat(model.Pricing.Output),
-			CostPer1MInCached:      parseFloat(model.Pricing.CacheWrite),
-			CostPer1MOutCached:     parseFloat(model.Pricing.CacheRead),
+			ID:   model.ModelID,
+			Name: model.ModelName,
+			Pricing: catwalk.Pricing{
+				Input:       roundCost(parseFloat(model.Pricing.Input)),
+				Output:      roundCost(parseFloat(model.Pricing.Output)),
+				CacheCreate: roundCost(parseFloat(model.Pricing.CacheWrite)),
+				CacheHit:    roundCost(parseFloat(model.Pricing.CacheRead)),
+			},
 			ContextWindow:          model.ContextLength,
 			DefaultMaxTokens:       maxTokens,
 			CanReason:              canReason,

--- a/cmd/aihubmix/main.go
+++ b/cmd/aihubmix/main.go
@@ -168,7 +168,7 @@ func main() {
 			CanReason:              canReason,
 			ReasoningLevels:        reasoningLevels,
 			DefaultReasoningEffort: defaultReasoning,
-			SupportsImages:         supportsImages,
+			Capabilities:           catwalk.Capabilities{Vision: supportsImages},
 		})
 	}
 

--- a/cmd/atlascloud/main.go
+++ b/cmd/atlascloud/main.go
@@ -192,7 +192,7 @@ func main() {
 			},
 			ContextWindow:    model.ContextLength,
 			DefaultMaxTokens: defaultMaxTokens,
-			SupportsImages:   supportsImages,
+			Capabilities:     catwalk.Capabilities{Vision: supportsImages},
 		}
 
 		atlasCloudProvider.Models = append(atlasCloudProvider.Models, m)

--- a/cmd/atlascloud/main.go
+++ b/cmd/atlascloud/main.go
@@ -161,9 +161,9 @@ func main() {
 		}
 
 		priceMultiplier := 1 - model.DiscountToUser
-		costPer1MIn := roundCost(parsePrice(pricing.Prompt) * priceMultiplier * 1_000_000)
-		costPer1MOut := roundCost(parsePrice(pricing.Completion) * priceMultiplier * 1_000_000)
-		costPer1MCacheRead := roundCost(parsePrice(pricing.InputCacheRead) * priceMultiplier * 1_000_000)
+		costPerTokenIn := roundCost(parsePrice(pricing.Prompt) * priceMultiplier * 1_000_000)
+		costPerTokenOut := roundCost(parsePrice(pricing.Completion) * priceMultiplier * 1_000_000)
+		costPerTokenCacheRead := roundCost(parsePrice(pricing.InputCacheRead) * priceMultiplier * 1_000_000)
 
 		supportsImages := slices.Contains(model.InputModalities, "image")
 
@@ -183,14 +183,16 @@ func main() {
 		}
 
 		m := catwalk.Model{
-			ID:                 model.ID,
-			Name:               model.Name,
-			CostPer1MIn:        costPer1MIn,
-			CostPer1MOut:       costPer1MOut,
-			CostPer1MOutCached: costPer1MCacheRead,
-			ContextWindow:      model.ContextLength,
-			DefaultMaxTokens:   defaultMaxTokens,
-			SupportsImages:     supportsImages,
+			ID:   model.ID,
+			Name: model.Name,
+			Pricing: catwalk.Pricing{
+				Input:    costPerTokenIn,
+				Output:   costPerTokenOut,
+				CacheHit: costPerTokenCacheRead,
+			},
+			ContextWindow:    model.ContextLength,
+			DefaultMaxTokens: defaultMaxTokens,
+			SupportsImages:   supportsImages,
 		}
 
 		atlasCloudProvider.Models = append(atlasCloudProvider.Models, m)

--- a/cmd/avian/main.go
+++ b/cmd/avian/main.go
@@ -90,12 +90,13 @@ func main() {
 		}
 
 		m := catwalk.Model{
-			ID:                     model.ID,
-			Name:                   model.DisplayName,
-			CostPer1MIn:            model.Pricing.InputPerMillion,
-			CostPer1MOut:           model.Pricing.OutputPerMillion,
-			CostPer1MInCached:      model.Pricing.CacheReadPerMillion,
-			CostPer1MOutCached:     0,
+			ID:   model.ID,
+			Name: model.DisplayName,
+			Pricing: catwalk.Pricing{
+				Input:    model.Pricing.InputPerMillion,
+				Output:   model.Pricing.OutputPerMillion,
+				CacheHit: model.Pricing.CacheReadPerMillion,
+			},
 			ContextWindow:          model.ContextLength,
 			DefaultMaxTokens:       model.MaxOutput,
 			CanReason:              model.Reasoning,

--- a/cmd/avian/main.go
+++ b/cmd/avian/main.go
@@ -102,7 +102,7 @@ func main() {
 			CanReason:              model.Reasoning,
 			ReasoningLevels:        reasoningLevels,
 			DefaultReasoningEffort: defaultReasoning,
-			SupportsImages:         false,
+			Capabilities:           catwalk.Capabilities{Vision: false},
 		}
 
 		avianProvider.Models = append(avianProvider.Models, m)

--- a/cmd/baseten/main.go
+++ b/cmd/baseten/main.go
@@ -171,12 +171,13 @@ func main() {
 		}
 
 		m := catwalk.Model{
-			ID:                     model.ID,
-			Name:                   model.Name,
-			CostPer1MIn:            parsePrice(model.Pricing.Prompt),
-			CostPer1MOut:           parsePrice(model.Pricing.Completion),
-			CostPer1MInCached:      0,
-			CostPer1MOutCached:     parsePrice(model.Pricing.InputCacheRead),
+			ID:   model.ID,
+			Name: model.Name,
+			Pricing: catwalk.Pricing{
+				Input:    parsePrice(model.Pricing.Prompt),
+				Output:   parsePrice(model.Pricing.Completion),
+				CacheHit: parsePrice(model.Pricing.InputCacheRead),
+			},
 			ContextWindow:          model.ContextLength,
 			DefaultMaxTokens:       maxTokens,
 			CanReason:              canReason,

--- a/cmd/baseten/main.go
+++ b/cmd/baseten/main.go
@@ -183,7 +183,7 @@ func main() {
 			CanReason:              canReason,
 			ReasoningLevels:        reasoningLevels,
 			DefaultReasoningEffort: defaultReasoning,
-			SupportsImages:         hasModality(model, "image"),
+			Capabilities:           catwalk.Capabilities{Vision: hasModality(model, "image")},
 		}
 
 		basetenProvider.Models = append(basetenProvider.Models, m)

--- a/cmd/chutes/main.go
+++ b/cmd/chutes/main.go
@@ -122,7 +122,7 @@ func main() {
 			CanReason:              canReason,
 			DefaultReasoningEffort: defaultReasoning,
 			ReasoningLevels:        reasoningLevels,
-			SupportsImages:         hasModality(m, "image"),
+			Capabilities:           catwalk.Capabilities{Vision: hasModality(m, "image")},
 		}
 		models = append(models, model)
 	}

--- a/cmd/chutes/main.go
+++ b/cmd/chutes/main.go
@@ -110,11 +110,13 @@ func main() {
 		}
 
 		model := catwalk.Model{
-			ID:                     m.ID,
-			Name:                   modelDisplayName(m.ID),
-			CostPer1MIn:            roundCost(m.Pricing.Prompt),
-			CostPer1MOut:           roundCost(m.Pricing.Completion),
-			CostPer1MInCached:      roundCost(m.Pricing.InputCacheRead),
+			ID:   m.ID,
+			Name: modelDisplayName(m.ID),
+			Pricing: catwalk.Pricing{
+				Input:    roundCost(m.Pricing.Prompt),
+				Output:   roundCost(m.Pricing.Completion),
+				CacheHit: roundCost(m.Pricing.InputCacheRead),
+			},
 			ContextWindow:          m.ContextLength,
 			DefaultMaxTokens:       m.MaxOutputLength,
 			CanReason:              canReason,

--- a/cmd/copilot/main.go
+++ b/cmd/copilot/main.go
@@ -251,7 +251,7 @@ func modelToCatwalk(m Model) catwalk.Model {
 		Name:             m.Name,
 		DefaultMaxTokens: int64(m.Capabilities.Limits.MaxOutputTokens),
 		ContextWindow:    int64(m.Capabilities.Limits.MaxContextWindowTokens),
-		SupportsImages:   m.Capabilities.Supports.Vision,
+		Capabilities:     catwalk.Capabilities{Vision: m.Capabilities.Supports.Vision},
 	}
 }
 

--- a/cmd/cortecs/main.go
+++ b/cmd/cortecs/main.go
@@ -143,7 +143,7 @@ func main() {
 			CanReason:              canReason,
 			DefaultReasoningEffort: defaultReasoning,
 			ReasoningLevels:        reasoningLevels,
-			SupportsImages:         model.hasTag("Image"),
+			Capabilities:           catwalk.Capabilities{Vision: model.hasTag("Image")},
 		}
 		models = append(models, model)
 	}

--- a/cmd/cortecs/main.go
+++ b/cmd/cortecs/main.go
@@ -132,13 +132,13 @@ func main() {
 		}
 
 		model := catwalk.Model{
-			ID:                     model.ID,
-			Name:                   model.ID,
-			ContextWindow:          detailData.ContextSize,
-			CostPer1MIn:            detailData.Pricing.InputToken,
-			CostPer1MOut:           detailData.Pricing.OutputToken,
-			CostPer1MInCached:      0,
-			CostPer1MOutCached:     0,
+			ID:            model.ID,
+			Name:          model.ID,
+			ContextWindow: detailData.ContextSize,
+			Pricing: catwalk.Pricing{
+				Input:  detailData.Pricing.InputToken,
+				Output: detailData.Pricing.OutputToken,
+			},
 			DefaultMaxTokens:       model.ContextSize / 10,
 			CanReason:              canReason,
 			DefaultReasoningEffort: defaultReasoning,

--- a/cmd/huggingface/main.go
+++ b/cmd/huggingface/main.go
@@ -155,26 +155,26 @@ func main() {
 			}
 
 			// Calculate pricing (convert from per-token to per-1M tokens)
-			var costPer1MIn, costPer1MOut float64
+			var costPerTokenIn, costPerTokenOut float64
 			if provider.Pricing != nil {
-				costPer1MIn = math.Round(provider.Pricing.Input*1e5) / 1e5
-				costPer1MOut = math.Round(provider.Pricing.Output*1e5) / 1e5
+				costPerTokenIn = math.Round(provider.Pricing.Input*1e5) / 1e5
+				costPerTokenOut = math.Round(provider.Pricing.Output*1e5) / 1e5
 			}
 
 			// Set default max tokens (conservative estimate)
 			defaultMaxTokens := min(contextLength/4, 8192)
 
 			m := catwalk.Model{
-				ID:                 modelID,
-				Name:               modelName,
-				CostPer1MIn:        costPer1MIn,
-				CostPer1MOut:       costPer1MOut,
-				CostPer1MInCached:  0, // Not provided by HF Router
-				CostPer1MOutCached: 0, // Not provided by HF Router
-				ContextWindow:      contextLength,
-				DefaultMaxTokens:   defaultMaxTokens,
-				CanReason:          false, // Not provided by HF Router
-				SupportsImages:     false, // Not provided by HF Router
+				ID:   modelID,
+				Name: modelName,
+				Pricing: catwalk.Pricing{
+					Input:  costPerTokenIn,
+					Output: costPerTokenOut,
+				},
+				ContextWindow:    contextLength,
+				DefaultMaxTokens: defaultMaxTokens,
+				CanReason:        false, // Not provided by HF Router
+				SupportsImages:   false, // Not provided by HF Router
 			}
 
 			hfProvider.Models = append(hfProvider.Models, m)

--- a/cmd/huggingface/main.go
+++ b/cmd/huggingface/main.go
@@ -173,8 +173,8 @@ func main() {
 				},
 				ContextWindow:    contextLength,
 				DefaultMaxTokens: defaultMaxTokens,
-				CanReason:        false, // Not provided by HF Router
-				SupportsImages:   false, // Not provided by HF Router
+				CanReason:        false,                               // Not provided by HF Router
+				Capabilities:     catwalk.Capabilities{Vision: false}, // Not provided by HF Router
 			}
 
 			hfProvider.Models = append(hfProvider.Models, m)

--- a/cmd/ionet/main.go
+++ b/cmd/ionet/main.go
@@ -79,12 +79,11 @@ func main() {
 			defaultReasoning = "medium"
 		}
 
-		// Convert token prices (per token) to cost per 1M tokens
 		roundCost := func(v float64) float64 { return math.Round(v*1e5) / 1e5 }
-		costPer1MIn := roundCost(model.InputTokenPrice * 1_000_000)
-		costPer1MOut := roundCost(model.OutputTokenPrice * 1_000_000)
-		costPer1MInCached := roundCost(model.CacheReadTokenPrice * 1_000_000)
-		costPer1MOutCached := roundCost(model.CacheWriteTokenPrice * 1_000_000)
+		costPerTokenIn := roundCost(model.InputTokenPrice * 1_000_000)
+		costPerTokenOut := roundCost(model.OutputTokenPrice * 1_000_000)
+		costCacheCreate := roundCost(model.CacheWriteTokenPrice * 1_000_000)
+		costCacheHit := roundCost(model.CacheReadTokenPrice * 1_000_000)
 
 		switch model.ID {
 		case "google/gemma-4-26b-a4b-it":
@@ -92,12 +91,14 @@ func main() {
 		}
 
 		m := catwalk.Model{
-			ID:                     model.ID,
-			Name:                   model.Name,
-			CostPer1MIn:            costPer1MIn,
-			CostPer1MOut:           costPer1MOut,
-			CostPer1MInCached:      costPer1MInCached,
-			CostPer1MOutCached:     costPer1MOutCached,
+			ID:   model.ID,
+			Name: model.Name,
+			Pricing: catwalk.Pricing{
+				Input:       costPerTokenIn,
+				Output:      costPerTokenOut,
+				CacheCreate: costCacheCreate,
+				CacheHit:    costCacheHit,
+			},
 			ContextWindow:          int64(model.ContextWindow),
 			DefaultMaxTokens:       int64(cmp.Or(model.MaxTokens, model.ContextWindow) / 10),
 			CanReason:              isReasoningModel(model.ID),

--- a/cmd/ionet/main.go
+++ b/cmd/ionet/main.go
@@ -104,7 +104,7 @@ func main() {
 			CanReason:              isReasoningModel(model.ID),
 			ReasoningLevels:        reasoningLevels,
 			DefaultReasoningEffort: defaultReasoning,
-			SupportsImages:         model.SupportsImagesInput,
+			Capabilities:           catwalk.Capabilities{Vision: model.SupportsImagesInput},
 		}
 
 		provider.Models = append(provider.Models, m)

--- a/cmd/nebius/main.go
+++ b/cmd/nebius/main.go
@@ -146,7 +146,7 @@ func main() {
 			CanReason:              canReason,
 			ReasoningLevels:        reasoningLevels,
 			DefaultReasoningEffort: defaultReasoning,
-			SupportsImages:         supportsImages,
+			Capabilities:           catwalk.Capabilities{Vision: supportsImages},
 		}
 
 		nebiusProvider.Models = append(nebiusProvider.Models, m)

--- a/cmd/nebius/main.go
+++ b/cmd/nebius/main.go
@@ -107,21 +107,21 @@ func main() {
 		}
 
 		// Convert pricing from string to float64
-		var costPer1MIn, costPer1MOut float64
+		var costPerTokenIn, costPerTokenOut float64
 
 		// Handle prompt price conversion
 		promptPrice, err := strconv.ParseFloat(model.Pricing.Prompt, 64)
 		if err != nil {
 			promptPrice = 0.0
 		}
-		costPer1MIn = math.Round(promptPrice*1_000_000*100) / 100 // Round to 2 decimal places
+		costPerTokenIn = math.Round(promptPrice*1_000_000*100) / 100 // Round to 2 decimal places
 
 		// Handle completion price conversion
 		completionPrice, err := strconv.ParseFloat(model.Pricing.Completion, 64)
 		if err != nil {
 			completionPrice = 0.0
 		}
-		costPer1MOut = math.Round(completionPrice*1_000_000*100) / 100 // Round to 2 decimal places
+		costPerTokenOut = math.Round(completionPrice*1_000_000*100) / 100 // Round to 2 decimal places
 
 		var (
 			supportsImages   = strings.Contains(strings.ToLower(model.Architecture.Modality), "image")
@@ -135,12 +135,12 @@ func main() {
 		}
 
 		m := catwalk.Model{
-			ID:                     model.ID,
-			Name:                   model.DisplayName,
-			CostPer1MIn:            costPer1MIn,
-			CostPer1MOut:           costPer1MOut,
-			CostPer1MInCached:      0,
-			CostPer1MOutCached:     0,
+			ID:   model.ID,
+			Name: model.DisplayName,
+			Pricing: catwalk.Pricing{
+				Input:  costPerTokenIn,
+				Output: costPerTokenOut,
+			},
 			ContextWindow:          model.ContextLength,
 			DefaultMaxTokens:       model.ContextLength / 10, // there is no MaxTokens exposed, so play safe
 			CanReason:              canReason,

--- a/cmd/neuralwatt/main.go
+++ b/cmd/neuralwatt/main.go
@@ -140,8 +140,8 @@ func main() {
 
 		costIn := ptrDeref(meta.Pricing.InputPerMillion, 0)
 		costOut := ptrDeref(meta.Pricing.OutputPerMillion, 0)
-		costInCached := ptrDeref(meta.Pricing.CachedInputPerMillion, 0)
-		costOutCached := ptrDeref(meta.Pricing.CachedOutputPerMillion, 0)
+		costCacheCreate := ptrDeref(meta.Pricing.CachedInputPerMillion, 0)
+		costCacheHit := ptrDeref(meta.Pricing.CachedOutputPerMillion, 0)
 
 		var defaultMaxTokens int64
 		if meta.Limits.MaxOutputTokens != nil {
@@ -168,12 +168,14 @@ func main() {
 		}
 
 		m := catwalk.Model{
-			ID:                     model.ID,
-			Name:                   name,
-			CostPer1MIn:            roundCost(costIn),
-			CostPer1MOut:           roundCost(costOut),
-			CostPer1MInCached:      roundCost(costInCached),
-			CostPer1MOutCached:     roundCost(costOutCached),
+			ID:   model.ID,
+			Name: name,
+			Pricing: catwalk.Pricing{
+				Input:       roundCost(costIn),
+				Output:      roundCost(costOut),
+				CacheCreate: roundCost(costCacheCreate),
+				CacheHit:    roundCost(costCacheHit),
+			},
 			ContextWindow:          model.MaxModelLen,
 			DefaultMaxTokens:       defaultMaxTokens,
 			CanReason:              meta.Capabilities.Reasoning,

--- a/cmd/neuralwatt/main.go
+++ b/cmd/neuralwatt/main.go
@@ -181,7 +181,7 @@ func main() {
 			CanReason:              meta.Capabilities.Reasoning,
 			DefaultReasoningEffort: defaultReasoning,
 			ReasoningLevels:        reasoningLevels,
-			SupportsImages:         meta.Capabilities.Vision,
+			Capabilities:           catwalk.Capabilities{Vision: meta.Capabilities.Vision},
 		}
 
 		neuralwattProvider.Models = append(neuralwattProvider.Models, m)

--- a/cmd/opencode-go/main.go
+++ b/cmd/opencode-go/main.go
@@ -95,9 +95,9 @@ func main() {
 	}
 
 	for _, goModel := range goModels {
-		costPer1MIn := math.Round(goModel.Cost.Input*100) / 100
-		costPer1MOut := math.Round(goModel.Cost.Output*100) / 100
-		costPer1MInCached := math.Round(goModel.Cost.CacheRead*100) / 100
+		costPerTokenIn := math.Round(goModel.Cost.Input*100) / 100
+		costPerTokenOut := math.Round(goModel.Cost.Output*100) / 100
+		costCacheHit := math.Round(goModel.Cost.CacheRead*100) / 100
 
 		var reasoningLevels []string
 		var defaultReasoningEffort string
@@ -125,11 +125,13 @@ func main() {
 		}
 
 		m := catwalk.Model{
-			ID:                     goModel.ID,
-			Name:                   goModel.Name,
-			CostPer1MIn:            costPer1MIn,
-			CostPer1MOut:           costPer1MOut,
-			CostPer1MInCached:      costPer1MInCached,
+			ID:   goModel.ID,
+			Name: goModel.Name,
+			Pricing: catwalk.Pricing{
+				Input:    costPerTokenIn,
+				Output:   costPerTokenOut,
+				CacheHit: costCacheHit,
+			},
 			ContextWindow:          goModel.Limit.Context,
 			DefaultMaxTokens:       goModel.Limit.Output,
 			SupportsImages:         goModel.Attachment,

--- a/cmd/opencode-go/main.go
+++ b/cmd/opencode-go/main.go
@@ -134,7 +134,7 @@ func main() {
 			},
 			ContextWindow:          goModel.Limit.Context,
 			DefaultMaxTokens:       goModel.Limit.Output,
-			SupportsImages:         goModel.Attachment,
+			Capabilities:           catwalk.Capabilities{Vision: goModel.Attachment},
 			CanReason:              goModel.Reasoning,
 			ReasoningLevels:        reasoningLevels,
 			DefaultReasoningEffort: defaultReasoningEffort,

--- a/cmd/opencode-zen/main.go
+++ b/cmd/opencode-zen/main.go
@@ -145,7 +145,7 @@ func main() {
 	for _, zenModel := range zenModels {
 		enrichment, hasEnrichment := enrichmentData[zenModel.ID]
 
-		var costPer1MIn, costPer1MOut, costPer1MInCached, costPer1MOutCached float64
+		var costInput, costOutput, costCacheCreate, costCacheHit float64
 		var contextWindow, defaultMaxTokens int64 = 200000, 20000
 		var supportsImages bool
 		var canReason bool
@@ -154,10 +154,10 @@ func main() {
 		modelName := zenModel.ID
 
 		if hasEnrichment {
-			costPer1MIn = math.Round(enrichment.Cost.Input*100) / 100
-			costPer1MOut = math.Round(enrichment.Cost.Output*100) / 100
-			costPer1MInCached = math.Round(enrichment.Cost.CacheRead*100) / 100
-			costPer1MOutCached = math.Round(enrichment.Cost.CacheWrite*100) / 100
+			costInput = math.Round(enrichment.Cost.Input*100) / 100
+			costOutput = math.Round(enrichment.Cost.Output*100) / 100
+			costCacheCreate = math.Round(enrichment.Cost.CacheWrite*100) / 100
+			costCacheHit = math.Round(enrichment.Cost.CacheRead*100) / 100
 			contextWindow = enrichment.Limit.Context
 			defaultMaxTokens = enrichment.Limit.Output
 			supportsImages = enrichment.Attachment
@@ -192,12 +192,14 @@ func main() {
 		}
 
 		m := catwalk.Model{
-			ID:                     zenModel.ID,
-			Name:                   modelName,
-			CostPer1MIn:            costPer1MIn,
-			CostPer1MOut:           costPer1MOut,
-			CostPer1MInCached:      costPer1MInCached,
-			CostPer1MOutCached:     costPer1MOutCached,
+			ID:   zenModel.ID,
+			Name: modelName,
+			Pricing: catwalk.Pricing{
+				Input:       costInput,
+				Output:      costOutput,
+				CacheCreate: costCacheCreate,
+				CacheHit:    costCacheHit,
+			},
 			ContextWindow:          contextWindow,
 			DefaultMaxTokens:       defaultMaxTokens,
 			SupportsImages:         supportsImages,

--- a/cmd/opencode-zen/main.go
+++ b/cmd/opencode-zen/main.go
@@ -202,7 +202,7 @@ func main() {
 			},
 			ContextWindow:          contextWindow,
 			DefaultMaxTokens:       defaultMaxTokens,
-			SupportsImages:         supportsImages,
+			Capabilities:           catwalk.Capabilities{Vision: supportsImages},
 			CanReason:              canReason,
 			ReasoningLevels:        reasoningLevels,
 			DefaultReasoningEffort: defaultReasoningEffort,

--- a/cmd/openrouter/main.go
+++ b/cmd/openrouter/main.go
@@ -93,42 +93,33 @@ type ModelsResponse struct {
 	Data []Model `json:"data"`
 }
 
-// ModelPricing is the pricing structure for a model, detailing costs per
-// million tokens for input and output, both cached and uncached.
-type ModelPricing struct {
-	CostPer1MIn        float64 `json:"cost_per_1m_in"`
-	CostPer1MOut       float64 `json:"cost_per_1m_out"`
-	CostPer1MInCached  float64 `json:"cost_per_1m_in_cached"`
-	CostPer1MOutCached float64 `json:"cost_per_1m_out_cached"`
-}
-
 func roundCost(v float64) float64 {
 	return math.Round(v*1e5) / 1e5
 }
 
-func getPricing(model Model) ModelPricing {
-	pricing := ModelPricing{}
+func getPricing(model Model) catwalk.Pricing {
+	pricing := catwalk.Pricing{}
 	costPrompt, err := strconv.ParseFloat(model.Pricing.Prompt, 64)
 	if err != nil {
 		costPrompt = 0.0
 	}
-	pricing.CostPer1MIn = roundCost(costPrompt * 1_000_000)
+	pricing.Input = roundCost(costPrompt * 1_000_000)
 	costCompletion, err := strconv.ParseFloat(model.Pricing.Completion, 64)
 	if err != nil {
 		costCompletion = 0.0
 	}
-	pricing.CostPer1MOut = roundCost(costCompletion * 1_000_000)
+	pricing.Output = roundCost(costCompletion * 1_000_000)
 
-	costPromptCached, err := strconv.ParseFloat(model.Pricing.InputCacheWrite, 64)
+	costCacheWrite, err := strconv.ParseFloat(model.Pricing.InputCacheWrite, 64)
 	if err != nil {
-		costPromptCached = 0.0
+		costCacheWrite = 0.0
 	}
-	pricing.CostPer1MInCached = roundCost(costPromptCached * 1_000_000)
-	costCompletionCached, err := strconv.ParseFloat(model.Pricing.InputCacheRead, 64)
+	pricing.CacheCreate = roundCost(costCacheWrite * 1_000_000)
+	costCacheRead, err := strconv.ParseFloat(model.Pricing.InputCacheRead, 64)
 	if err != nil {
-		costCompletionCached = 0.0
+		costCacheRead = 0.0
 	}
-	pricing.CostPer1MOutCached = roundCost(costCompletionCached * 1_000_000)
+	pricing.CacheHit = roundCost(costCacheRead * 1_000_000)
 	return pricing
 }
 
@@ -302,10 +293,7 @@ func main() {
 			m := catwalk.Model{
 				ID:                     model.ID,
 				Name:                   model.Name,
-				CostPer1MIn:            pricing.CostPer1MIn,
-				CostPer1MOut:           pricing.CostPer1MOut,
-				CostPer1MInCached:      pricing.CostPer1MInCached,
-				CostPer1MOutCached:     pricing.CostPer1MOutCached,
+				Pricing:                pricing,
 				ContextWindow:          model.ContextLength,
 				CanReason:              canReason,
 				DefaultReasoningEffort: defaultReasoning,
@@ -337,28 +325,28 @@ func main() {
 		}
 
 		// Use the best endpoint's configuration
-		pricing := ModelPricing{}
+		pricing := catwalk.Pricing{}
 		costPrompt, err := strconv.ParseFloat(bestEndpoint.Pricing.Prompt, 64)
 		if err != nil {
 			costPrompt = 0.0
 		}
-		pricing.CostPer1MIn = roundCost(costPrompt * 1_000_000)
+		pricing.Input = roundCost(costPrompt * 1_000_000)
 		costCompletion, err := strconv.ParseFloat(bestEndpoint.Pricing.Completion, 64)
 		if err != nil {
 			costCompletion = 0.0
 		}
-		pricing.CostPer1MOut = roundCost(costCompletion * 1_000_000)
+		pricing.Output = roundCost(costCompletion * 1_000_000)
 
-		costPromptCached, err := strconv.ParseFloat(bestEndpoint.Pricing.InputCacheWrite, 64)
+		costCacheWrite, err := strconv.ParseFloat(bestEndpoint.Pricing.InputCacheWrite, 64)
 		if err != nil {
-			costPromptCached = 0.0
+			costCacheWrite = 0.0
 		}
-		pricing.CostPer1MInCached = roundCost(costPromptCached * 1_000_000)
-		costCompletionCached, err := strconv.ParseFloat(bestEndpoint.Pricing.InputCacheRead, 64)
+		pricing.CacheCreate = roundCost(costCacheWrite * 1_000_000)
+		costCacheRead, err := strconv.ParseFloat(bestEndpoint.Pricing.InputCacheRead, 64)
 		if err != nil {
-			costCompletionCached = 0.0
+			costCacheRead = 0.0
 		}
-		pricing.CostPer1MOutCached = roundCost(costCompletionCached * 1_000_000)
+		pricing.CacheHit = roundCost(costCacheRead * 1_000_000)
 
 		canReason := slices.Contains(bestEndpoint.SupportedParams, "reasoning")
 		supportsImages := slices.Contains(model.Architecture.InputModalities, "image")
@@ -372,10 +360,7 @@ func main() {
 		m := catwalk.Model{
 			ID:                     model.ID,
 			Name:                   model.Name,
-			CostPer1MIn:            pricing.CostPer1MIn,
-			CostPer1MOut:           pricing.CostPer1MOut,
-			CostPer1MInCached:      pricing.CostPer1MInCached,
-			CostPer1MOutCached:     pricing.CostPer1MOutCached,
+			Pricing:                pricing,
 			ContextWindow:          bestEndpoint.ContextLength,
 			CanReason:              canReason,
 			DefaultReasoningEffort: defaultReasoning,

--- a/cmd/openrouter/main.go
+++ b/cmd/openrouter/main.go
@@ -298,7 +298,7 @@ func main() {
 				CanReason:              canReason,
 				DefaultReasoningEffort: defaultReasoning,
 				ReasoningLevels:        reasoningLevels,
-				SupportsImages:         supportsImages,
+				Capabilities:           catwalk.Capabilities{Vision: supportsImages},
 			}
 			if model.TopProvider.MaxCompletionTokens != nil {
 				m.DefaultMaxTokens = *model.TopProvider.MaxCompletionTokens / 2
@@ -365,7 +365,7 @@ func main() {
 			CanReason:              canReason,
 			DefaultReasoningEffort: defaultReasoning,
 			ReasoningLevels:        reasoningLevels,
-			SupportsImages:         supportsImages,
+			Capabilities:           catwalk.Capabilities{Vision: supportsImages},
 		}
 
 		// Set max tokens based on the best endpoint

--- a/cmd/pioneer/main.go
+++ b/cmd/pioneer/main.go
@@ -107,10 +107,12 @@ func main() {
 		}
 
 		model := catwalk.Model{
-			ID:                     m.ID,
-			Name:                   m.Label,
-			CostPer1MIn:            roundCost(m.InputPrice),
-			CostPer1MOut:           roundCost(m.OutputPrice),
+			ID:   m.ID,
+			Name: m.Label,
+			Pricing: catwalk.Pricing{
+				Input:  roundCost(m.InputPrice),
+				Output: roundCost(m.OutputPrice),
+			},
 			ContextWindow:          contextWindow,
 			DefaultMaxTokens:       defaultMaxTokens,
 			CanReason:              canReason,

--- a/cmd/synthetic/main.go
+++ b/cmd/synthetic/main.go
@@ -211,7 +211,7 @@ func main() {
 			CanReason:              canReason,
 			DefaultReasoningEffort: defaultReasoning,
 			ReasoningLevels:        reasoningLevels,
-			SupportsImages:         supportsImages,
+			Capabilities:           catwalk.Capabilities{Vision: supportsImages},
 		}
 
 		// Set max tokens based on max_output_length if available, but cap at

--- a/cmd/synthetic/main.go
+++ b/cmd/synthetic/main.go
@@ -46,15 +46,6 @@ type ModelsResponse struct {
 	Data []Model `json:"data"`
 }
 
-// ModelPricing is the pricing structure for a model, detailing costs per
-// million tokens for input and output, both cached and uncached.
-type ModelPricing struct {
-	CostPer1MIn        float64 `json:"cost_per_1m_in"`
-	CostPer1MOut       float64 `json:"cost_per_1m_out"`
-	CostPer1MInCached  float64 `json:"cost_per_1m_in_cached"`
-	CostPer1MOutCached float64 `json:"cost_per_1m_out_cached"`
-}
-
 // parsePrice extracts a float from Synthetic's price format (e.g. "$0.00000055").
 func parsePrice(s string) float64 {
 	s = strings.TrimPrefix(s, "$")
@@ -69,12 +60,12 @@ func roundCost(v float64) float64 {
 	return math.Round(v*1e5) / 1e5
 }
 
-func getPricing(model Model) ModelPricing {
-	return ModelPricing{
-		CostPer1MIn:        roundCost(parsePrice(model.Pricing.Prompt) * 1_000_000),
-		CostPer1MOut:       roundCost(parsePrice(model.Pricing.Completion) * 1_000_000),
-		CostPer1MInCached:  roundCost(parsePrice(model.Pricing.InputCacheReads) * 1_000_000),
-		CostPer1MOutCached: roundCost(parsePrice(model.Pricing.InputCacheReads) * 1_000_000),
+func getPricing(model Model) catwalk.Pricing {
+	return catwalk.Pricing{
+		Input:       roundCost(parsePrice(model.Pricing.Prompt) * 1_000_000),
+		Output:      roundCost(parsePrice(model.Pricing.Completion) * 1_000_000),
+		CacheCreate: roundCost(parsePrice(model.Pricing.InputCacheWrites) * 1_000_000),
+		CacheHit:    roundCost(parsePrice(model.Pricing.InputCacheReads) * 1_000_000),
 	}
 }
 
@@ -215,10 +206,7 @@ func main() {
 		m := catwalk.Model{
 			ID:                     model.ID,
 			Name:                   modelName,
-			CostPer1MIn:            pricing.CostPer1MIn,
-			CostPer1MOut:           pricing.CostPer1MOut,
-			CostPer1MInCached:      pricing.CostPer1MInCached,
-			CostPer1MOutCached:     pricing.CostPer1MOutCached,
+			Pricing:                pricing,
 			ContextWindow:          model.ContextLength,
 			CanReason:              canReason,
 			DefaultReasoningEffort: defaultReasoning,

--- a/cmd/venice/main.go
+++ b/cmd/venice/main.go
@@ -216,7 +216,7 @@ func main() {
 			CanReason:              canReason,
 			ReasoningLevels:        reasoningLevels,
 			DefaultReasoningEffort: defaultReasoning,
-			SupportsImages:         model.ModelSpec.Capabilities.SupportsVision,
+			Capabilities:           catwalk.Capabilities{Vision: model.ModelSpec.Capabilities.SupportsVision},
 			Options:                options,
 		}
 

--- a/cmd/venice/main.go
+++ b/cmd/venice/main.go
@@ -101,8 +101,8 @@ func bestLargeModelID(models []catwalk.Model) string {
 			best = m
 			continue
 		}
-		mCost := m.CostPer1MIn + m.CostPer1MOut
-		bestCost := best.CostPer1MIn + best.CostPer1MOut
+		mCost := m.Pricing.Input + m.Pricing.Output
+		bestCost := best.Pricing.Input + best.Pricing.Output
 		if mCost > bestCost {
 			best = m
 			continue
@@ -125,8 +125,8 @@ func bestSmallModelID(models []catwalk.Model) string {
 			best = m
 			continue
 		}
-		mCost := m.CostPer1MIn + m.CostPer1MOut
-		bestCost := best.CostPer1MIn + best.CostPer1MOut
+		mCost := m.Pricing.Input + m.Pricing.Output
+		bestCost := best.Pricing.Input + best.Pricing.Output
 		if mCost < bestCost {
 			best = m
 			continue
@@ -205,12 +205,12 @@ func main() {
 
 		roundCost := func(v float64) float64 { return math.Round(v*1e5) / 1e5 }
 		m := catwalk.Model{
-			ID:                     model.ID,
-			Name:                   model.ModelSpec.Name,
-			CostPer1MIn:            roundCost(model.ModelSpec.Pricing.Input.USD),
-			CostPer1MOut:           roundCost(model.ModelSpec.Pricing.Output.USD),
-			CostPer1MInCached:      0,
-			CostPer1MOutCached:     0,
+			ID:   model.ID,
+			Name: model.ModelSpec.Name,
+			Pricing: catwalk.Pricing{
+				Input:  roundCost(model.ModelSpec.Pricing.Input.USD),
+				Output: roundCost(model.ModelSpec.Pricing.Output.USD),
+			},
 			ContextWindow:          contextWindow,
 			DefaultMaxTokens:       model.ModelSpec.MaxCompletionTokens,
 			CanReason:              canReason,

--- a/cmd/vercel/main.go
+++ b/cmd/vercel/main.go
@@ -110,40 +110,36 @@ func main() {
 
 		// Parse pricing
 		roundCost := func(v float64) float64 { return math.Round(v*1e5) / 1e5 }
-		costPer1MIn := 0.0
-		costPer1MOut := 0.0
-		costPer1MInCached := 0.0
-		costPer1MOutCached := 0.0
+		costInput := 0.0
+		costOutput := 0.0
+		costCacheCreate := 0.0
+		costCacheHit := 0.0
 
 		if model.Pricing.Input != "" {
 			costPrompt, err := strconv.ParseFloat(model.Pricing.Input, 64)
 			if err == nil {
-				costPer1MIn = roundCost(costPrompt * 1_000_000)
+				costInput = roundCost(costPrompt * 1_000_000)
 			}
 		}
 
 		if model.Pricing.Output != "" {
 			costCompletion, err := strconv.ParseFloat(model.Pricing.Output, 64)
 			if err == nil {
-				costPer1MOut = roundCost(costCompletion * 1_000_000)
+				costOutput = roundCost(costCompletion * 1_000_000)
 			}
 		}
 
-		// NOTE: catwalk's naming is confusing (see providers.go in hyper):
-		// - cost_per_1m_in_cached  = cache CREATION (write)
-		// - cost_per_1m_out_cached = cache READ
-		// Vercel's API uses the intuitive names, so we map them accordingly.
 		if model.Pricing.InputCacheRead != "" {
 			costCacheRead, err := strconv.ParseFloat(model.Pricing.InputCacheRead, 64)
 			if err == nil {
-				costPer1MOutCached = roundCost(costCacheRead * 1_000_000)
+				costCacheHit = roundCost(costCacheRead * 1_000_000)
 			}
 		}
 
 		if model.Pricing.InputCacheWrite != "" {
 			costCacheWrite, err := strconv.ParseFloat(model.Pricing.InputCacheWrite, 64)
 			if err == nil {
-				costPer1MInCached = roundCost(costCacheWrite * 1_000_000)
+				costCacheCreate = roundCost(costCacheWrite * 1_000_000)
 			}
 		}
 
@@ -173,12 +169,14 @@ func main() {
 		supportsImages := slices.Contains(model.Tags, "vision")
 
 		m := catwalk.Model{
-			ID:                     model.ID,
-			Name:                   model.Name,
-			CostPer1MIn:            costPer1MIn,
-			CostPer1MOut:           costPer1MOut,
-			CostPer1MInCached:      costPer1MInCached,
-			CostPer1MOutCached:     costPer1MOutCached,
+			ID:   model.ID,
+			Name: model.Name,
+			Pricing: catwalk.Pricing{
+				Input:       costInput,
+				Output:      costOutput,
+				CacheCreate: costCacheCreate,
+				CacheHit:    costCacheHit,
+			},
 			ContextWindow:          model.ContextWindow,
 			DefaultMaxTokens:       cmp.Or(model.MaxTokens, model.ContextWindow/10),
 			CanReason:              canReason,

--- a/cmd/vercel/main.go
+++ b/cmd/vercel/main.go
@@ -182,7 +182,7 @@ func main() {
 			CanReason:              canReason,
 			ReasoningLevels:        reasoningLevels,
 			DefaultReasoningEffort: defaultReasoning,
-			SupportsImages:         supportsImages,
+			Capabilities:           catwalk.Capabilities{Vision: supportsImages},
 		}
 
 		vercelProvider.Models = append(vercelProvider.Models, m)

--- a/cmd/xai/main.go
+++ b/cmd/xai/main.go
@@ -183,7 +183,7 @@ func main() {
 			CanReason:              canReason,
 			ReasoningLevels:        reasoningLevels,
 			DefaultReasoningEffort: defaultReasoningLevel,
-			SupportsImages:         supportsImages,
+			Capabilities:           catwalk.Capabilities{Vision: supportsImages},
 		}
 
 		provider.Models = append(provider.Models, m)

--- a/cmd/xai/main.go
+++ b/cmd/xai/main.go
@@ -87,7 +87,7 @@ func roundCost(v float64) float64 {
 	return math.Round(v*1e5) / 1e5
 }
 
-func priceToDollarsPerMillion(centsPerHundredMillion int64) float64 {
+func priceToDollarsPerToken(centsPerHundredMillion int64) float64 {
 	return roundCost(float64(centsPerHundredMillion) / 10_000)
 }
 
@@ -171,12 +171,13 @@ func main() {
 		}
 
 		m := catwalk.Model{
-			ID:                     id,
-			Name:                   prettyName(id),
-			CostPer1MIn:            priceToDollarsPerMillion(model.PromptTextTokenPrice),
-			CostPer1MOut:           priceToDollarsPerMillion(model.CompletionTextTokenPrice),
-			CostPer1MInCached:      0,
-			CostPer1MOutCached:     priceToDollarsPerMillion(model.CachedPromptTextTokenPrc),
+			ID:   id,
+			Name: prettyName(id),
+			Pricing: catwalk.Pricing{
+				Input:    priceToDollarsPerToken(model.PromptTextTokenPrice),
+				Output:   priceToDollarsPerToken(model.CompletionTextTokenPrice),
+				CacheHit: priceToDollarsPerToken(model.CachedPromptTextTokenPrc),
+			},
 			ContextWindow:          ctxWindow,
 			DefaultMaxTokens:       defaultMaxTokens,
 			CanReason:              canReason,

--- a/internal/providers/configs/aihubmix.json
+++ b/internal/providers/configs/aihubmix.json
@@ -10,10 +10,10 @@
     {
       "id": "AiHubmix-Phi-4-mini-reasoning",
       "name": "Aihubmix Phi 4 Mini (reasoning)",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.12
+      },
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
@@ -22,10 +22,10 @@
     {
       "id": "ByteDance-Seed/Seed-OSS-36B-Instruct",
       "name": "Seed Oss 36B Instruct",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.534,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.534
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -34,10 +34,10 @@
     {
       "id": "DeepSeek-V3",
       "name": "DeepSeek V3",
-      "cost_per_1m_in": 0.272,
-      "cost_per_1m_out": 1.088,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.272,
+        "output": 1.088
+      },
       "context_window": 1638000,
       "default_max_tokens": 163800,
       "can_reason": false,
@@ -46,10 +46,10 @@
     {
       "id": "DeepSeek-V3.1-Terminus",
       "name": "DeepSeek V3.1 Terminus",
-      "cost_per_1m_in": 0.56,
-      "cost_per_1m_out": 1.68,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.56,
+        "output": 1.68
+      },
       "context_window": 160000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -58,10 +58,10 @@
     {
       "id": "DeepSeek-V3.1-Think",
       "name": "DeepSeek V3.1 Thinking",
-      "cost_per_1m_in": 0.56,
-      "cost_per_1m_out": 1.68,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.56,
+        "output": 1.68
+      },
       "context_window": 128000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -76,10 +76,10 @@
     {
       "id": "ERNIE-X1.1-Preview",
       "name": "ERNIE X1.1 Preview",
-      "cost_per_1m_in": 0.136,
-      "cost_per_1m_out": 0.544,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.136,
+        "output": 0.544
+      },
       "context_window": 119000,
       "default_max_tokens": 11900,
       "can_reason": true,
@@ -94,10 +94,10 @@
     {
       "id": "agnes-2.5-flash",
       "name": "Agnes 2.5 Flash",
-      "cost_per_1m_in": 0.03,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.03,
+        "output": 0.15
+      },
       "context_window": 512000,
       "default_max_tokens": 65500,
       "can_reason": true,
@@ -112,10 +112,11 @@
     {
       "id": "agnes-2.5-pro",
       "name": "Agnes 2.5 Pro",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.00378,
+      "pricing": {
+        "input": 0.45,
+        "output": 0.9,
+        "cache_hit": 0.00378
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -130,10 +131,11 @@
     {
       "id": "agnes-2.5-pro-alpha",
       "name": "Agnes 2.5 Pro Alpha",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.00378,
+      "pricing": {
+        "input": 0.45,
+        "output": 0.9,
+        "cache_hit": 0.00378
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -148,10 +150,10 @@
     {
       "id": "aihub-Phi-4-mini-instruct",
       "name": "Aihub Phi 4 Mini Instruct",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.48,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.48
+      },
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
@@ -160,10 +162,10 @@
     {
       "id": "aihub-Phi-4-multimodal-instruct",
       "name": "Aihub Phi 4 Multimodal Instruct",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.48,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.48
+      },
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
@@ -172,10 +174,12 @@
     {
       "id": "anthropic-opus-4-6",
       "name": "Anthropic Opus 4.6",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -190,10 +194,10 @@
     {
       "id": "auto",
       "name": "Auto",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 2
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -208,10 +212,11 @@
     {
       "id": "baidu-deepseek-v4-pro-0813",
       "name": "Baidu DeepSeek V4 Pro 0813",
-      "cost_per_1m_in": 1.268,
-      "cost_per_1m_out": 3.804,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1268,
+      "pricing": {
+        "input": 1.268,
+        "output": 3.804,
+        "cache_hit": 0.1268
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -226,10 +231,10 @@
     {
       "id": "claude-3-7-sonnet",
       "name": "Claude 3.7 Sonnet",
-      "cost_per_1m_in": 3.3,
-      "cost_per_1m_out": 16.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.3,
+        "output": 16.5
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
@@ -244,10 +249,12 @@
     {
       "id": "claude-fable-5",
       "name": "Claude Fable 5",
-      "cost_per_1m_in": 11,
-      "cost_per_1m_out": 55,
-      "cost_per_1m_in_cached": 13.75,
-      "cost_per_1m_out_cached": 1.1,
+      "pricing": {
+        "input": 11,
+        "output": 55,
+        "cache_create": 13.75,
+        "cache_hit": 1.1
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -262,10 +269,12 @@
     {
       "id": "claude-fable-5-1",
       "name": "Claude Fable 5.1",
-      "cost_per_1m_in": 11,
-      "cost_per_1m_out": 55,
-      "cost_per_1m_in_cached": 13.75,
-      "cost_per_1m_out_cached": 0.275,
+      "pricing": {
+        "input": 11,
+        "output": 55,
+        "cache_create": 13.75,
+        "cache_hit": 0.275
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -280,10 +289,12 @@
     {
       "id": "claude-haiku-4-5",
       "name": "Claude Haiku 4.5",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 5.5,
-      "cost_per_1m_in_cached": 1.375,
-      "cost_per_1m_out_cached": 0.11,
+      "pricing": {
+        "input": 1.1,
+        "output": 5.5,
+        "cache_create": 1.375,
+        "cache_hit": 0.11
+      },
       "context_window": 204800,
       "default_max_tokens": 20480,
       "can_reason": true,
@@ -298,10 +309,10 @@
     {
       "id": "claude-opus-4-1",
       "name": "Claude Opus 4.1",
-      "cost_per_1m_in": 16.5,
-      "cost_per_1m_out": 82.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 16.5,
+        "output": 82.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -316,10 +327,12 @@
     {
       "id": "claude-opus-4-5",
       "name": "Claude Opus 4.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -334,10 +347,12 @@
     {
       "id": "claude-opus-4-5-think",
       "name": "Claude Opus 4.5 Thinking",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -352,10 +367,12 @@
     {
       "id": "claude-opus-4-6",
       "name": "Claude Opus 4.6",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -370,10 +387,12 @@
     {
       "id": "claude-opus-4-6-think",
       "name": "Claude Opus 4.6 Thinking",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -388,10 +407,12 @@
     {
       "id": "claude-opus-4-7",
       "name": "Claude Opus 4.7",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -406,10 +427,12 @@
     {
       "id": "claude-opus-4-7-think",
       "name": "Claude Opus 4.7 Thinking",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -424,10 +447,12 @@
     {
       "id": "claude-opus-4-8",
       "name": "Claude Opus 4.8",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -442,10 +467,12 @@
     {
       "id": "claude-opus-4-8-think",
       "name": "Claude Opus 4.8 Thinking",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -460,10 +487,12 @@
     {
       "id": "claude-opus-5",
       "name": "Claude Opus 5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -478,10 +507,12 @@
     {
       "id": "claude-sonnet-4-5",
       "name": "Claude Sonnet 4.5",
-      "cost_per_1m_in": 3.3,
-      "cost_per_1m_out": 16.5,
-      "cost_per_1m_in_cached": 4.125,
-      "cost_per_1m_out_cached": 0.33,
+      "pricing": {
+        "input": 3.3,
+        "output": 16.5,
+        "cache_create": 4.125,
+        "cache_hit": 0.33
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -496,10 +527,12 @@
     {
       "id": "claude-sonnet-4-5-think",
       "name": "Claude Sonnet 4.5 Thinking",
-      "cost_per_1m_in": 3.3,
-      "cost_per_1m_out": 16.5,
-      "cost_per_1m_in_cached": 4.125,
-      "cost_per_1m_out_cached": 0.33,
+      "pricing": {
+        "input": 3.3,
+        "output": 16.5,
+        "cache_create": 4.125,
+        "cache_hit": 0.33
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -514,10 +547,12 @@
     {
       "id": "claude-sonnet-4-6",
       "name": "Claude Sonnet 4.6",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -532,10 +567,12 @@
     {
       "id": "claude-sonnet-4-6-think",
       "name": "Claude Sonnet 4.6 Thinking",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -550,10 +587,12 @@
     {
       "id": "claude-sonnet-5",
       "name": "Claude Sonnet 5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 10,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -568,10 +607,10 @@
     {
       "id": "coding-glm-4.6-free",
       "name": "Coding GLM 4.6 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
@@ -586,10 +625,11 @@
     {
       "id": "coding-kimi-k3",
       "name": "Coding Kimi K3",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 1.61333,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.066,
+      "pricing": {
+        "input": 0.44,
+        "output": 1.61333,
+        "cache_hit": 0.066
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -604,10 +644,10 @@
     {
       "id": "coding-kimi-k3-free",
       "name": "Coding Kimi K3 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -622,10 +662,10 @@
     {
       "id": "coding-minimax-m2",
       "name": "Coding MiniMax M2",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -640,10 +680,10 @@
     {
       "id": "coding-minimax-m2-free",
       "name": "Coding MiniMax M2 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -658,10 +698,10 @@
     {
       "id": "coding-minimax-m2.1",
       "name": "Coding MiniMax M2.1",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -676,10 +716,10 @@
     {
       "id": "coding-minimax-m2.1-free",
       "name": "Coding MiniMax M2.1 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -694,10 +734,10 @@
     {
       "id": "coding-minimax-m2.5",
       "name": "Coding MiniMax M2.5",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -712,10 +752,10 @@
     {
       "id": "coding-minimax-m2.5-free",
       "name": "Coding MiniMax M2.5 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -730,10 +770,10 @@
     {
       "id": "coding-minimax-m2.5-highspeed",
       "name": "Coding MiniMax M2.5 Highspeed",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -748,10 +788,10 @@
     {
       "id": "coding-minimax-m2.7",
       "name": "Coding MiniMax M2.7",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -766,10 +806,10 @@
     {
       "id": "coding-minimax-m2.7-free",
       "name": "Coding MiniMax M2.7 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -784,10 +824,10 @@
     {
       "id": "coding-minimax-m2.7-highspeed",
       "name": "Coding MiniMax M2.7 Highspeed",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -802,10 +842,10 @@
     {
       "id": "coding-minimax-m3",
       "name": "Coding MiniMax M3",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -820,10 +860,10 @@
     {
       "id": "coding-minimax-m3-free",
       "name": "Coding MiniMax M3 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 204800,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -838,10 +878,10 @@
     {
       "id": "command-a-plus-05-2026",
       "name": "Command A Plus 05 2026",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 10
+      },
       "context_window": 128000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -856,10 +896,11 @@
     {
       "id": "deepseek-v3.2",
       "name": "DeepSeek V3.2",
-      "cost_per_1m_in": 0.302,
-      "cost_per_1m_out": 0.453,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0302,
+      "pricing": {
+        "input": 0.302,
+        "output": 0.453,
+        "cache_hit": 0.0302
+      },
       "context_window": 128000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -874,10 +915,11 @@
     {
       "id": "deepseek-v3.2-think",
       "name": "DeepSeek V3.2 Thinking",
-      "cost_per_1m_in": 0.302,
-      "cost_per_1m_out": 0.453,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0302,
+      "pricing": {
+        "input": 0.302,
+        "output": 0.453,
+        "cache_hit": 0.0302
+      },
       "context_window": 128000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -892,10 +934,11 @@
     {
       "id": "deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.142,
-      "cost_per_1m_out": 0.284,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0284,
+      "pricing": {
+        "input": 0.142,
+        "output": 0.284,
+        "cache_hit": 0.0284
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -910,10 +953,11 @@
     {
       "id": "deepseek-v4-flash-0731",
       "name": "DeepSeek V4 Flash 0731",
-      "cost_per_1m_in": 0.142,
-      "cost_per_1m_out": 0.284,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0284,
+      "pricing": {
+        "input": 0.142,
+        "output": 0.284,
+        "cache_hit": 0.0284
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -928,10 +972,11 @@
     {
       "id": "deepseek-v4-flash-0731-fast",
       "name": "DeepSeek V4 Flash 0731 Fast",
-      "cost_per_1m_in": 0.28,
-      "cost_per_1m_out": 1.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.07,
+      "pricing": {
+        "input": 0.28,
+        "output": 1.4,
+        "cache_hit": 0.07
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -946,10 +991,11 @@
     {
       "id": "deepseek-v4-flash-vision-exp",
       "name": "DeepSeek V4 Flash Vision Exp",
-      "cost_per_1m_in": 0.142,
-      "cost_per_1m_out": 0.284,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0284,
+      "pricing": {
+        "input": 0.142,
+        "output": 0.284,
+        "cache_hit": 0.0284
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -964,10 +1010,11 @@
     {
       "id": "deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
-      "cost_per_1m_in": 1.69,
-      "cost_per_1m_out": 3.38,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.14027,
+      "pricing": {
+        "input": 1.69,
+        "output": 3.38,
+        "cache_hit": 0.14027
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -982,10 +1029,11 @@
     {
       "id": "deepseek-v4-pro-0813",
       "name": "DeepSeek V4 Pro 0813",
-      "cost_per_1m_in": 0.6918,
-      "cost_per_1m_out": 2.0754,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.02306,
+      "pricing": {
+        "input": 0.6918,
+        "output": 2.0754,
+        "cache_hit": 0.02306
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -1000,10 +1048,10 @@
     {
       "id": "dots-3-note-preview-free",
       "name": "Dots 3 Note Preview (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 512000,
       "default_max_tokens": 51200,
       "can_reason": false,
@@ -1012,10 +1060,11 @@
     {
       "id": "doubao-deepseek-v4-flash-0731",
       "name": "Doubao Deepseek V4 Flash 0731",
-      "cost_per_1m_in": 0.4226,
-      "cost_per_1m_out": 1.2678,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.14085,
+      "pricing": {
+        "input": 0.4226,
+        "output": 1.2678,
+        "cache_hit": 0.14085
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -1030,10 +1079,11 @@
     {
       "id": "doubao-seed-1-6",
       "name": "Doubao Seed 1.6",
-      "cost_per_1m_in": 0.18,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.036,
+      "pricing": {
+        "input": 0.18,
+        "output": 1.8,
+        "cache_hit": 0.036
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -1042,10 +1092,11 @@
     {
       "id": "doubao-seed-1-6-flash",
       "name": "Doubao Seed 1.6 Flash",
-      "cost_per_1m_in": 0.044,
-      "cost_per_1m_out": 0.44,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0088,
+      "pricing": {
+        "input": 0.044,
+        "output": 0.44,
+        "cache_hit": 0.0088
+      },
       "context_window": 256000,
       "default_max_tokens": 33000,
       "can_reason": false,
@@ -1054,10 +1105,11 @@
     {
       "id": "doubao-seed-1-6-lite",
       "name": "Doubao Seed 1.6 Lite",
-      "cost_per_1m_in": 0.082,
-      "cost_per_1m_out": 0.656,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0164,
+      "pricing": {
+        "input": 0.082,
+        "output": 0.656,
+        "cache_hit": 0.0164
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -1066,10 +1118,11 @@
     {
       "id": "doubao-seed-1-6-thinking",
       "name": "Doubao Seed 1.6 Thinking",
-      "cost_per_1m_in": 0.18,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.036,
+      "pricing": {
+        "input": 0.18,
+        "output": 1.8,
+        "cache_hit": 0.036
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -1078,10 +1131,11 @@
     {
       "id": "doubao-seed-1-8",
       "name": "Doubao Seed 1.8",
-      "cost_per_1m_in": 0.10959,
-      "cost_per_1m_out": 0.27398,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.02192,
+      "pricing": {
+        "input": 0.10959,
+        "output": 0.27398,
+        "cache_hit": 0.02192
+      },
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1096,10 +1150,11 @@
     {
       "id": "doubao-seed-2-0-code-preview",
       "name": "Doubao Seed 2.0 Code Preview",
-      "cost_per_1m_in": 0.4822,
-      "cost_per_1m_out": 2.411,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.09644,
+      "pricing": {
+        "input": 0.4822,
+        "output": 2.411,
+        "cache_hit": 0.09644
+      },
       "context_window": 256000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1114,10 +1169,11 @@
     {
       "id": "doubao-seed-2-0-lite-260215",
       "name": "Doubao Seed 2.0 Lite 260215",
-      "cost_per_1m_in": 0.09041,
-      "cost_per_1m_out": 0.54246,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01808,
+      "pricing": {
+        "input": 0.09041,
+        "output": 0.54246,
+        "cache_hit": 0.01808
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -1132,10 +1188,11 @@
     {
       "id": "doubao-seed-2-0-lite-260428",
       "name": "Doubao Seed 2.0 Lite 260428",
-      "cost_per_1m_in": 0.09041,
-      "cost_per_1m_out": 0.54246,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01808,
+      "pricing": {
+        "input": 0.09041,
+        "output": 0.54246,
+        "cache_hit": 0.01808
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -1150,10 +1207,11 @@
     {
       "id": "doubao-seed-2-0-mini",
       "name": "Doubao Seed 2.0 Mini",
-      "cost_per_1m_in": 0.03014,
-      "cost_per_1m_out": 0.30136,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.00603,
+      "pricing": {
+        "input": 0.03014,
+        "output": 0.30136,
+        "cache_hit": 0.00603
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -1168,10 +1226,11 @@
     {
       "id": "doubao-seed-2-0-mini-260428",
       "name": "Doubao Seed 2.0 Mini 260428",
-      "cost_per_1m_in": 0.0282,
-      "cost_per_1m_out": 0.282,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.00564,
+      "pricing": {
+        "input": 0.0282,
+        "output": 0.282,
+        "cache_hit": 0.00564
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -1186,10 +1245,11 @@
     {
       "id": "doubao-seed-2-0-pro",
       "name": "Doubao Seed 2.0 Pro",
-      "cost_per_1m_in": 0.4822,
-      "cost_per_1m_out": 2.411,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.09644,
+      "pricing": {
+        "input": 0.4822,
+        "output": 2.411,
+        "cache_hit": 0.09644
+      },
       "context_window": 256000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1204,10 +1264,11 @@
     {
       "id": "doubao-seed-2-1-pro",
       "name": "Doubao Seed 2.1 Pro",
-      "cost_per_1m_in": 0.9295,
-      "cost_per_1m_out": 4.6475,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1859,
+      "pricing": {
+        "input": 0.9295,
+        "output": 4.6475,
+        "cache_hit": 0.1859
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -1222,10 +1283,11 @@
     {
       "id": "doubao-seed-2-1-turbo",
       "name": "Doubao Seed 2.1 Turbo",
-      "cost_per_1m_in": 0.46475,
-      "cost_per_1m_out": 2.32375,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.09295,
+      "pricing": {
+        "input": 0.46475,
+        "output": 2.32375,
+        "cache_hit": 0.09295
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -1240,10 +1302,10 @@
     {
       "id": "ernie-4.5",
       "name": "ERNIE 4.5",
-      "cost_per_1m_in": 0.068,
-      "cost_per_1m_out": 0.272,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.068,
+        "output": 0.272
+      },
       "context_window": 160000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -1252,10 +1314,10 @@
     {
       "id": "ernie-4.5-turbo-latest",
       "name": "ERNIE 4.5 Turbo",
-      "cost_per_1m_in": 0.11,
-      "cost_per_1m_out": 0.44,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.11,
+        "output": 0.44
+      },
       "context_window": 135000,
       "default_max_tokens": 12000,
       "can_reason": false,
@@ -1264,10 +1326,10 @@
     {
       "id": "ernie-4.5-turbo-vl",
       "name": "ERNIE 4.5 Turbo VL",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 1.2
+      },
       "context_window": 139000,
       "default_max_tokens": 16000,
       "can_reason": false,
@@ -1276,10 +1338,11 @@
     {
       "id": "ernie-5.0",
       "name": "ERNIE 5.0",
-      "cost_per_1m_in": 0.82192,
-      "cost_per_1m_out": 3.28768,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.82192,
+      "pricing": {
+        "input": 0.82192,
+        "output": 3.28768,
+        "cache_hit": 0.82192
+      },
       "context_window": 119000,
       "default_max_tokens": 11900,
       "can_reason": true,
@@ -1294,10 +1357,11 @@
     {
       "id": "ernie-5.0-thinking-exp",
       "name": "ERNIE 5.0 Thinking Exp",
-      "cost_per_1m_in": 0.82192,
-      "cost_per_1m_out": 3.28768,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.82192,
+      "pricing": {
+        "input": 0.82192,
+        "output": 3.28768,
+        "cache_hit": 0.82192
+      },
       "context_window": 119000,
       "default_max_tokens": 11900,
       "can_reason": true,
@@ -1312,10 +1376,11 @@
     {
       "id": "ernie-5.0-thinking-preview",
       "name": "ERNIE 5.0 Thinking Preview",
-      "cost_per_1m_in": 0.822,
-      "cost_per_1m_out": 3.288,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.822,
+      "pricing": {
+        "input": 0.822,
+        "output": 3.288,
+        "cache_hit": 0.822
+      },
       "context_window": 183000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1330,10 +1395,11 @@
     {
       "id": "ernie-5.1",
       "name": "ERNIE 5.1",
-      "cost_per_1m_in": 0.5634,
-      "cost_per_1m_out": 2.5353,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5634,
+      "pricing": {
+        "input": 0.5634,
+        "output": 2.5353,
+        "cache_hit": 0.5634
+      },
       "context_window": 119000,
       "default_max_tokens": 11900,
       "can_reason": true,
@@ -1348,10 +1414,10 @@
     {
       "id": "ernie-x1-turbo",
       "name": "ERNIE X1 Turbo",
-      "cost_per_1m_in": 0.136,
-      "cost_per_1m_out": 0.544,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.136,
+        "output": 0.544
+      },
       "context_window": 50500,
       "default_max_tokens": 5050,
       "can_reason": true,
@@ -1366,10 +1432,11 @@
     {
       "id": "gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.499,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.499,
+        "cache_hit": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1378,10 +1445,11 @@
     {
       "id": "gemini-2.5-flash-image",
       "name": "Gemini 2.5 Flash Image",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.499,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.499,
+        "cache_hit": 0.3
+      },
       "context_window": 32800,
       "default_max_tokens": 8000,
       "can_reason": false,
@@ -1390,10 +1458,11 @@
     {
       "id": "gemini-2.5-flash-lite",
       "name": "Gemini 2.5 Flash Lite",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_hit": 0.01
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1402,10 +1471,11 @@
     {
       "id": "gemini-2.5-flash-lite-nothink",
       "name": "Gemini 2.5 Flash Lite (no think)",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_hit": 0.01
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1414,10 +1484,11 @@
     {
       "id": "gemini-2.5-flash-lite-preview-09-2025",
       "name": "Gemini 2.5 Flash Lite Preview 09 2025",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_hit": 0.01
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1426,10 +1497,11 @@
     {
       "id": "gemini-2.5-flash-lite-preview-09-2025-nothink",
       "name": "Gemini 2.5 Flash Lite Preview 09 2025 (no think)",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_hit": 0.01
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1438,10 +1510,11 @@
     {
       "id": "gemini-2.5-flash-nothink",
       "name": "Gemini 2.5 Flash (no think)",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.499,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.499,
+        "cache_hit": 0.03
+      },
       "context_window": 1047576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1450,10 +1523,11 @@
     {
       "id": "gemini-2.5-flash-preview-05-20-nothink",
       "name": "Gemini 2.5 Flash Preview 05-20 (no think)",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.499,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.499,
+        "cache_hit": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1462,10 +1536,11 @@
     {
       "id": "gemini-2.5-flash-preview-05-20-search",
       "name": "Gemini 2.5 Flash Preview 05-20 Search",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.499,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.499,
+        "cache_hit": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1474,10 +1549,11 @@
     {
       "id": "gemini-2.5-flash-preview-09-2025",
       "name": "Gemini 2.5 Flash Preview 09 2025",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.499,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.499,
+        "cache_hit": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1486,10 +1562,11 @@
     {
       "id": "gemini-2.5-flash-search",
       "name": "Gemini 2.5 Flash Search",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.499,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.499,
+        "cache_hit": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1498,10 +1575,11 @@
     {
       "id": "gemini-2.5-pro",
       "name": "Gemini 2.5 Pro",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1516,10 +1594,11 @@
     {
       "id": "gemini-2.5-pro-preview-05-06",
       "name": "Gemini 2.5 Pro Preview 05-06",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1534,10 +1613,11 @@
     {
       "id": "gemini-2.5-pro-preview-06-05",
       "name": "Gemini 2.5 Pro Preview 06-05",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1552,10 +1632,11 @@
     {
       "id": "gemini-2.5-pro-search",
       "name": "Gemini 2.5 Pro Search",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1570,10 +1651,11 @@
     {
       "id": "gemini-3-flash-preview",
       "name": "Gemini 3 Flash Preview",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_hit": 0.05
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -1588,10 +1670,10 @@
     {
       "id": "gemini-3-flash-preview-free",
       "name": "Gemini 3 Flash Preview (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1606,10 +1688,11 @@
     {
       "id": "gemini-3-flash-preview-search",
       "name": "Gemini 3 Flash Preview Search",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_hit": 0.05
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -1624,10 +1707,11 @@
     {
       "id": "gemini-3.1-flash-lite",
       "name": "Gemini 3.1 Flash Lite",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 0.25,
+        "output": 1.5,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1642,10 +1726,11 @@
     {
       "id": "gemini-3.1-flash-lite-nothink",
       "name": "Gemini 3.1 Flash Lite (no think)",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 0.25,
+        "output": 1.5,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1660,10 +1745,11 @@
     {
       "id": "gemini-3.1-pro-preview",
       "name": "Gemini 3.1 Pro Preview",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1678,10 +1764,11 @@
     {
       "id": "gemini-3.1-pro-preview-customtools",
       "name": "Gemini 3.1 Pro Preview Customtools",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1696,10 +1783,11 @@
     {
       "id": "gemini-3.5-flash",
       "name": "Gemini 3.5 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.5,
+        "output": 9,
+        "cache_hit": 0.15
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1714,10 +1802,11 @@
     {
       "id": "gemini-3.5-flash-lite",
       "name": "Gemini 3.5 Flash Lite",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_hit": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1732,10 +1821,10 @@
     {
       "id": "gemini-3.5-flash-lite-free",
       "name": "Gemini 3.5 Flash Lite (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1750,10 +1839,11 @@
     {
       "id": "gemini-3.6-flash",
       "name": "Gemini 3.6 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.5,
+        "output": 7.5,
+        "cache_hit": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1768,10 +1858,10 @@
     {
       "id": "gemini-3.6-flash-free",
       "name": "Gemini 3.6 Flash (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1786,10 +1876,11 @@
     {
       "id": "gemini-3.7-flash",
       "name": "Gemini 3.7 Flash",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 3.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.75,
+        "output": 3.75,
+        "cache_hit": 0.075
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1804,10 +1895,10 @@
     {
       "id": "gemini-3.7-flash-free",
       "name": "Gemini 3.7 Flash (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1822,10 +1913,11 @@
     {
       "id": "gemini-3.8-flash",
       "name": "Gemini 3.8 Flash",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 3.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.75,
+        "output": 3.75,
+        "cache_hit": 0.075
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1840,10 +1932,10 @@
     {
       "id": "gemini-3.8-flash-free",
       "name": "Gemini 3.8 Flash (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1858,10 +1950,10 @@
     {
       "id": "gemma-4-26b-a4b-it-free",
       "name": "Gemma 4 26B A4B It (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -1870,10 +1962,10 @@
     {
       "id": "gemma-4-31b-it-free",
       "name": "Gemma 4 31B It (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -1882,10 +1974,11 @@
     {
       "id": "glm-4.5v",
       "name": "GLM 4.5 Vision",
-      "cost_per_1m_in": 0.274,
-      "cost_per_1m_out": 0.822,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.274,
+      "pricing": {
+        "input": 0.274,
+        "output": 0.822,
+        "cache_hit": 0.274
+      },
       "context_window": 64000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1894,10 +1987,11 @@
     {
       "id": "glm-4.6",
       "name": "GLM 4.6",
-      "cost_per_1m_in": 0.27397,
-      "cost_per_1m_out": 1.0959,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0548,
+      "pricing": {
+        "input": 0.27397,
+        "output": 1.0959,
+        "cache_hit": 0.0548
+      },
       "context_window": 204800,
       "default_max_tokens": 20480,
       "can_reason": true,
@@ -1912,10 +2006,11 @@
     {
       "id": "glm-4.6v",
       "name": "GLM 4.6 Vision",
-      "cost_per_1m_in": 0.137,
-      "cost_per_1m_out": 0.411,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0274,
+      "pricing": {
+        "input": 0.137,
+        "output": 0.411,
+        "cache_hit": 0.0274
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -1924,10 +2019,11 @@
     {
       "id": "glm-4.7",
       "name": "GLM 4.7",
-      "cost_per_1m_in": 0.27397,
-      "cost_per_1m_out": 1.0959,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0548,
+      "pricing": {
+        "input": 0.27397,
+        "output": 1.0959,
+        "cache_hit": 0.0548
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
@@ -1942,10 +2038,11 @@
     {
       "id": "glm-5",
       "name": "GLM 5",
-      "cost_per_1m_in": 0.88,
-      "cost_per_1m_out": 2.816,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.176,
+      "pricing": {
+        "input": 0.88,
+        "output": 2.816,
+        "cache_hit": 0.176
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
@@ -1960,10 +2057,11 @@
     {
       "id": "glm-5-turbo",
       "name": "GLM 5 Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 3.9996,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 3.9996,
+        "cache_hit": 0.24
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
@@ -1978,10 +2076,11 @@
     {
       "id": "glm-5.1",
       "name": "GLM 5.1",
-      "cost_per_1m_in": 0.845,
-      "cost_per_1m_out": 3.38,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.18311,
+      "pricing": {
+        "input": 0.845,
+        "output": 3.38,
+        "cache_hit": 0.18311
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
@@ -1996,10 +2095,11 @@
     {
       "id": "glm-5.2",
       "name": "GLM 5.2",
-      "cost_per_1m_in": 1.1268,
-      "cost_per_1m_out": 3.9438,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2817,
+      "pricing": {
+        "input": 1.1268,
+        "output": 3.9438,
+        "cache_hit": 0.2817
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2014,10 +2114,11 @@
     {
       "id": "glm-5.2-fast-preview",
       "name": "GLM 5.2 Fast Preview",
-      "cost_per_1m_in": 2.254,
-      "cost_per_1m_out": 7.889,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5635,
+      "pricing": {
+        "input": 2.254,
+        "output": 7.889,
+        "cache_hit": 0.5635
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2032,10 +2133,11 @@
     {
       "id": "glm-5.3",
       "name": "GLM 5.3",
-      "cost_per_1m_in": 1.1268,
-      "cost_per_1m_out": 3.9438,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2817,
+      "pricing": {
+        "input": 1.1268,
+        "output": 3.9438,
+        "cache_hit": 0.2817
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2050,10 +2152,11 @@
     {
       "id": "glm-5.3-flash",
       "name": "GLM 5.3 Flash",
-      "cost_per_1m_in": 0.11268,
-      "cost_per_1m_out": 0.39438,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.02817,
+      "pricing": {
+        "input": 0.11268,
+        "output": 0.39438,
+        "cache_hit": 0.02817
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2068,10 +2171,11 @@
     {
       "id": "glm-5v-turbo",
       "name": "GLM 5 Vision Turbo",
-      "cost_per_1m_in": 0.7042,
-      "cost_per_1m_out": 3.09848,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.16901,
+      "pricing": {
+        "input": 0.7042,
+        "output": 3.09848,
+        "cache_hit": 0.16901
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": false,
@@ -2080,10 +2184,11 @@
     {
       "id": "gpt-4.1",
       "name": "GPT 4.1",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -2092,10 +2197,10 @@
     {
       "id": "gpt-4.1-free",
       "name": "GPT 4.1 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -2104,10 +2209,11 @@
     {
       "id": "gpt-4.1-mini",
       "name": "GPT 4.1 Mini",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 1.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_hit": 0.1
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -2116,10 +2222,10 @@
     {
       "id": "gpt-4.1-mini-free",
       "name": "GPT 4.1 Mini (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -2128,10 +2234,11 @@
     {
       "id": "gpt-4.1-nano",
       "name": "GPT 4.1 Nano",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_hit": 0.025
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -2140,10 +2247,10 @@
     {
       "id": "gpt-4.1-nano-free",
       "name": "GPT 4.1 Nano (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -2152,10 +2259,11 @@
     {
       "id": "gpt-4o",
       "name": "GPT 4o",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 10,
+        "cache_hit": 1.25
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -2164,10 +2272,11 @@
     {
       "id": "gpt-4o-2024-11-20",
       "name": "GPT 4o 2024 11-20",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 10,
+        "cache_hit": 1.25
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -2176,10 +2285,10 @@
     {
       "id": "gpt-4o-audio-preview",
       "name": "GPT 4o Audio Preview",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 10
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -2188,10 +2297,10 @@
     {
       "id": "gpt-4o-free",
       "name": "GPT 4o (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -2200,10 +2309,11 @@
     {
       "id": "gpt-4o-mini",
       "name": "GPT 4o Mini",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.075
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -2212,10 +2322,11 @@
     {
       "id": "gpt-4o-mini-search-preview",
       "name": "GPT 4o Mini Search Preview",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.075
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -2224,10 +2335,11 @@
     {
       "id": "gpt-4o-search-preview",
       "name": "GPT 4o Search Preview",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 10,
+        "cache_hit": 1.25
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -2236,10 +2348,11 @@
     {
       "id": "gpt-5",
       "name": "GPT 5",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2254,10 +2367,11 @@
     {
       "id": "gpt-5-chat-latest",
       "name": "GPT 5 Chat",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -2266,10 +2380,11 @@
     {
       "id": "gpt-5-codex",
       "name": "GPT-5-Codex",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2284,10 +2399,11 @@
     {
       "id": "gpt-5-mini",
       "name": "GPT 5 Mini",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_hit": 0.025
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2302,10 +2418,11 @@
     {
       "id": "gpt-5-nano",
       "name": "GPT 5 Nano",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.005,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.4,
+        "cache_hit": 0.005
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2320,10 +2437,10 @@
     {
       "id": "gpt-5-pro",
       "name": "GPT 5 Pro",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 120,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 15,
+        "output": 120
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2338,10 +2455,11 @@
     {
       "id": "gpt-5.1",
       "name": "GPT 5.1",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2356,10 +2474,11 @@
     {
       "id": "gpt-5.1-chat-latest",
       "name": "GPT 5.1 Chat",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -2368,10 +2487,11 @@
     {
       "id": "gpt-5.1-codex",
       "name": "GPT-5.1-Codex",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2386,10 +2506,11 @@
     {
       "id": "gpt-5.1-codex-max",
       "name": "GPT-5.1-Codex Max",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2404,10 +2525,11 @@
     {
       "id": "gpt-5.1-codex-mini",
       "name": "GPT-5.1-Codex Mini",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_hit": 0.025
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2422,10 +2544,11 @@
     {
       "id": "gpt-5.2",
       "name": "GPT 5.2",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2440,10 +2563,11 @@
     {
       "id": "gpt-5.2-chat-latest",
       "name": "GPT 5.2 Chat",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -2452,10 +2576,11 @@
     {
       "id": "gpt-5.2-codex",
       "name": "GPT-5.2-Codex",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2470,10 +2595,11 @@
     {
       "id": "gpt-5.2-high",
       "name": "GPT 5.2 High",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2488,10 +2614,11 @@
     {
       "id": "gpt-5.2-low",
       "name": "GPT 5.2 Low",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2506,10 +2633,11 @@
     {
       "id": "gpt-5.2-pro",
       "name": "GPT 5.2 Pro",
-      "cost_per_1m_in": 21,
-      "cost_per_1m_out": 168,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 2.1,
+      "pricing": {
+        "input": 21,
+        "output": 168,
+        "cache_hit": 2.1
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2524,10 +2652,11 @@
     {
       "id": "gpt-5.3-chat-latest",
       "name": "GPT 5.3 Chat",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -2536,10 +2665,11 @@
     {
       "id": "gpt-5.3-codex",
       "name": "GPT-5.3-Codex",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2554,10 +2684,11 @@
     {
       "id": "gpt-5.4",
       "name": "GPT 5.4",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 15,
+        "cache_hit": 0.25
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2572,10 +2703,11 @@
     {
       "id": "gpt-5.4-high",
       "name": "GPT 5.4 High",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 15,
+        "cache_hit": 0.25
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2590,10 +2722,11 @@
     {
       "id": "gpt-5.4-low",
       "name": "GPT 5.4 Low",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 15,
+        "cache_hit": 0.25
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2608,10 +2741,11 @@
     {
       "id": "gpt-5.4-mini",
       "name": "GPT 5.4 Mini",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.75,
+        "output": 4.5,
+        "cache_hit": 0.075
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -2620,10 +2754,11 @@
     {
       "id": "gpt-5.4-nano",
       "name": "GPT 5.4 Nano",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.25,
+        "cache_hit": 0.02
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2638,10 +2773,11 @@
     {
       "id": "gpt-5.4-pro",
       "name": "GPT 5.4 Pro",
-      "cost_per_1m_in": 30,
-      "cost_per_1m_out": 180,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 30,
+      "pricing": {
+        "input": 30,
+        "output": 180,
+        "cache_hit": 30
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2656,10 +2792,11 @@
     {
       "id": "gpt-5.5",
       "name": "GPT 5.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 30,
+        "cache_hit": 0.5
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2674,10 +2811,10 @@
     {
       "id": "gpt-5.5-free",
       "name": "GPT 5.5 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2692,10 +2829,11 @@
     {
       "id": "gpt-5.5-pro",
       "name": "GPT 5.5 Pro",
-      "cost_per_1m_in": 30,
-      "cost_per_1m_out": 180,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 30,
+      "pricing": {
+        "input": 30,
+        "output": 180,
+        "cache_hit": 30
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2710,10 +2848,12 @@
     {
       "id": "gpt-5.6-luna",
       "name": "GPT 5.6 Luna",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.25,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.2,
+        "cache_create": 0.25,
+        "cache_hit": 0.02
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2728,10 +2868,12 @@
     {
       "id": "gpt-5.6-sol",
       "name": "GPT 5.6 Sol",
-      "cost_per_1m_in": 4,
-      "cost_per_1m_out": 20,
-      "cost_per_1m_in_cached": 5,
-      "cost_per_1m_out_cached": 0.4,
+      "pricing": {
+        "input": 4,
+        "output": 20,
+        "cache_create": 5,
+        "cache_hit": 0.4
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2746,10 +2888,12 @@
     {
       "id": "gpt-5.6-sol-disc",
       "name": "GPT 5.6 Sol Disc",
-      "cost_per_1m_in": 4,
-      "cost_per_1m_out": 20,
-      "cost_per_1m_in_cached": 5,
-      "cost_per_1m_out_cached": 0.4,
+      "pricing": {
+        "input": 4,
+        "output": 20,
+        "cache_create": 5,
+        "cache_hit": 0.4
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2764,10 +2908,12 @@
     {
       "id": "gpt-5.6-terra",
       "name": "GPT 5.6 Terra",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2782,10 +2928,11 @@
     {
       "id": "gpt-audio-1.5",
       "name": "GPT Audio 1.5",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 2.5,
+      "pricing": {
+        "input": 2.5,
+        "output": 10,
+        "cache_hit": 2.5
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -2800,10 +2947,11 @@
     {
       "id": "gpt-chat-latest",
       "name": "GPT Chat",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 30,
+        "cache_hit": 0.5
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2818,10 +2966,10 @@
     {
       "id": "gpt-oss-120b",
       "name": "gpt-oss-120b",
-      "cost_per_1m_in": 0.18,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.18,
+        "output": 0.9
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -2836,10 +2984,10 @@
     {
       "id": "gpt-oss-20b",
       "name": "gpt-oss-20b",
-      "cost_per_1m_in": 0.11,
-      "cost_per_1m_out": 0.55,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.11,
+        "output": 0.55
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -2854,10 +3002,10 @@
     {
       "id": "gpt-oss-20b-free",
       "name": "GPT Oss 20B (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
@@ -2866,10 +3014,11 @@
     {
       "id": "grok-4",
       "name": "Grok 4",
-      "cost_per_1m_in": 3.3,
-      "cost_per_1m_out": 16.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.825,
+      "pricing": {
+        "input": 3.3,
+        "output": 16.5,
+        "cache_hit": 0.825
+      },
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2884,10 +3033,11 @@
     {
       "id": "grok-4-1-fast-non-reasoning",
       "name": "Grok 4.1 Fast",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.5,
+        "cache_hit": 0.05
+      },
       "context_window": 2000000,
       "default_max_tokens": 200000,
       "can_reason": false,
@@ -2896,10 +3046,11 @@
     {
       "id": "grok-4-1-fast-reasoning",
       "name": "Grok 4.1 Fast (reasoning)",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.5,
+        "cache_hit": 0.05
+      },
       "context_window": 2000000,
       "default_max_tokens": 200000,
       "can_reason": true,
@@ -2914,10 +3065,11 @@
     {
       "id": "grok-4-20-non-reasoning",
       "name": "Grok 4 20",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 200000,
       "can_reason": true,
@@ -2932,10 +3084,11 @@
     {
       "id": "grok-4-20-reasoning",
       "name": "Grok 4 20 (reasoning)",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 200000,
       "can_reason": true,
@@ -2950,10 +3103,11 @@
     {
       "id": "grok-4-fast-non-reasoning",
       "name": "Grok 4 Fast",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.5,
+        "cache_hit": 0.05
+      },
       "context_window": 2000000,
       "default_max_tokens": 30000,
       "can_reason": false,
@@ -2962,10 +3116,11 @@
     {
       "id": "grok-4-fast-reasoning",
       "name": "Grok 4 Fast (reasoning)",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.5,
+        "cache_hit": 0.05
+      },
       "context_window": 2000000,
       "default_max_tokens": 30000,
       "can_reason": true,
@@ -2980,10 +3135,11 @@
     {
       "id": "grok-4.20-beta-0309-non-reasoning",
       "name": "Grok 4.20 Beta 0309",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 200000,
       "can_reason": true,
@@ -2998,10 +3154,11 @@
     {
       "id": "grok-4.20-beta-0309-reasoning",
       "name": "Grok 4.20 Beta 0309 (reasoning)",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 200000,
       "can_reason": true,
@@ -3016,10 +3173,11 @@
     {
       "id": "grok-4.20-multi-agent-0309",
       "name": "Grok 4.20 Multi Agent 0309",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 200000,
       "can_reason": true,
@@ -3034,10 +3192,11 @@
     {
       "id": "grok-4.20-multi-agent-beta-0309",
       "name": "Grok 4.20 Multi Agent Beta 0309",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 200000,
       "can_reason": true,
@@ -3052,10 +3211,11 @@
     {
       "id": "grok-4.3",
       "name": "Grok 4.3",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3070,10 +3230,11 @@
     {
       "id": "grok-4.5",
       "name": "Grok 4.5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.5
+      },
       "context_window": 500000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -3088,10 +3249,11 @@
     {
       "id": "grok-4.6",
       "name": "Grok 4.6",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.5
+      },
       "context_window": 500000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -3106,10 +3268,11 @@
     {
       "id": "grok-build-0.1",
       "name": "Grok Build 0.1",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1,
+        "output": 2,
+        "cache_hit": 0.2
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -3124,10 +3287,11 @@
     {
       "id": "grok-code-fast-1",
       "name": "Grok Code Fast 1",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1,
+        "output": 2,
+        "cache_hit": 0.2
+      },
       "context_window": 256000,
       "default_max_tokens": 10000,
       "can_reason": true,
@@ -3142,10 +3306,11 @@
     {
       "id": "hy3",
       "name": "Hy3",
-      "cost_per_1m_in": 0.1562,
-      "cost_per_1m_out": 0.6248,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03905,
+      "pricing": {
+        "input": 0.1562,
+        "output": 0.6248,
+        "cache_hit": 0.03905
+      },
       "context_window": 256000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -3160,10 +3325,10 @@
     {
       "id": "hy3-free",
       "name": "Hy3 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -3178,10 +3343,11 @@
     {
       "id": "hy3-preview",
       "name": "Hy3 Preview",
-      "cost_per_1m_in": 0.17,
-      "cost_per_1m_out": 0.56666,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.051,
+      "pricing": {
+        "input": 0.17,
+        "output": 0.56666,
+        "cache_hit": 0.051
+      },
       "context_window": 256000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -3196,10 +3362,11 @@
     {
       "id": "hy4-preview",
       "name": "Hy4 Preview",
-      "cost_per_1m_in": 0.845,
-      "cost_per_1m_out": 2.535,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04225,
+      "pricing": {
+        "input": 0.845,
+        "output": 2.535,
+        "cache_hit": 0.04225
+      },
       "context_window": 1024000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -3214,10 +3381,10 @@
     {
       "id": "jina-deepsearch-v1",
       "name": "Jina Deepsearch V1",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.05,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.05
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3232,10 +3399,10 @@
     {
       "id": "k2.6-code-preview-free",
       "name": "K2.6 Code Preview (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -3250,10 +3417,10 @@
     {
       "id": "kat-dev",
       "name": "Kat Dev",
-      "cost_per_1m_in": 0.137,
-      "cost_per_1m_out": 0.548,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.137,
+        "output": 0.548
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -3262,10 +3429,10 @@
     {
       "id": "kimi-for-coding-free",
       "name": "Kimi For Coding (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -3280,10 +3447,10 @@
     {
       "id": "kimi-k2-0711",
       "name": "Kimi K2 0711",
-      "cost_per_1m_in": 0.54,
-      "cost_per_1m_out": 2.16,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.54,
+        "output": 2.16
+      },
       "context_window": 131000,
       "default_max_tokens": 13100,
       "can_reason": false,
@@ -3292,10 +3459,11 @@
     {
       "id": "kimi-k2-thinking",
       "name": "Kimi K2 Thinking",
-      "cost_per_1m_in": 0.548,
-      "cost_per_1m_out": 2.192,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.137,
+      "pricing": {
+        "input": 0.548,
+        "output": 2.192,
+        "cache_hit": 0.137
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -3310,10 +3478,11 @@
     {
       "id": "kimi-k2-turbo-preview",
       "name": "Kimi K2 Turbo Preview",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 1.2,
+        "output": 4.8,
+        "cache_hit": 0.3
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -3322,10 +3491,11 @@
     {
       "id": "kimi-k2.5",
       "name": "Kimi K2.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.105,
+      "pricing": {
+        "input": 0.6,
+        "output": 3,
+        "cache_hit": 0.105
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -3340,10 +3510,11 @@
     {
       "id": "kimi-k2.6",
       "name": "Kimi K2.6",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 3.9995,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.16084,
+      "pricing": {
+        "input": 0.95,
+        "output": 3.9995,
+        "cache_hit": 0.16084
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3358,10 +3529,11 @@
     {
       "id": "kimi-k2.7-code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 3.9995,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.16084,
+      "pricing": {
+        "input": 0.95,
+        "output": 3.9995,
+        "cache_hit": 0.16084
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3376,10 +3548,11 @@
     {
       "id": "kimi-k2.7-code-highspeed",
       "name": "Kimi K2.7 Code Highspeed",
-      "cost_per_1m_in": 1.9,
-      "cost_per_1m_out": 7.999,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.32167,
+      "pricing": {
+        "input": 1.9,
+        "output": 7.999,
+        "cache_hit": 0.32167
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3394,10 +3567,11 @@
     {
       "id": "kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_hit": 0.3
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -3412,10 +3586,10 @@
     {
       "id": "laguna-s-2.1-free",
       "name": "Laguna S 2.1 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -3424,10 +3598,10 @@
     {
       "id": "laguna-xs-2.1-free",
       "name": "Laguna Xs 2.1 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -3436,10 +3610,10 @@
     {
       "id": "lfm-2.5-2.6b-free",
       "name": "Lfm 2.5 2.6b (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -3448,10 +3622,10 @@
     {
       "id": "ling-3.0-flash-free",
       "name": "Ling 3.0 Flash (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -3460,10 +3634,10 @@
     {
       "id": "ling-3.0-tiny-free",
       "name": "Ling 3.0 Tiny (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -3472,10 +3646,10 @@
     {
       "id": "llama-4-maverick",
       "name": "Llama 4 Maverick",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -3484,10 +3658,10 @@
     {
       "id": "llama-4-scout",
       "name": "Llama 4 Scout",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 131000,
       "default_max_tokens": 13100,
       "can_reason": false,
@@ -3496,10 +3670,10 @@
     {
       "id": "mai-thinking-1",
       "name": "Mai Thinking 1",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 8
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -3514,10 +3688,11 @@
     {
       "id": "mercury-2.5-preview",
       "name": "Mercury 2.5 Preview",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.75,
+        "cache_hit": 0.02
+      },
       "context_window": 260000,
       "default_max_tokens": 26000,
       "can_reason": true,
@@ -3532,10 +3707,10 @@
     {
       "id": "mimo-v2-flash-free",
       "name": "MiMo V2 Flash (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -3544,10 +3719,11 @@
     {
       "id": "mimo-v2-omni",
       "name": "MiMo V2 Omni",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.088,
+      "pricing": {
+        "input": 0.44,
+        "output": 2.2,
+        "cache_hit": 0.088
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -3556,10 +3732,11 @@
     {
       "id": "mimo-v2-pro",
       "name": "MiMo V2 Pro",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 3.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.22,
+      "pricing": {
+        "input": 1.1,
+        "output": 3.3,
+        "cache_hit": 0.22
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": false,
@@ -3568,10 +3745,10 @@
     {
       "id": "minimax-m2",
       "name": "MiniMax M2",
-      "cost_per_1m_in": 0.288,
-      "cost_per_1m_out": 1.152,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.288,
+        "output": 1.152
+      },
       "context_window": 204800,
       "default_max_tokens": 20480,
       "can_reason": true,
@@ -3586,10 +3763,10 @@
     {
       "id": "minimax-m2.1",
       "name": "MiniMax M2.1",
-      "cost_per_1m_in": 0.288,
-      "cost_per_1m_out": 1.152,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.288,
+        "output": 1.152
+      },
       "context_window": 204800,
       "default_max_tokens": 20480,
       "can_reason": true,
@@ -3604,10 +3781,10 @@
     {
       "id": "minimax-m2.5",
       "name": "MiniMax M2.5",
-      "cost_per_1m_in": 0.288,
-      "cost_per_1m_out": 1.152,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.288,
+        "output": 1.152
+      },
       "context_window": 204800,
       "default_max_tokens": 20480,
       "can_reason": true,
@@ -3622,10 +3799,10 @@
     {
       "id": "minimax-m2.5-highspeed",
       "name": "MiniMax M2.5 Highspeed",
-      "cost_per_1m_in": 0.288,
-      "cost_per_1m_out": 1.152,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.288,
+        "output": 1.152
+      },
       "context_window": 204800,
       "default_max_tokens": 20480,
       "can_reason": true,
@@ -3640,10 +3817,11 @@
     {
       "id": "minimax-m2.7",
       "name": "MiniMax M2.7",
-      "cost_per_1m_in": 0.2958,
-      "cost_per_1m_out": 1.1832,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05916,
+      "pricing": {
+        "input": 0.2958,
+        "output": 1.1832,
+        "cache_hit": 0.05916
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
@@ -3658,10 +3836,10 @@
     {
       "id": "minimax-m2.7-free",
       "name": "MiniMax M2.7 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 196608,
       "default_max_tokens": 19660,
       "can_reason": false,
@@ -3670,10 +3848,10 @@
     {
       "id": "minimax-m3",
       "name": "MiniMax M3",
-      "cost_per_1m_in": 0.288,
-      "cost_per_1m_out": 1.152,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.288,
+        "output": 1.152
+      },
       "context_window": 204800,
       "default_max_tokens": 20480,
       "can_reason": true,
@@ -3688,10 +3866,10 @@
     {
       "id": "minimax-m3-free",
       "name": "MiniMax M3 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -3700,10 +3878,10 @@
     {
       "id": "mistral-large-3",
       "name": "Mistral Large 3",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 1.5
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -3712,10 +3890,10 @@
     {
       "id": "muse-spark-1.1",
       "name": "Muse Spark 1.1",
-      "cost_per_1m_in": 1.375,
-      "cost_per_1m_out": 4.675,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.375,
+        "output": 4.675
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3730,10 +3908,10 @@
     {
       "id": "muse-spark-1.2",
       "name": "Muse Spark 1.2",
-      "cost_per_1m_in": 1.375,
-      "cost_per_1m_out": 4.675,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.375,
+        "output": 4.675
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3748,10 +3926,10 @@
     {
       "id": "nemotron-3-nano-30b-a3b-free",
       "name": "Nemotron 3 Nano 30B A3B (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -3760,10 +3938,10 @@
     {
       "id": "nemotron-3-nano-omni-30b-a3b-reasoning-free",
       "name": "Nemotron 3 Nano Omni 30B A3B (reasoning) (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -3772,10 +3950,10 @@
     {
       "id": "nemotron-3-super-120b-a12b-free",
       "name": "Nemotron 3 Super 120B A12B (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -3784,10 +3962,10 @@
     {
       "id": "nemotron-3-ultra-550b-a55b-free",
       "name": "Nemotron 3 Ultra 550B A55B (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": false,
@@ -3796,10 +3974,10 @@
     {
       "id": "nemotron-3.5-content-safety-free",
       "name": "Nemotron 3.5 Content Safety (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -3808,10 +3986,10 @@
     {
       "id": "nemotron-3.5-lightning-free",
       "name": "Nemotron 3.5 Lightning (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": false,
@@ -3820,10 +3998,10 @@
     {
       "id": "nemotron-nano-12b-v2-vl-free",
       "name": "Nemotron Nano 12B V2 VL (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -3832,10 +4010,10 @@
     {
       "id": "nemotron-nano-9b-v2-free",
       "name": "Nemotron Nano 9B V2 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -3844,10 +4022,10 @@
     {
       "id": "north-mini-code-free",
       "name": "North Mini Code (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -3856,10 +4034,11 @@
     {
       "id": "nvidia-nemotron-3-super-120b-a12b",
       "name": "Nvidia Nemotron 3 Super 120B A12B",
-      "cost_per_1m_in": 0.11,
-      "cost_per_1m_out": 0.55,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0275,
+      "pricing": {
+        "input": 0.11,
+        "output": 0.55,
+        "cache_hit": 0.0275
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3874,10 +4053,11 @@
     {
       "id": "o3",
       "name": "O3",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3892,10 +4072,11 @@
     {
       "id": "o3-mini",
       "name": "O3 Mini",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.55
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3910,10 +4091,11 @@
     {
       "id": "o3-pro",
       "name": "O3 Pro",
-      "cost_per_1m_in": 20,
-      "cost_per_1m_out": 80,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 20,
+      "pricing": {
+        "input": 20,
+        "output": 80,
+        "cache_hit": 20
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3928,10 +4110,11 @@
     {
       "id": "o4-mini",
       "name": "O4 Mini",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.275,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.275
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3946,10 +4129,10 @@
     {
       "id": "ox-alpha",
       "name": "Ox Alpha",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -3958,10 +4141,10 @@
     {
       "id": "qwen3-235b-a22b",
       "name": "Qwen3 235B A22B",
-      "cost_per_1m_in": 0.28,
-      "cost_per_1m_out": 1.12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.28,
+        "output": 1.12
+      },
       "context_window": 131100,
       "default_max_tokens": 13110,
       "can_reason": false,
@@ -3970,10 +4153,10 @@
     {
       "id": "qwen3-235b-a22b-instruct-2507",
       "name": "Qwen3 235B A22B Instruct 2507",
-      "cost_per_1m_in": 0.28,
-      "cost_per_1m_out": 1.12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.28,
+        "output": 1.12
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -3982,10 +4165,10 @@
     {
       "id": "qwen3-235b-a22b-thinking-2507",
       "name": "Qwen3 235B A22B Thinking 2507",
-      "cost_per_1m_in": 0.28,
-      "cost_per_1m_out": 2.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.28,
+        "output": 2.8
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -4000,10 +4183,11 @@
     {
       "id": "qwen3-coder-30b-a3b-instruct",
       "name": "Qwen3 Coder 30B A3B Instruct",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.8,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 262000,
       "can_reason": false,
@@ -4012,10 +4196,11 @@
     {
       "id": "qwen3-coder-480b-a35b-instruct",
       "name": "Qwen3 Coder 480B A35B Instruct",
-      "cost_per_1m_in": 0.82,
-      "cost_per_1m_out": 3.28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.82,
+      "pricing": {
+        "input": 0.82,
+        "output": 3.28,
+        "cache_hit": 0.82
+      },
       "context_window": 262000,
       "default_max_tokens": 26200,
       "can_reason": false,
@@ -4024,10 +4209,11 @@
     {
       "id": "qwen3-coder-flash",
       "name": "Qwen3 Coder Flash",
-      "cost_per_1m_in": 0.136,
-      "cost_per_1m_out": 0.544,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.136,
+      "pricing": {
+        "input": 0.136,
+        "output": 0.544,
+        "cache_hit": 0.136
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -4036,10 +4222,11 @@
     {
       "id": "qwen3-coder-next",
       "name": "Qwen3 Coder Next",
-      "cost_per_1m_in": 0.137,
-      "cost_per_1m_out": 0.548,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.137,
+      "pricing": {
+        "input": 0.137,
+        "output": 0.548,
+        "cache_hit": 0.137
+      },
       "context_window": 2000000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -4048,10 +4235,11 @@
     {
       "id": "qwen3-coder-plus",
       "name": "Qwen3 Coder Plus",
-      "cost_per_1m_in": 0.54,
-      "cost_per_1m_out": 2.16,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.108,
+      "pricing": {
+        "input": 0.54,
+        "output": 2.16,
+        "cache_hit": 0.108
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -4060,10 +4248,11 @@
     {
       "id": "qwen3-coder-plus-2025-07-22",
       "name": "Qwen3 Coder Plus 2025 07-22",
-      "cost_per_1m_in": 0.54,
-      "cost_per_1m_out": 2.16,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.54,
+      "pricing": {
+        "input": 0.54,
+        "output": 2.16,
+        "cache_hit": 0.54
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -4072,10 +4261,12 @@
     {
       "id": "qwen3-max",
       "name": "Qwen3 Max",
-      "cost_per_1m_in": 0.4508,
-      "cost_per_1m_out": 1.8032,
-      "cost_per_1m_in_cached": 0.5635,
-      "cost_per_1m_out_cached": 0.09016,
+      "pricing": {
+        "input": 0.4508,
+        "output": 1.8032,
+        "cache_create": 0.5635,
+        "cache_hit": 0.09016
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -4084,10 +4275,12 @@
     {
       "id": "qwen3-max-2026-01-23",
       "name": "Qwen3 Max 2026 01-23",
-      "cost_per_1m_in": 0.4508,
-      "cost_per_1m_out": 1.8032,
-      "cost_per_1m_in_cached": 0.5635,
-      "cost_per_1m_out_cached": 0.09016,
+      "pricing": {
+        "input": 0.4508,
+        "output": 1.8032,
+        "cache_create": 0.5635,
+        "cache_hit": 0.09016
+      },
       "context_window": 252000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -4102,10 +4295,10 @@
     {
       "id": "qwen3-next-80b-a3b-instruct",
       "name": "Qwen3 Next 80B A3B Instruct",
-      "cost_per_1m_in": 0.138,
-      "cost_per_1m_out": 0.552,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.138,
+        "output": 0.552
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -4114,10 +4307,10 @@
     {
       "id": "qwen3-next-80b-a3b-thinking",
       "name": "Qwen3 Next 80B A3B Thinking",
-      "cost_per_1m_in": 0.142,
-      "cost_per_1m_out": 1.42,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.142,
+        "output": 1.42
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -4132,10 +4325,10 @@
     {
       "id": "qwen3-vl-235b-a22b-instruct",
       "name": "Qwen3 VL 235B A22B Instruct",
-      "cost_per_1m_in": 0.274,
-      "cost_per_1m_out": 1.096,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.274,
+        "output": 1.096
+      },
       "context_window": 131000,
       "default_max_tokens": 33000,
       "can_reason": false,
@@ -4144,10 +4337,10 @@
     {
       "id": "qwen3-vl-235b-a22b-thinking",
       "name": "Qwen3 VL 235B A22B Thinking",
-      "cost_per_1m_in": 0.274,
-      "cost_per_1m_out": 2.74,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.274,
+        "output": 2.74
+      },
       "context_window": 131000,
       "default_max_tokens": 33000,
       "can_reason": true,
@@ -4162,10 +4355,10 @@
     {
       "id": "qwen3-vl-30b-a3b-instruct",
       "name": "Qwen3 VL 30B A3B Instruct",
-      "cost_per_1m_in": 0.1028,
-      "cost_per_1m_out": 0.4112,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1028,
+        "output": 0.4112
+      },
       "context_window": 128000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -4174,10 +4367,10 @@
     {
       "id": "qwen3-vl-30b-a3b-thinking",
       "name": "Qwen3 VL 30B A3B Thinking",
-      "cost_per_1m_in": 0.1028,
-      "cost_per_1m_out": 1.028,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1028,
+        "output": 1.028
+      },
       "context_window": 128000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -4192,10 +4385,11 @@
     {
       "id": "qwen3-vl-flash",
       "name": "Qwen3 VL Flash",
-      "cost_per_1m_in": 0.0206,
-      "cost_per_1m_out": 0.206,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.00412,
+      "pricing": {
+        "input": 0.0206,
+        "output": 0.206,
+        "cache_hit": 0.00412
+      },
       "context_window": 254000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -4204,10 +4398,11 @@
     {
       "id": "qwen3-vl-flash-2026-01-22",
       "name": "Qwen3 VL Flash 2026 01-22",
-      "cost_per_1m_in": 0.0206,
-      "cost_per_1m_out": 0.206,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0206,
+      "pricing": {
+        "input": 0.0206,
+        "output": 0.206,
+        "cache_hit": 0.0206
+      },
       "context_window": 254000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -4216,10 +4411,11 @@
     {
       "id": "qwen3-vl-plus",
       "name": "Qwen3 VL Plus",
-      "cost_per_1m_in": 0.137,
-      "cost_per_1m_out": 1.37,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0274,
+      "pricing": {
+        "input": 0.137,
+        "output": 1.37,
+        "cache_hit": 0.0274
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -4228,10 +4424,11 @@
     {
       "id": "qwen3.5-122b-a10b",
       "name": "Qwen3.5 122B A10B",
-      "cost_per_1m_in": 0.1126,
-      "cost_per_1m_out": 0.9008,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1126,
+      "pricing": {
+        "input": 0.1126,
+        "output": 0.9008,
+        "cache_hit": 0.1126
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4246,10 +4443,11 @@
     {
       "id": "qwen3.5-27b",
       "name": "Qwen3.5 27B",
-      "cost_per_1m_in": 0.0846,
-      "cost_per_1m_out": 0.6768,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0846,
+      "pricing": {
+        "input": 0.0846,
+        "output": 0.6768,
+        "cache_hit": 0.0846
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4264,10 +4462,11 @@
     {
       "id": "qwen3.5-35b-a3b",
       "name": "Qwen3.5 35B A3B",
-      "cost_per_1m_in": 0.0564,
-      "cost_per_1m_out": 0.4512,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0564,
+      "pricing": {
+        "input": 0.0564,
+        "output": 0.4512,
+        "cache_hit": 0.0564
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4282,10 +4481,11 @@
     {
       "id": "qwen3.5-397b-a17b",
       "name": "Qwen3.5 397B A17B",
-      "cost_per_1m_in": 0.1644,
-      "cost_per_1m_out": 0.9864,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1644,
+      "pricing": {
+        "input": 0.1644,
+        "output": 0.9864,
+        "cache_hit": 0.1644
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4300,10 +4500,12 @@
     {
       "id": "qwen3.5-flash",
       "name": "Qwen3.5 Flash",
-      "cost_per_1m_in": 0.0282,
-      "cost_per_1m_out": 0.282,
-      "cost_per_1m_in_cached": 0.03525,
-      "cost_per_1m_out_cached": 0.00282,
+      "pricing": {
+        "input": 0.0282,
+        "output": 0.282,
+        "cache_create": 0.03525,
+        "cache_hit": 0.00282
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4318,10 +4520,12 @@
     {
       "id": "qwen3.5-plus",
       "name": "Qwen3.5 Plus",
-      "cost_per_1m_in": 0.1096,
-      "cost_per_1m_out": 0.6576,
-      "cost_per_1m_in_cached": 0.137,
-      "cost_per_1m_out_cached": 0.01096,
+      "pricing": {
+        "input": 0.1096,
+        "output": 0.6576,
+        "cache_create": 0.137,
+        "cache_hit": 0.01096
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4336,10 +4540,10 @@
     {
       "id": "qwen3.6-27b",
       "name": "Qwen3.6 27B",
-      "cost_per_1m_in": 0.422,
-      "cost_per_1m_out": 2.532,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.422,
+        "output": 2.532
+      },
       "context_window": 254000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4354,10 +4558,11 @@
     {
       "id": "qwen3.6-35b-a3b",
       "name": "Qwen3.6 35B A3B",
-      "cost_per_1m_in": 0.254,
-      "cost_per_1m_out": 1.524,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.254,
+      "pricing": {
+        "input": 0.254,
+        "output": 1.524,
+        "cache_hit": 0.254
+      },
       "context_window": 254000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4372,10 +4577,12 @@
     {
       "id": "qwen3.6-flash",
       "name": "Qwen3.6 Flash",
-      "cost_per_1m_in": 0.169,
-      "cost_per_1m_out": 1.014,
-      "cost_per_1m_in_cached": 0.21125,
-      "cost_per_1m_out_cached": 0.0169,
+      "pricing": {
+        "input": 0.169,
+        "output": 1.014,
+        "cache_create": 0.21125,
+        "cache_hit": 0.0169
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4390,10 +4597,12 @@
     {
       "id": "qwen3.6-max-preview",
       "name": "Qwen3.6 Max Preview",
-      "cost_per_1m_in": 1.268,
-      "cost_per_1m_out": 7.608,
-      "cost_per_1m_in_cached": 1.585,
-      "cost_per_1m_out_cached": 0.1268,
+      "pricing": {
+        "input": 1.268,
+        "output": 7.608,
+        "cache_create": 1.585,
+        "cache_hit": 0.1268
+      },
       "context_window": 240000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4408,10 +4617,12 @@
     {
       "id": "qwen3.6-plus",
       "name": "Qwen3.6 Plus",
-      "cost_per_1m_in": 0.282,
-      "cost_per_1m_out": 1.692,
-      "cost_per_1m_in_cached": 0.3525,
-      "cost_per_1m_out_cached": 0.0282,
+      "pricing": {
+        "input": 0.282,
+        "output": 1.692,
+        "cache_create": 0.3525,
+        "cache_hit": 0.0282
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4426,10 +4637,10 @@
     {
       "id": "qwen3.6-plus-preview-free",
       "name": "Qwen3.6 Plus Preview (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 65535,
       "can_reason": true,
@@ -4444,10 +4655,12 @@
     {
       "id": "qwen3.7-flash",
       "name": "Qwen3.7 Flash",
-      "cost_per_1m_in": 0.0282,
-      "cost_per_1m_out": 0.1128,
-      "cost_per_1m_in_cached": 0.03525,
-      "cost_per_1m_out_cached": 0.00564,
+      "pricing": {
+        "input": 0.0282,
+        "output": 0.1128,
+        "cache_create": 0.03525,
+        "cache_hit": 0.00564
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4462,10 +4675,12 @@
     {
       "id": "qwen3.7-max",
       "name": "Qwen3.7 Max",
-      "cost_per_1m_in": 1.69,
-      "cost_per_1m_out": 5.07,
-      "cost_per_1m_in_cached": 2.1125,
-      "cost_per_1m_out_cached": 0.169,
+      "pricing": {
+        "input": 1.69,
+        "output": 5.07,
+        "cache_create": 2.1125,
+        "cache_hit": 0.169
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4480,10 +4695,12 @@
     {
       "id": "qwen3.7-plus",
       "name": "Qwen3.7 Plus",
-      "cost_per_1m_in": 0.282,
-      "cost_per_1m_out": 1.128,
-      "cost_per_1m_in_cached": 0.3525,
-      "cost_per_1m_out_cached": 0.0564,
+      "pricing": {
+        "input": 0.282,
+        "output": 1.128,
+        "cache_create": 0.3525,
+        "cache_hit": 0.0564
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -4498,10 +4715,11 @@
     {
       "id": "qwen3.8-2.4t-a95b",
       "name": "Qwen3.8 2.4t A95B",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.5
+      },
       "context_window": 262000,
       "default_max_tokens": 26200,
       "can_reason": true,
@@ -4516,10 +4734,12 @@
     {
       "id": "qwen3.8-flash",
       "name": "Qwen3.8 Flash",
-      "cost_per_1m_in": 0.1126,
-      "cost_per_1m_out": 0.38003,
-      "cost_per_1m_in_cached": 0.17594,
-      "cost_per_1m_out_cached": 0.01408,
+      "pricing": {
+        "input": 0.1126,
+        "output": 0.38003,
+        "cache_create": 0.17594,
+        "cache_hit": 0.01408
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -4534,10 +4754,12 @@
     {
       "id": "qwen3.8-max",
       "name": "Qwen3.8 Max",
-      "cost_per_1m_in": 1.69,
-      "cost_per_1m_out": 5.07,
-      "cost_per_1m_in_cached": 2.1125,
-      "cost_per_1m_out_cached": 0.169,
+      "pricing": {
+        "input": 1.69,
+        "output": 5.07,
+        "cache_create": 2.1125,
+        "cache_hit": 0.169
+      },
       "context_window": 991000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -4552,10 +4774,12 @@
     {
       "id": "qwen3.8-max-2026-09-02",
       "name": "Qwen3.8 Max 2026 09-02",
-      "cost_per_1m_in": 1.69,
-      "cost_per_1m_out": 5.07,
-      "cost_per_1m_in_cached": 2.1125,
-      "cost_per_1m_out_cached": 0.169,
+      "pricing": {
+        "input": 1.69,
+        "output": 5.07,
+        "cache_create": 2.1125,
+        "cache_hit": 0.169
+      },
       "context_window": 991000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -4570,10 +4794,12 @@
     {
       "id": "qwen3.8-max-preview",
       "name": "Qwen3.8 Max Preview",
-      "cost_per_1m_in": 0.338,
-      "cost_per_1m_out": 1.014,
-      "cost_per_1m_in_cached": 0.4225,
-      "cost_per_1m_out_cached": 0.0676,
+      "pricing": {
+        "input": 0.338,
+        "output": 1.014,
+        "cache_create": 0.4225,
+        "cache_hit": 0.0676
+      },
       "context_window": 983616,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -4588,10 +4814,10 @@
     {
       "id": "step-3.5-flash",
       "name": "Step 3.5 Flash",
-      "cost_per_1m_in": 0.11,
-      "cost_per_1m_out": 0.33,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.11,
+        "output": 0.33
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -4600,10 +4826,11 @@
     {
       "id": "step-3.7-flash",
       "name": "Step 3.7 Flash",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 1.32,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.044,
+      "pricing": {
+        "input": 0.22,
+        "output": 1.32,
+        "cache_hit": 0.044
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -4612,10 +4839,10 @@
     {
       "id": "xiaomi-mimo-v2-omni-free",
       "name": "Xiaomi Mimo V2 Omni (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -4624,10 +4851,10 @@
     {
       "id": "xiaomi-mimo-v2-pro-free",
       "name": "Xiaomi Mimo V2 Pro (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -4636,10 +4863,11 @@
     {
       "id": "xiaomi-mimo-v2.5",
       "name": "Xiaomi Mimo V2.5",
-      "cost_per_1m_in": 0.155,
-      "cost_per_1m_out": 0.31,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0031,
+      "pricing": {
+        "input": 0.155,
+        "output": 0.31,
+        "cache_hit": 0.0031
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -4648,10 +4876,10 @@
     {
       "id": "xiaomi-mimo-v2.5-free",
       "name": "Xiaomi Mimo V2.5 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -4660,10 +4888,11 @@
     {
       "id": "xiaomi-mimo-v2.5-pro",
       "name": "Xiaomi Mimo V2.5 Pro",
-      "cost_per_1m_in": 0.48,
-      "cost_per_1m_out": 0.96,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.00384,
+      "pricing": {
+        "input": 0.48,
+        "output": 0.96,
+        "cache_hit": 0.00384
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": false,
@@ -4672,10 +4901,10 @@
     {
       "id": "xiaomi-mimo-v2.5-pro-free",
       "name": "Xiaomi Mimo V2.5 Pro (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,

--- a/internal/providers/configs/aihubmix.json
+++ b/internal/providers/configs/aihubmix.json
@@ -17,7 +17,9 @@
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "ByteDance-Seed/Seed-OSS-36B-Instruct",
@@ -29,7 +31,9 @@
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "DeepSeek-V3",
@@ -41,7 +45,9 @@
       "context_window": 1638000,
       "default_max_tokens": 163800,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "DeepSeek-V3.1-Terminus",
@@ -53,7 +59,9 @@
       "context_window": 160000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "DeepSeek-V3.1-Think",
@@ -71,7 +79,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "ERNIE-X1.1-Preview",
@@ -89,7 +99,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "agnes-2.5-flash",
@@ -107,7 +119,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "agnes-2.5-pro",
@@ -126,7 +140,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "agnes-2.5-pro-alpha",
@@ -145,7 +161,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "aihub-Phi-4-mini-instruct",
@@ -157,7 +175,9 @@
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "aihub-Phi-4-multimodal-instruct",
@@ -169,7 +189,9 @@
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic-opus-4-6",
@@ -189,7 +211,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "auto",
@@ -207,7 +231,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "baidu-deepseek-v4-pro-0813",
@@ -226,7 +252,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-3-7-sonnet",
@@ -244,7 +272,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-fable-5",
@@ -264,7 +294,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-fable-5-1",
@@ -284,7 +316,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-haiku-4-5",
@@ -304,7 +338,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-1",
@@ -322,7 +358,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-5",
@@ -342,7 +380,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-5-think",
@@ -362,7 +402,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-6",
@@ -382,7 +424,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-6-think",
@@ -402,7 +446,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-7",
@@ -422,7 +468,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-7-think",
@@ -442,7 +490,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-8",
@@ -462,7 +512,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-8-think",
@@ -482,7 +534,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-5",
@@ -502,7 +556,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-5",
@@ -522,7 +578,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-5-think",
@@ -542,7 +600,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-6",
@@ -562,7 +622,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-6-think",
@@ -582,7 +644,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-5",
@@ -602,7 +666,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "coding-glm-4.6-free",
@@ -620,7 +686,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-kimi-k3",
@@ -639,7 +707,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "coding-kimi-k3-free",
@@ -657,7 +727,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "coding-minimax-m2",
@@ -675,7 +747,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m2-free",
@@ -693,7 +767,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m2.1",
@@ -711,7 +787,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m2.1-free",
@@ -729,7 +807,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m2.5",
@@ -747,7 +827,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m2.5-free",
@@ -765,7 +847,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m2.5-highspeed",
@@ -783,7 +867,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m2.7",
@@ -801,7 +887,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m2.7-free",
@@ -819,7 +907,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m2.7-highspeed",
@@ -837,7 +927,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m3",
@@ -855,7 +947,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "coding-minimax-m3-free",
@@ -873,7 +967,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "command-a-plus-05-2026",
@@ -891,7 +987,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek-v3.2",
@@ -910,7 +1008,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v3.2-think",
@@ -929,7 +1029,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash",
@@ -948,7 +1050,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash-0731",
@@ -967,7 +1071,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash-0731-fast",
@@ -986,7 +1092,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash-vision-exp",
@@ -1005,7 +1113,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek-v4-pro",
@@ -1024,7 +1134,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-pro-0813",
@@ -1043,7 +1155,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "dots-3-note-preview-free",
@@ -1055,7 +1169,9 @@
       "context_window": 512000,
       "default_max_tokens": 51200,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-deepseek-v4-flash-0731",
@@ -1074,7 +1190,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "doubao-seed-1-6",
@@ -1087,7 +1205,9 @@
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-1-6-flash",
@@ -1100,7 +1220,9 @@
       "context_window": 256000,
       "default_max_tokens": 33000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-1-6-lite",
@@ -1113,7 +1235,9 @@
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-1-6-thinking",
@@ -1126,7 +1250,9 @@
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-1-8",
@@ -1145,7 +1271,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-2-0-code-preview",
@@ -1164,7 +1292,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-2-0-lite-260215",
@@ -1183,7 +1313,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-2-0-lite-260428",
@@ -1202,7 +1334,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-2-0-mini",
@@ -1221,7 +1355,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-2-0-mini-260428",
@@ -1240,7 +1376,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-2-0-pro",
@@ -1259,7 +1397,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-2-1-pro",
@@ -1278,7 +1418,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-2-1-turbo",
@@ -1297,7 +1439,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ernie-4.5",
@@ -1309,7 +1453,9 @@
       "context_window": 160000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ernie-4.5-turbo-latest",
@@ -1321,7 +1467,9 @@
       "context_window": 135000,
       "default_max_tokens": 12000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ernie-4.5-turbo-vl",
@@ -1333,7 +1481,9 @@
       "context_window": 139000,
       "default_max_tokens": 16000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ernie-5.0",
@@ -1352,7 +1502,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ernie-5.0-thinking-exp",
@@ -1371,7 +1523,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ernie-5.0-thinking-preview",
@@ -1390,7 +1544,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "ernie-5.1",
@@ -1409,7 +1565,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "ernie-x1-turbo",
@@ -1427,7 +1585,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gemini-2.5-flash",
@@ -1440,7 +1600,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash-image",
@@ -1453,7 +1615,9 @@
       "context_window": 32800,
       "default_max_tokens": 8000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash-lite",
@@ -1466,7 +1630,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash-lite-nothink",
@@ -1479,7 +1645,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash-lite-preview-09-2025",
@@ -1492,7 +1660,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash-lite-preview-09-2025-nothink",
@@ -1505,7 +1675,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash-nothink",
@@ -1518,7 +1690,9 @@
       "context_window": 1047576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash-preview-05-20-nothink",
@@ -1531,7 +1705,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash-preview-05-20-search",
@@ -1544,7 +1720,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash-preview-09-2025",
@@ -1557,7 +1735,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash-search",
@@ -1570,7 +1750,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-pro",
@@ -1589,7 +1771,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-pro-preview-05-06",
@@ -1608,7 +1792,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-pro-preview-06-05",
@@ -1627,7 +1813,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-pro-search",
@@ -1646,7 +1834,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-flash-preview",
@@ -1665,7 +1855,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-flash-preview-free",
@@ -1683,7 +1875,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-flash-preview-search",
@@ -1702,7 +1896,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.1-flash-lite",
@@ -1721,7 +1917,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.1-flash-lite-nothink",
@@ -1740,7 +1938,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.1-pro-preview",
@@ -1759,7 +1959,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.1-pro-preview-customtools",
@@ -1778,7 +1980,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.5-flash",
@@ -1797,7 +2001,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.5-flash-lite",
@@ -1816,7 +2022,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.5-flash-lite-free",
@@ -1834,7 +2042,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.6-flash",
@@ -1853,7 +2063,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.6-flash-free",
@@ -1871,7 +2083,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.7-flash",
@@ -1890,7 +2104,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.7-flash-free",
@@ -1908,7 +2124,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.8-flash",
@@ -1927,7 +2145,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.8-flash-free",
@@ -1945,7 +2165,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemma-4-26b-a4b-it-free",
@@ -1957,7 +2179,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemma-4-31b-it-free",
@@ -1969,7 +2193,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-4.5v",
@@ -1982,7 +2208,9 @@
       "context_window": 64000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-4.6",
@@ -2001,7 +2229,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.6v",
@@ -2014,7 +2244,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-4.7",
@@ -2033,7 +2265,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5",
@@ -2052,7 +2286,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5-turbo",
@@ -2071,7 +2307,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.1",
@@ -2090,7 +2328,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2",
@@ -2109,7 +2349,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2-fast-preview",
@@ -2128,7 +2370,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.3",
@@ -2147,7 +2391,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.3-flash",
@@ -2166,7 +2412,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-5v-turbo",
@@ -2179,7 +2427,9 @@
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1",
@@ -2192,7 +2442,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-free",
@@ -2204,7 +2456,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-mini",
@@ -2217,7 +2471,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-mini-free",
@@ -2229,7 +2485,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-nano",
@@ -2242,7 +2500,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-nano-free",
@@ -2254,7 +2514,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4o",
@@ -2267,7 +2529,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4o-2024-11-20",
@@ -2280,7 +2544,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4o-audio-preview",
@@ -2292,7 +2558,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-4o-free",
@@ -2304,7 +2572,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4o-mini",
@@ -2317,7 +2587,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4o-mini-search-preview",
@@ -2330,7 +2602,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4o-search-preview",
@@ -2343,7 +2617,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5",
@@ -2362,7 +2638,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-chat-latest",
@@ -2375,7 +2653,9 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-codex",
@@ -2394,7 +2674,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-mini",
@@ -2413,7 +2695,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-nano",
@@ -2432,7 +2716,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-pro",
@@ -2450,7 +2736,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1",
@@ -2469,7 +2757,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1-chat-latest",
@@ -2482,7 +2772,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1-codex",
@@ -2501,7 +2793,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1-codex-max",
@@ -2520,7 +2814,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1-codex-mini",
@@ -2539,7 +2835,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.2",
@@ -2558,7 +2856,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.2-chat-latest",
@@ -2571,7 +2871,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.2-codex",
@@ -2590,7 +2892,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.2-high",
@@ -2609,7 +2913,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.2-low",
@@ -2628,7 +2934,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.2-pro",
@@ -2647,7 +2955,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.3-chat-latest",
@@ -2660,7 +2970,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.3-codex",
@@ -2679,7 +2991,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4",
@@ -2698,7 +3012,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-high",
@@ -2717,7 +3033,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-low",
@@ -2736,7 +3054,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-mini",
@@ -2749,7 +3069,9 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-nano",
@@ -2768,7 +3090,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-pro",
@@ -2787,7 +3111,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.5",
@@ -2806,7 +3132,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.5-free",
@@ -2824,7 +3152,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.5-pro",
@@ -2843,7 +3173,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-luna",
@@ -2863,7 +3195,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-sol",
@@ -2883,7 +3217,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-sol-disc",
@@ -2903,7 +3239,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-terra",
@@ -2923,7 +3261,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-audio-1.5",
@@ -2942,7 +3282,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-chat-latest",
@@ -2961,7 +3303,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-oss-120b",
@@ -2979,7 +3323,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-oss-20b",
@@ -2997,7 +3343,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-oss-20b-free",
@@ -3009,7 +3357,9 @@
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "grok-4",
@@ -3028,7 +3378,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4-1-fast-non-reasoning",
@@ -3041,7 +3393,9 @@
       "context_window": 2000000,
       "default_max_tokens": 200000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4-1-fast-reasoning",
@@ -3060,7 +3414,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4-20-non-reasoning",
@@ -3079,7 +3435,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4-20-reasoning",
@@ -3098,7 +3456,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4-fast-non-reasoning",
@@ -3111,7 +3471,9 @@
       "context_window": 2000000,
       "default_max_tokens": 30000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4-fast-reasoning",
@@ -3130,7 +3492,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.20-beta-0309-non-reasoning",
@@ -3149,7 +3513,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.20-beta-0309-reasoning",
@@ -3168,7 +3534,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.20-multi-agent-0309",
@@ -3187,7 +3555,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.20-multi-agent-beta-0309",
@@ -3206,7 +3576,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.3",
@@ -3225,7 +3597,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.5",
@@ -3244,7 +3618,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.6",
@@ -3263,7 +3639,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-build-0.1",
@@ -3282,7 +3660,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-code-fast-1",
@@ -3301,7 +3681,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "hy3",
@@ -3320,7 +3702,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "hy3-free",
@@ -3338,7 +3722,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "hy3-preview",
@@ -3357,7 +3743,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "hy4-preview",
@@ -3376,7 +3764,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "jina-deepsearch-v1",
@@ -3394,7 +3784,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "k2.6-code-preview-free",
@@ -3412,7 +3804,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kat-dev",
@@ -3424,7 +3818,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-for-coding-free",
@@ -3442,7 +3838,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-k2-0711",
@@ -3454,7 +3852,9 @@
       "context_window": 131000,
       "default_max_tokens": 13100,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-k2-thinking",
@@ -3473,7 +3873,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-k2-turbo-preview",
@@ -3486,7 +3888,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-k2.5",
@@ -3505,7 +3909,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.6",
@@ -3524,7 +3930,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code",
@@ -3543,7 +3951,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code-highspeed",
@@ -3562,7 +3972,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k3",
@@ -3581,7 +3993,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "laguna-s-2.1-free",
@@ -3593,7 +4007,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "laguna-xs-2.1-free",
@@ -3605,7 +4021,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "lfm-2.5-2.6b-free",
@@ -3617,7 +4035,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "ling-3.0-flash-free",
@@ -3629,7 +4049,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "ling-3.0-tiny-free",
@@ -3641,7 +4063,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "llama-4-maverick",
@@ -3653,7 +4077,9 @@
       "context_window": 1048576,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "llama-4-scout",
@@ -3665,7 +4091,9 @@
       "context_window": 131000,
       "default_max_tokens": 13100,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mai-thinking-1",
@@ -3683,7 +4111,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mercury-2.5-preview",
@@ -3702,7 +4132,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mimo-v2-flash-free",
@@ -3714,7 +4146,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mimo-v2-omni",
@@ -3727,7 +4161,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mimo-v2-pro",
@@ -3740,7 +4176,9 @@
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax-m2",
@@ -3758,7 +4196,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m2.1",
@@ -3776,7 +4216,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m2.5",
@@ -3794,7 +4236,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m2.5-highspeed",
@@ -3812,7 +4256,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m2.7",
@@ -3831,7 +4277,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m2.7-free",
@@ -3843,7 +4291,9 @@
       "context_window": 196608,
       "default_max_tokens": 19660,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m3",
@@ -3861,7 +4311,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m3-free",
@@ -3873,7 +4325,9 @@
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral-large-3",
@@ -3885,7 +4339,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "muse-spark-1.1",
@@ -3903,7 +4359,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "muse-spark-1.2",
@@ -3921,7 +4379,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nemotron-3-nano-30b-a3b-free",
@@ -3933,7 +4393,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nemotron-3-nano-omni-30b-a3b-reasoning-free",
@@ -3945,7 +4407,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nemotron-3-super-120b-a12b-free",
@@ -3957,7 +4421,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nemotron-3-ultra-550b-a55b-free",
@@ -3969,7 +4435,9 @@
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nemotron-3.5-content-safety-free",
@@ -3981,7 +4449,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nemotron-3.5-lightning-free",
@@ -3993,7 +4463,9 @@
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nemotron-nano-12b-v2-vl-free",
@@ -4005,7 +4477,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nemotron-nano-9b-v2-free",
@@ -4017,7 +4491,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "north-mini-code-free",
@@ -4029,7 +4505,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia-nemotron-3-super-120b-a12b",
@@ -4048,7 +4526,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "o3",
@@ -4067,7 +4547,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "o3-mini",
@@ -4086,7 +4568,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "o3-pro",
@@ -4105,7 +4589,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "o4-mini",
@@ -4124,7 +4610,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ox-alpha",
@@ -4136,7 +4624,9 @@
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-235b-a22b",
@@ -4148,7 +4638,9 @@
       "context_window": 131100,
       "default_max_tokens": 13110,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-235b-a22b-instruct-2507",
@@ -4160,7 +4652,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-235b-a22b-thinking-2507",
@@ -4178,7 +4672,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-coder-30b-a3b-instruct",
@@ -4191,7 +4687,9 @@
       "context_window": 2000000,
       "default_max_tokens": 262000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-coder-480b-a35b-instruct",
@@ -4204,7 +4702,9 @@
       "context_window": 262000,
       "default_max_tokens": 26200,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-coder-flash",
@@ -4217,7 +4717,9 @@
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-coder-next",
@@ -4230,7 +4732,9 @@
       "context_window": 2000000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-coder-plus",
@@ -4243,7 +4747,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-coder-plus-2025-07-22",
@@ -4256,7 +4762,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-max",
@@ -4270,7 +4778,9 @@
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-max-2026-01-23",
@@ -4290,7 +4800,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-next-80b-a3b-instruct",
@@ -4302,7 +4814,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-next-80b-a3b-thinking",
@@ -4320,7 +4834,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-vl-235b-a22b-instruct",
@@ -4332,7 +4848,9 @@
       "context_window": 131000,
       "default_max_tokens": 33000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-vl-235b-a22b-thinking",
@@ -4350,7 +4868,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-vl-30b-a3b-instruct",
@@ -4362,7 +4882,9 @@
       "context_window": 128000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-vl-30b-a3b-thinking",
@@ -4380,7 +4902,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-vl-flash",
@@ -4393,7 +4917,9 @@
       "context_window": 254000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-vl-flash-2026-01-22",
@@ -4406,7 +4932,9 @@
       "context_window": 254000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-vl-plus",
@@ -4419,7 +4947,9 @@
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.5-122b-a10b",
@@ -4438,7 +4968,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.5-27b",
@@ -4457,7 +4989,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.5-35b-a3b",
@@ -4476,7 +5010,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.5-397b-a17b",
@@ -4495,7 +5031,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.5-flash",
@@ -4515,7 +5053,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.5-plus",
@@ -4535,7 +5075,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-27b",
@@ -4553,7 +5095,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-35b-a3b",
@@ -4572,7 +5116,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-flash",
@@ -4592,7 +5138,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-max-preview",
@@ -4612,7 +5160,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.6-plus",
@@ -4632,7 +5182,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-plus-preview-free",
@@ -4650,7 +5202,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.7-flash",
@@ -4670,7 +5224,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.7-max",
@@ -4690,7 +5246,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.7-plus",
@@ -4710,7 +5268,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.8-2.4t-a95b",
@@ -4729,7 +5289,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.8-flash",
@@ -4749,7 +5311,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.8-max",
@@ -4769,7 +5333,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.8-max-2026-09-02",
@@ -4789,7 +5355,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.8-max-preview",
@@ -4809,7 +5377,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "step-3.5-flash",
@@ -4821,7 +5391,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "step-3.7-flash",
@@ -4834,7 +5406,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "xiaomi-mimo-v2-omni-free",
@@ -4846,7 +5420,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "xiaomi-mimo-v2-pro-free",
@@ -4858,7 +5434,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "xiaomi-mimo-v2.5",
@@ -4871,7 +5449,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "xiaomi-mimo-v2.5-free",
@@ -4883,7 +5463,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "xiaomi-mimo-v2.5-pro",
@@ -4896,7 +5478,9 @@
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "xiaomi-mimo-v2.5-pro-free",
@@ -4908,7 +5492,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ],
   "default_headers": {

--- a/internal/providers/configs/alibaba-singapore.json
+++ b/internal/providers/configs/alibaba-singapore.json
@@ -17,7 +17,9 @@
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.5-27b",
@@ -29,7 +31,9 @@
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-flash",
@@ -43,7 +47,9 @@
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-plus",
@@ -57,7 +63,9 @@
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-max-preview",
@@ -71,7 +79,9 @@
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.7-flash",
@@ -84,7 +94,9 @@
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.7-plus",
@@ -97,7 +109,9 @@
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.7-max",
@@ -110,7 +124,9 @@
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.8-max",
@@ -123,7 +139,9 @@
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.8-flash",
@@ -136,7 +154,9 @@
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.8-27b",
@@ -149,7 +169,9 @@
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.8-2.4t-a95b",
@@ -162,7 +184,9 @@
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2",
@@ -180,7 +204,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.1",
@@ -198,7 +224,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-k3",
@@ -217,7 +245,9 @@
         "max"
       ],
       "default_reasoning_effort": "max",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code",
@@ -230,7 +260,9 @@
       "context_window": 256000,
       "default_max_tokens": 16000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek-v4-pro",
@@ -248,7 +280,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-pro-0813",
@@ -267,7 +301,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash",
@@ -285,7 +321,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash-0731",
@@ -304,7 +342,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v3.2",
@@ -317,7 +357,9 @@
       "context_window": 128000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/alibaba-singapore.json
+++ b/internal/providers/configs/alibaba-singapore.json
@@ -10,10 +10,10 @@
     {
       "id": "qwen3.5-35b-a3b",
       "name": "Qwen3.5-35B-A3B",
-      "cost_per_1m_in": 0.248,
-      "cost_per_1m_out": 1.485,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.248,
+        "output": 1.485
+      },
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -22,10 +22,10 @@
     {
       "id": "qwen3.5-27b",
       "name": "Qwen3.5-27B",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 3.6
+      },
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -34,10 +34,12 @@
     {
       "id": "qwen3.6-flash",
       "name": "Qwen3.6-Flash",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 1.25,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 1,
+        "output": 4,
+        "cache_create": 1.25,
+        "cache_hit": 0.1
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -46,10 +48,12 @@
     {
       "id": "qwen3.6-plus",
       "name": "Qwen3.6-Plus",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -58,10 +62,12 @@
     {
       "id": "qwen3.6-max-preview",
       "name": "Qwen3.6-Max",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -70,10 +76,11 @@
     {
       "id": "qwen3.7-flash",
       "name": "Qwen3.7-Flash",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.8,
+        "cache_hit": 0.04
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -82,10 +89,11 @@
     {
       "id": "qwen3.7-plus",
       "name": "Qwen3.7-Plus",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 4.8,
+        "cache_hit": 0.24
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -94,10 +102,11 @@
     {
       "id": "qwen3.7-max",
       "name": "Qwen3.7-Max",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2.5,
+        "output": 7.5,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -106,10 +115,11 @@
     {
       "id": "qwen3.8-max",
       "name": "Qwen3.8-Max",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -118,10 +128,11 @@
     {
       "id": "qwen3.8-flash",
       "name": "Qwen3.8-Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.47,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.016,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.47,
+        "cache_hit": 0.016
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -130,10 +141,11 @@
     {
       "id": "qwen3.8-27b",
       "name": "Qwen3.8-27B",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_hit": 0.1
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -142,10 +154,11 @@
     {
       "id": "qwen3.8-2.4t-a95b",
       "name": "Qwen3.8-2.4T-A95B",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -154,10 +167,11 @@
     {
       "id": "glm-5.2",
       "name": "GLM 5.2",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.28,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.28
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -171,10 +185,11 @@
     {
       "id": "glm-5.1",
       "name": "GLM 5.1",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.26,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.26
+      },
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -188,10 +203,11 @@
     {
       "id": "kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_hit": 0.3
+      },
       "context_window": 1048576,
       "default_max_tokens": 16000,
       "can_reason": true,
@@ -206,10 +222,11 @@
     {
       "id": "kimi-k2.7-code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.19,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_hit": 0.19
+      },
       "context_window": 256000,
       "default_max_tokens": 16000,
       "can_reason": false,
@@ -218,10 +235,11 @@
     {
       "id": "deepseek-v4-pro",
       "name": "DeepSeek-V4-Pro",
-      "cost_per_1m_in": 2.4,
-      "cost_per_1m_out": 4.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2.4,
+        "output": 4.8,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -235,10 +253,11 @@
     {
       "id": "deepseek-v4-pro-0813",
       "name": "DeepSeek-V4-Pro-0813",
-      "cost_per_1m_in": 1.32,
-      "cost_per_1m_out": 3.96,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.132,
+      "pricing": {
+        "input": 1.32,
+        "output": 3.96,
+        "cache_hit": 0.132
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -253,10 +272,11 @@
     {
       "id": "deepseek-v4-flash",
       "name": "DeepSeek-V4-Flash",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.4,
+        "cache_hit": 0.04
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -270,10 +290,11 @@
     {
       "id": "deepseek-v4-flash-0731",
       "name": "DeepSeek-V4-Flash-0731",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 1.32,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.044,
+      "pricing": {
+        "input": 0.44,
+        "output": 1.32,
+        "cache_hit": 0.044
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -288,10 +309,11 @@
     {
       "id": "deepseek-v3.2",
       "name": "DeepSeek-V3.2",
-      "cost_per_1m_in": 0.57,
-      "cost_per_1m_out": 1.71,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.114,
+      "pricing": {
+        "input": 0.57,
+        "output": 1.71,
+        "cache_hit": 0.114
+      },
       "context_window": 128000,
       "default_max_tokens": 64000,
       "can_reason": true,

--- a/internal/providers/configs/alibaba-united-states.json
+++ b/internal/providers/configs/alibaba-united-states.json
@@ -10,10 +10,11 @@
     {
       "id": "deepseek-v4-pro-us",
       "name": "DeepSeek-V4-Pro",
-      "cost_per_1m_in": 2.4,
-      "cost_per_1m_out": 4.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2.4,
+        "output": 4.8,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -27,10 +28,11 @@
     {
       "id": "deepseek-v4-flash-us",
       "name": "DeepSeek-V4-Flash",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.4,
+        "cache_hit": 0.04
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -44,10 +46,11 @@
     {
       "id": "glm-5.2",
       "name": "GLM 5.2",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 3.851,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.275,
+      "pricing": {
+        "input": 1.1,
+        "output": 3.851,
+        "cache_hit": 0.275
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -61,10 +64,11 @@
     {
       "id": "qwen3.8-max",
       "name": "Qwen3.8-Max",
-      "cost_per_1m_in": 1.65,
-      "cost_per_1m_out": 4.951,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.206,
+      "pricing": {
+        "input": 1.65,
+        "output": 4.951,
+        "cache_hit": 0.206
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,

--- a/internal/providers/configs/alibaba-united-states.json
+++ b/internal/providers/configs/alibaba-united-states.json
@@ -23,7 +23,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash-us",
@@ -41,7 +43,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2",
@@ -59,7 +63,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.8-max",
@@ -72,7 +78,9 @@
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/anthropic.json
+++ b/internal/providers/configs/anthropic.json
@@ -21,7 +21,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-fable-5",
@@ -37,7 +39,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-5",
@@ -53,7 +57,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-8",
@@ -69,7 +75,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-7",
@@ -85,7 +93,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-6",
@@ -101,7 +111,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-5-20251101",
@@ -117,7 +129,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-5",
@@ -133,7 +147,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-6",
@@ -149,7 +165,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-5-20250929",
@@ -163,7 +181,9 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-haiku-4-5-20251001",
@@ -177,7 +197,9 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-1-20250805",
@@ -191,7 +213,9 @@
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-20250514",
@@ -205,7 +229,9 @@
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-20250514",
@@ -219,7 +245,9 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-mythos-5-1",
@@ -235,7 +263,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-mythos-5",
@@ -251,7 +281,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/anthropic.json
+++ b/internal/providers/configs/anthropic.json
@@ -10,10 +10,12 @@
     {
       "id": "claude-fable-5-1",
       "name": "Claude Fable 5.1",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -24,10 +26,12 @@
     {
       "id": "claude-fable-5",
       "name": "Claude Fable 5",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 1,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 1
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -38,10 +42,12 @@
     {
       "id": "claude-opus-5",
       "name": "Claude Opus 5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -52,10 +58,12 @@
     {
       "id": "claude-opus-4-8",
       "name": "Claude Opus 4.8",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -66,10 +74,12 @@
     {
       "id": "claude-opus-4-7",
       "name": "Claude Opus 4.7",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -80,10 +90,12 @@
     {
       "id": "claude-opus-4-6",
       "name": "Claude Opus 4.6",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -94,10 +106,12 @@
     {
       "id": "claude-opus-4-5-20251101",
       "name": "Claude Opus 4.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -108,10 +122,12 @@
     {
       "id": "claude-sonnet-5",
       "name": "Claude Sonnet 5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 10,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -122,10 +138,12 @@
     {
       "id": "claude-sonnet-4-6",
       "name": "Claude Sonnet 4.6",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -136,10 +154,12 @@
     {
       "id": "claude-sonnet-4-5-20250929",
       "name": "Claude Sonnet 4.5",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -148,10 +168,12 @@
     {
       "id": "claude-haiku-4-5-20251001",
       "name": "Claude Haiku 4.5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 1.25,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 1,
+        "output": 5,
+        "cache_create": 1.25,
+        "cache_hit": 0.1
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -160,10 +182,12 @@
     {
       "id": "claude-opus-4-1-20250805",
       "name": "Claude Opus 4.1",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 75,
-      "cost_per_1m_in_cached": 18.75,
-      "cost_per_1m_out_cached": 1.5,
+      "pricing": {
+        "input": 15,
+        "output": 75,
+        "cache_create": 18.75,
+        "cache_hit": 1.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -172,10 +196,12 @@
     {
       "id": "claude-opus-4-20250514",
       "name": "Claude Opus 4",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 75,
-      "cost_per_1m_in_cached": 18.75,
-      "cost_per_1m_out_cached": 1.5,
+      "pricing": {
+        "input": 15,
+        "output": 75,
+        "cache_create": 18.75,
+        "cache_hit": 1.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -184,10 +210,12 @@
     {
       "id": "claude-sonnet-4-20250514",
       "name": "Claude Sonnet 4",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -196,10 +224,12 @@
     {
       "id": "claude-mythos-5-1",
       "name": "Claude Mythos 5.1",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -210,10 +240,12 @@
     {
       "id": "claude-mythos-5",
       "name": "Claude Mythos 5",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 1,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 1
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,

--- a/internal/providers/configs/atlascloud.json
+++ b/internal/providers/configs/atlascloud.json
@@ -18,7 +18,9 @@
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V3.1-Terminus",
@@ -31,7 +33,9 @@
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/deepseek-v3.2",
@@ -44,7 +48,9 @@
       "context_window": 163840,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V3.2-Exp",
@@ -57,7 +63,9 @@
       "context_window": 163840,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/deepseek-v4-flash",
@@ -70,7 +78,9 @@
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/deepseek-v4-flash-0731",
@@ -83,7 +93,9 @@
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/deepseek-v4-flash-vision-exp",
@@ -96,7 +108,9 @@
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek-ai/deepseek-v4-pro",
@@ -109,7 +123,9 @@
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/deepseek-v4-pro-0813",
@@ -122,7 +138,9 @@
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-4.6",
@@ -135,7 +153,9 @@
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/glm-4.7",
@@ -148,7 +168,9 @@
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/glm-5.1",
@@ -161,7 +183,9 @@
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/glm-5.2",
@@ -174,7 +198,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/glm-5.3",
@@ -187,7 +213,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/glm-5v-turbo",
@@ -200,7 +228,9 @@
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "tencent/hy3",
@@ -213,7 +243,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kwaipilot/kat-coder-air-v2.5",
@@ -226,7 +258,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kwaipilot/kat-coder-pro-v2",
@@ -239,7 +273,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kwaipilot/kat-coder-pro-v2.5",
@@ -252,7 +288,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k2.5",
@@ -265,7 +303,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k2.6",
@@ -278,7 +318,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meituan-longcat/longcat-2.0",
@@ -291,7 +333,9 @@
       "context_window": 1048756,
       "default_max_tokens": 131072,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimaxai/minimax-m2.5",
@@ -304,7 +348,9 @@
       "context_window": 196608,
       "default_max_tokens": 19660,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimaxai/minimax-m2.7",
@@ -317,7 +363,9 @@
       "context_window": 196608,
       "default_max_tokens": 19660,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
@@ -330,7 +378,9 @@
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3.5-122b-a10b",
@@ -343,7 +393,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-27b",
@@ -356,7 +408,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-35b-a3b",
@@ -369,7 +423,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-397b-a17b",
@@ -382,7 +438,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.6-35b-a3b",
@@ -395,7 +453,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.6-plus",
@@ -408,7 +468,9 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/atlascloud.json
+++ b/internal/providers/configs/atlascloud.json
@@ -10,10 +10,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V3.1",
       "name": "DeepSeek V3.1",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.95,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.95,
+        "cache_hit": 0.13
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
@@ -22,10 +23,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V3.1-Terminus",
       "name": "DeepSeek V3.1 Terminus",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.95,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.95,
+        "cache_hit": 0.13
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
@@ -34,10 +36,11 @@
     {
       "id": "deepseek-ai/deepseek-v3.2",
       "name": "DeepSeek V3.2",
-      "cost_per_1m_in": 0.26,
-      "cost_per_1m_out": 0.38,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 0.26,
+        "output": 0.38,
+        "cache_hit": 0.13
+      },
       "context_window": 163840,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -46,10 +49,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V3.2-Exp",
       "name": "DeepSeek V3.2 Exp",
-      "cost_per_1m_in": 0.27,
-      "cost_per_1m_out": 0.41,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.27,
+      "pricing": {
+        "input": 0.27,
+        "output": 0.41,
+        "cache_hit": 0.27
+      },
       "context_window": 163840,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -58,10 +62,11 @@
     {
       "id": "deepseek-ai/deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_hit": 0.028
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -70,10 +75,11 @@
     {
       "id": "deepseek-ai/deepseek-v4-flash-0731",
       "name": "DeepSeek V4 Flash 0731",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 1.32,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
+      "pricing": {
+        "input": 0.44,
+        "output": 1.32,
+        "cache_hit": 0.028
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -82,10 +88,11 @@
     {
       "id": "deepseek-ai/deepseek-v4-flash-vision-exp",
       "name": "DeepSeek V4 Flash Vision Exp",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 1.32,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
+      "pricing": {
+        "input": 0.44,
+        "output": 1.32,
+        "cache_hit": 0.028
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -94,10 +101,11 @@
     {
       "id": "deepseek-ai/deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
-      "cost_per_1m_in": 1.68,
-      "cost_per_1m_out": 3.38,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 1.68,
+        "output": 3.38,
+        "cache_hit": 0.13
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -106,10 +114,11 @@
     {
       "id": "deepseek-ai/deepseek-v4-pro-0813",
       "name": "DeepSeek V4 Pro 0813",
-      "cost_per_1m_in": 1.32,
-      "cost_per_1m_out": 3.96,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.132,
+      "pricing": {
+        "input": 1.32,
+        "output": 3.96,
+        "cache_hit": 0.132
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -118,10 +127,11 @@
     {
       "id": "zai-org/GLM-4.6",
       "name": "GLM 4.6",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_hit": 0.11
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": false,
@@ -130,10 +140,11 @@
     {
       "id": "zai-org/glm-4.7",
       "name": "GLM 4.7",
-      "cost_per_1m_in": 0.52,
-      "cost_per_1m_out": 1.85,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.12,
+      "pricing": {
+        "input": 0.52,
+        "output": 1.85,
+        "cache_hit": 0.12
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": false,
@@ -142,10 +153,11 @@
     {
       "id": "zai-org/glm-5.1",
       "name": "GLM 5.1",
-      "cost_per_1m_in": 1.26,
-      "cost_per_1m_out": 3.96,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.234,
+      "pricing": {
+        "input": 1.26,
+        "output": 3.96,
+        "cache_hit": 0.234
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": false,
@@ -154,10 +166,11 @@
     {
       "id": "zai-org/glm-5.2",
       "name": "GLM 5.2",
-      "cost_per_1m_in": 0.938,
-      "cost_per_1m_out": 2.948,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1742,
+      "pricing": {
+        "input": 0.938,
+        "output": 2.948,
+        "cache_hit": 0.1742
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -166,10 +179,11 @@
     {
       "id": "zai-org/glm-5.3",
       "name": "GLM 5.3",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.26,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.26
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -178,10 +192,11 @@
     {
       "id": "zai-org/glm-5v-turbo",
       "name": "GLM 5v Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 4,
+        "cache_hit": 0.24
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": false,
@@ -190,10 +205,11 @@
     {
       "id": "tencent/hy3",
       "name": "Hunyuan 3",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.8,
+        "cache_hit": 0.05
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -202,10 +218,11 @@
     {
       "id": "kwaipilot/kat-coder-air-v2.5",
       "name": "KAT Coder Air V2.5",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.03
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -214,10 +231,11 @@
     {
       "id": "kwaipilot/kat-coder-pro-v2",
       "name": "KAT Coder Pro V2",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.06
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -226,10 +244,11 @@
     {
       "id": "kwaipilot/kat-coder-pro-v2.5",
       "name": "KAT Coder Pro V2.5",
-      "cost_per_1m_in": 0.74,
-      "cost_per_1m_out": 2.96,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 0.74,
+        "output": 2.96,
+        "cache_hit": 0.15
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -238,10 +257,11 @@
     {
       "id": "moonshotai/kimi-k2.5",
       "name": "Kimi K2.5",
-      "cost_per_1m_in": 0.49,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 0.49,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -250,10 +270,11 @@
     {
       "id": "moonshotai/kimi-k2.6",
       "name": "Kimi K2.6",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.16,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_hit": 0.16
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -262,10 +283,11 @@
     {
       "id": "meituan-longcat/longcat-2.0",
       "name": "LongCat 2.0",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.006,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.006
+      },
       "context_window": 1048756,
       "default_max_tokens": 131072,
       "can_reason": false,
@@ -274,10 +296,11 @@
     {
       "id": "minimaxai/minimax-m2.5",
       "name": "MiniMax M2.5",
-      "cost_per_1m_in": 0.295,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.295,
+        "output": 1.2,
+        "cache_hit": 0.06
+      },
       "context_window": 196608,
       "default_max_tokens": 19660,
       "can_reason": false,
@@ -286,10 +309,11 @@
     {
       "id": "minimaxai/minimax-m2.7",
       "name": "MiniMax M2.7",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.06
+      },
       "context_window": 196608,
       "default_max_tokens": 19660,
       "can_reason": false,
@@ -298,10 +322,11 @@
     {
       "id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
       "name": "Qwen3-235B-A22B-Instruct-2507",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.88,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.88,
+        "cache_hit": 0.2
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
@@ -310,10 +335,11 @@
     {
       "id": "qwen/qwen3.5-122b-a10b",
       "name": "Qwen3.5 122B A10B",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.4,
+        "cache_hit": 0.3
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -322,10 +348,11 @@
     {
       "id": "qwen/qwen3.5-27b",
       "name": "Qwen3.5 27B",
-      "cost_per_1m_in": 0.27,
-      "cost_per_1m_out": 2.16,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.27,
+      "pricing": {
+        "input": 0.27,
+        "output": 2.16,
+        "cache_hit": 0.27
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -334,10 +361,11 @@
     {
       "id": "qwen/qwen3.5-35b-a3b",
       "name": "Qwen3.5 35B A3B",
-      "cost_per_1m_in": 0.225,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.225,
+      "pricing": {
+        "input": 0.225,
+        "output": 1.8,
+        "cache_hit": 0.225
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -346,10 +374,11 @@
     {
       "id": "qwen/qwen3.5-397b-a17b",
       "name": "Qwen3.5 397BA17B",
-      "cost_per_1m_in": 0.55,
-      "cost_per_1m_out": 3.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 0.55,
+        "output": 3.5,
+        "cache_hit": 0.55
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -358,10 +387,11 @@
     {
       "id": "qwen/qwen3.6-35b-a3b",
       "name": "Qwen3.6 35B A3B",
-      "cost_per_1m_in": 0.186,
-      "cost_per_1m_out": 1.11375,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.186,
+      "pricing": {
+        "input": 0.186,
+        "output": 1.11375,
+        "cache_hit": 0.186
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -370,10 +400,11 @@
     {
       "id": "qwen/qwen3.6-plus",
       "name": "Qwen3.6 Plus",
-      "cost_per_1m_in": 0.325,
-      "cost_per_1m_out": 1.95,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0325,
+      "pricing": {
+        "input": 0.325,
+        "output": 1.95,
+        "cache_hit": 0.0325
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": false,

--- a/internal/providers/configs/avian.json
+++ b/internal/providers/configs/avian.json
@@ -10,10 +10,11 @@
     {
       "id": "deepseek/deepseek-v3.2",
       "name": "DeepSeek V3.2 (Legacy)",
-      "cost_per_1m_in": 0.23,
-      "cost_per_1m_out": 0.33,
-      "cost_per_1m_in_cached": 0.012,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.23,
+        "output": 0.33,
+        "cache_create": 0.012
+      },
       "context_window": 163840,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -28,10 +29,11 @@
     {
       "id": "deepseek/deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.0805,
-      "cost_per_1m_out": 0.161,
-      "cost_per_1m_in_cached": 0.0165,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.0805,
+        "output": 0.161,
+        "cache_create": 0.0165
+      },
       "context_window": 1000000,
       "default_max_tokens": 393216,
       "can_reason": true,
@@ -46,10 +48,11 @@
     {
       "id": "deepseek/deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
-      "cost_per_1m_in": 1.305,
-      "cost_per_1m_out": 2.61,
-      "cost_per_1m_in_cached": 0.10875,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.305,
+        "output": 2.61,
+        "cache_create": 0.10875
+      },
       "context_window": 1000000,
       "default_max_tokens": 393216,
       "can_reason": true,
@@ -64,10 +67,11 @@
     {
       "id": "deepseek/deepseek-v4-pro-0813",
       "name": "DeepSeek V4 Pro 0813",
-      "cost_per_1m_in": 0.594,
-      "cost_per_1m_out": 1.782,
-      "cost_per_1m_in_cached": 0.0198,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.594,
+        "output": 1.782,
+        "cache_create": 0.0198
+      },
       "context_window": 1000000,
       "default_max_tokens": 393216,
       "can_reason": true,
@@ -82,10 +86,11 @@
     {
       "id": "z-ai/glm-4.7",
       "name": "GLM-4.7",
-      "cost_per_1m_in": 0.388,
-      "cost_per_1m_out": 1.806,
-      "cost_per_1m_in_cached": 0.097,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.388,
+        "output": 1.806,
+        "cache_create": 0.097
+      },
       "context_window": 202752,
       "default_max_tokens": 131072,
       "can_reason": false,
@@ -94,10 +99,11 @@
     {
       "id": "z-ai/glm-5",
       "name": "GLM-5",
-      "cost_per_1m_in": 0.516,
-      "cost_per_1m_out": 2.322,
-      "cost_per_1m_in_cached": 0.129,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.516,
+        "output": 2.322,
+        "cache_create": 0.129
+      },
       "context_window": 204800,
       "default_max_tokens": 131072,
       "can_reason": false,
@@ -106,10 +112,11 @@
     {
       "id": "z-ai/glm-5.1",
       "name": "GLM-5.1",
-      "cost_per_1m_in": 0.743,
-      "cost_per_1m_out": 2.971,
-      "cost_per_1m_in_cached": 0.186,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.743,
+        "output": 2.971,
+        "cache_create": 0.186
+      },
       "context_window": 202752,
       "default_max_tokens": 202752,
       "can_reason": false,
@@ -118,10 +125,11 @@
     {
       "id": "z-ai/glm-5.2",
       "name": "GLM-5.2",
-      "cost_per_1m_in": 0.495,
-      "cost_per_1m_out": 1.733,
-      "cost_per_1m_in_cached": 0.124,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.495,
+        "output": 1.733,
+        "cache_create": 0.124
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": false,
@@ -130,10 +138,11 @@
     {
       "id": "moonshotai/kimi-k2.5",
       "name": "Kimi K2.5",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.225,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.45,
+        "output": 2.2,
+        "cache_create": 0.225
+      },
       "context_window": 262144,
       "default_max_tokens": 262144,
       "can_reason": false,
@@ -142,10 +151,11 @@
     {
       "id": "moonshotai/kimi-k2.6",
       "name": "Kimi K2.6",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0.16,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_create": 0.16
+      },
       "context_window": 262144,
       "default_max_tokens": 262144,
       "can_reason": false,
@@ -154,10 +164,11 @@
     {
       "id": "xiaomi/mimo-v2.5-pro",
       "name": "MiMo-V2.5 Pro",
-      "cost_per_1m_in": 0.435,
-      "cost_per_1m_out": 0.87,
-      "cost_per_1m_in_cached": 0.0036,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.435,
+        "output": 0.87,
+        "cache_create": 0.0036
+      },
       "context_window": 1050000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -172,10 +183,11 @@
     {
       "id": "xiaomi/mimo-v2.5",
       "name": "MiMo-V2.5 Small",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.05,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.4,
+        "cache_create": 0.05
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -190,10 +202,11 @@
     {
       "id": "minimax/minimax-m2.5",
       "name": "MiniMax M2.5",
-      "cost_per_1m_in": 0.27,
-      "cost_per_1m_out": 1.08,
-      "cost_per_1m_in_cached": 0.15,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.27,
+        "output": 1.08,
+        "cache_create": 0.15
+      },
       "context_window": 196608,
       "default_max_tokens": 131072,
       "can_reason": false,

--- a/internal/providers/configs/avian.json
+++ b/internal/providers/configs/avian.json
@@ -24,7 +24,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-flash",
@@ -43,7 +45,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-pro",
@@ -62,7 +66,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-pro-0813",
@@ -81,7 +87,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-4.7",
@@ -94,7 +102,9 @@
       "context_window": 202752,
       "default_max_tokens": 131072,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5",
@@ -107,7 +117,9 @@
       "context_window": 204800,
       "default_max_tokens": 131072,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5.1",
@@ -120,7 +132,9 @@
       "context_window": 202752,
       "default_max_tokens": 202752,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5.2",
@@ -133,7 +147,9 @@
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/kimi-k2.5",
@@ -146,7 +162,9 @@
       "context_window": 262144,
       "default_max_tokens": 262144,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/kimi-k2.6",
@@ -159,7 +177,9 @@
       "context_window": 262144,
       "default_max_tokens": 262144,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "xiaomi/mimo-v2.5-pro",
@@ -178,7 +198,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "xiaomi/mimo-v2.5",
@@ -197,7 +219,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.5",
@@ -210,7 +234,9 @@
       "context_window": 196608,
       "default_max_tokens": 131072,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/azure.json
+++ b/internal/providers/configs/azure.json
@@ -10,10 +10,12 @@
     {
       "id": "gpt-5",
       "name": "GPT-5",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0.25,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_create": 0.25,
+        "cache_hit": 0.25
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -29,10 +31,12 @@
     {
       "id": "gpt-5-mini",
       "name": "GPT-5 Mini",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0.025,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_create": 0.025,
+        "cache_hit": 0.025
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -47,10 +51,12 @@
     {
       "id": "gpt-5-nano",
       "name": "GPT-5 Nano",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.005,
-      "cost_per_1m_out_cached": 0.005,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.4,
+        "cache_create": 0.005,
+        "cache_hit": 0.005
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -65,10 +71,11 @@
     {
       "id": "codex-mini-latest",
       "name": "Codex Mini",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 1.5,
+        "output": 6,
+        "cache_hit": 0.375
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -83,10 +90,11 @@
     {
       "id": "o4-mini",
       "name": "o4 Mini",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.275,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.275
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -97,10 +105,11 @@
     {
       "id": "o3",
       "name": "o3",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -115,10 +124,10 @@
     {
       "id": "o3-pro",
       "name": "o3 Pro",
-      "cost_per_1m_in": 20,
-      "cost_per_1m_out": 80,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 20,
+        "output": 80
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -133,10 +142,11 @@
     {
       "id": "gpt-4.1",
       "name": "GPT-4.1",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 1047576,
       "default_max_tokens": 50000,
       "can_reason": false,
@@ -145,10 +155,11 @@
     {
       "id": "gpt-4.1-mini",
       "name": "GPT-4.1 Mini",
-      "cost_per_1m_in": 0.39999999999999997,
-      "cost_per_1m_out": 1.5999999999999999,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.09999999999999999,
+      "pricing": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_hit": 0.1
+      },
       "context_window": 1047576,
       "default_max_tokens": 50000,
       "can_reason": false,
@@ -157,10 +168,11 @@
     {
       "id": "gpt-4.1-nano",
       "name": "GPT-4.1 Nano",
-      "cost_per_1m_in": 0.09999999999999999,
-      "cost_per_1m_out": 0.39999999999999997,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.024999999999999998,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_hit": 0.025
+      },
       "context_window": 1047576,
       "default_max_tokens": 50000,
       "can_reason": false,
@@ -169,10 +181,11 @@
     {
       "id": "gpt-4.5-preview",
       "name": "GPT-4.5 (Preview)",
-      "cost_per_1m_in": 75,
-      "cost_per_1m_out": 150,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 37.5,
+      "pricing": {
+        "input": 75,
+        "output": 150,
+        "cache_hit": 37.5
+      },
       "context_window": 128000,
       "default_max_tokens": 50000,
       "can_reason": false,
@@ -181,10 +194,11 @@
     {
       "id": "o3-mini",
       "name": "o3 Mini",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.55
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -199,10 +213,11 @@
     {
       "id": "gpt-4o",
       "name": "GPT-4o",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 10,
+        "cache_hit": 1.25
+      },
       "context_window": 128000,
       "default_max_tokens": 20000,
       "can_reason": false,
@@ -211,10 +226,11 @@
     {
       "id": "gpt-4o-mini",
       "name": "GPT-4o-mini",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.075
+      },
       "context_window": 128000,
       "default_max_tokens": 20000,
       "can_reason": false,

--- a/internal/providers/configs/azure.json
+++ b/internal/providers/configs/azure.json
@@ -26,7 +26,9 @@
         "high"
       ],
       "default_reasoning_effort": "minimal",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-mini",
@@ -46,7 +48,9 @@
         "high"
       ],
       "default_reasoning_effort": "low",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-nano",
@@ -66,7 +70,9 @@
         "high"
       ],
       "default_reasoning_effort": "low",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "codex-mini-latest",
@@ -85,7 +91,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "o4-mini",
@@ -100,7 +108,9 @@
       "can_reason": true,
       "has_reasoning_efforts": true,
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "o3",
@@ -119,7 +129,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "o3-pro",
@@ -137,7 +149,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1",
@@ -150,7 +164,9 @@
       "context_window": 1047576,
       "default_max_tokens": 50000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-mini",
@@ -163,7 +179,9 @@
       "context_window": 1047576,
       "default_max_tokens": 50000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-nano",
@@ -176,7 +194,9 @@
       "context_window": 1047576,
       "default_max_tokens": 50000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.5-preview",
@@ -189,7 +209,9 @@
       "context_window": 128000,
       "default_max_tokens": 50000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "o3-mini",
@@ -208,7 +230,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-4o",
@@ -221,7 +245,9 @@
       "context_window": 128000,
       "default_max_tokens": 20000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4o-mini",
@@ -235,7 +261,9 @@
       "default_max_tokens": 20000,
       "can_reason": false,
       "reasoning_effort": "",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/baseten.json
+++ b/internal/providers/configs/baseten.json
@@ -10,10 +10,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash-0731",
       "name": "DeepSeek V4 Flash 0731",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.26,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
+      "pricing": {
+        "input": 0.13,
+        "output": 0.26,
+        "cache_hit": 0.028
+      },
       "context_window": 1048576,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -29,10 +30,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V4-Pro",
       "name": "DeepSeek V4 Pro",
-      "cost_per_1m_in": 1.74,
-      "cost_per_1m_out": 3.48,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.145,
+      "pricing": {
+        "input": 1.74,
+        "output": 3.48,
+        "cache_hit": 0.145
+      },
       "context_window": 1048576,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -46,10 +48,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V4-Pro-0813",
       "name": "DeepSeek V4 Pro 0813",
-      "cost_per_1m_in": 1.32,
-      "cost_per_1m_out": 3.96,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.132,
+      "pricing": {
+        "input": 1.32,
+        "output": 3.96,
+        "cache_hit": 0.132
+      },
       "context_window": 1048576,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -65,10 +68,11 @@
     {
       "id": "zai-org/GLM-4.7",
       "name": "GLM 4.7",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.12,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_hit": 0.12
+      },
       "context_window": 200000,
       "default_max_tokens": 200000,
       "can_reason": false,
@@ -77,10 +81,11 @@
     {
       "id": "zai-org/GLM-5.2",
       "name": "GLM 5.2",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.14,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.14
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -95,10 +100,11 @@
     {
       "id": "zai-org/GLM-5.2-Fast",
       "name": "GLM 5.2 Fast",
-      "cost_per_1m_in": 2.1,
-      "cost_per_1m_out": 6.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.21,
+      "pricing": {
+        "input": 2.1,
+        "output": 6.6,
+        "cache_hit": 0.21
+      },
       "context_window": 1048576,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -113,10 +119,11 @@
     {
       "id": "zai-org/GLM-5.3",
       "name": "GLM 5.3",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.14,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.14
+      },
       "context_window": 1048576,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -131,10 +138,11 @@
     {
       "id": "zai-org/GLM-5.3-Flash",
       "name": "GLM 5.3 Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.5,
+        "cache_hit": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -149,10 +157,11 @@
     {
       "id": "thinkingmachines/inkling",
       "name": "Inkling",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 4.05,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.17,
+      "pricing": {
+        "input": 1,
+        "output": 4.05,
+        "cache_hit": 0.17
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -170,10 +179,11 @@
     {
       "id": "thinkingmachines/inkling-small",
       "name": "Inkling Small",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.5,
+        "output": 1.2,
+        "cache_hit": 0.1
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -188,10 +198,11 @@
     {
       "id": "moonshotai/Kimi-K2.6",
       "name": "Kimi K2.6",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.16,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_hit": 0.16
+      },
       "context_window": 262000,
       "default_max_tokens": 262000,
       "can_reason": true,
@@ -206,10 +217,11 @@
     {
       "id": "moonshotai/Kimi-K2.7-Code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.16,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_hit": 0.16
+      },
       "context_window": 262000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -218,10 +230,11 @@
     {
       "id": "moonshotai/Kimi-K3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_hit": 0.3
+      },
       "context_window": 1048576,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -236,10 +249,11 @@
     {
       "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
       "name": "Nemotron Ultra",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.12,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_hit": 0.12
+      },
       "context_window": 202800,
       "default_max_tokens": 202800,
       "can_reason": true,
@@ -254,10 +268,11 @@
     {
       "id": "openai/gpt-oss-120b",
       "name": "OpenAI GPT 120B",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.5,
+        "cache_hit": 0.1
+      },
       "context_window": 128072,
       "default_max_tokens": 128072,
       "can_reason": true,

--- a/internal/providers/configs/baseten.json
+++ b/internal/providers/configs/baseten.json
@@ -25,7 +25,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V4-Pro",
@@ -43,7 +45,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V4-Pro-0813",
@@ -63,7 +67,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-4.7",
@@ -76,7 +82,9 @@
       "context_window": 200000,
       "default_max_tokens": 200000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.2",
@@ -95,7 +103,9 @@
         "max"
       ],
       "default_reasoning_effort": "max",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "zai-org/GLM-5.2-Fast",
@@ -114,7 +124,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "zai-org/GLM-5.3",
@@ -133,7 +145,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.3-Flash",
@@ -152,7 +166,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "thinkingmachines/inkling",
@@ -174,7 +190,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "thinkingmachines/inkling-small",
@@ -193,7 +211,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/Kimi-K2.6",
@@ -212,7 +232,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/Kimi-K2.7-Code",
@@ -225,7 +247,9 @@
       "context_window": 262000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/Kimi-K3",
@@ -244,7 +268,9 @@
         "max"
       ],
       "default_reasoning_effort": "max",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
@@ -263,7 +289,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -286,7 +314,9 @@
         "max"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/bedrock-europe.json
+++ b/internal/providers/configs/bedrock-europe.json
@@ -21,7 +21,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "eu.anthropic.claude-sonnet-4-6",
@@ -37,7 +39,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -51,7 +55,9 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -65,7 +71,9 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "eu.anthropic.claude-opus-5",
@@ -81,7 +89,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "eu.anthropic.claude-opus-4-8",
@@ -97,7 +107,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "eu.anthropic.claude-opus-4-7",
@@ -113,7 +125,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "eu.anthropic.claude-opus-4-6-v1",
@@ -129,7 +143,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
@@ -143,7 +159,9 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "eu.anthropic.claude-opus-4-1-20250805-v1:0",
@@ -157,7 +175,9 @@
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/bedrock-europe.json
+++ b/internal/providers/configs/bedrock-europe.json
@@ -10,10 +10,12 @@
     {
       "id": "eu.anthropic.claude-sonnet-5",
       "name": "Claude Sonnet 5",
-      "cost_per_1m_in": 3.3,
-      "cost_per_1m_out": 16.5,
-      "cost_per_1m_in_cached": 4.125,
-      "cost_per_1m_out_cached": 0.33,
+      "pricing": {
+        "input": 3.3,
+        "output": 16.5,
+        "cache_create": 4.125,
+        "cache_hit": 0.33
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -24,10 +26,12 @@
     {
       "id": "eu.anthropic.claude-sonnet-4-6",
       "name": "Claude Sonnet 4.6",
-      "cost_per_1m_in": 3.3,
-      "cost_per_1m_out": 16.5,
-      "cost_per_1m_in_cached": 4.125,
-      "cost_per_1m_out_cached": 0.33,
+      "pricing": {
+        "input": 3.3,
+        "output": 16.5,
+        "cache_create": 4.125,
+        "cache_hit": 0.33
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -38,10 +42,12 @@
     {
       "id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
       "name": "Claude Sonnet 4.5",
-      "cost_per_1m_in": 3.3,
-      "cost_per_1m_out": 16.5,
-      "cost_per_1m_in_cached": 4.125,
-      "cost_per_1m_out_cached": 0.33,
+      "pricing": {
+        "input": 3.3,
+        "output": 16.5,
+        "cache_create": 4.125,
+        "cache_hit": 0.33
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -50,10 +56,12 @@
     {
       "id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
       "name": "Claude Haiku 4.5",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 5.5,
-      "cost_per_1m_in_cached": 1.375,
-      "cost_per_1m_out_cached": 0.11,
+      "pricing": {
+        "input": 1.1,
+        "output": 5.5,
+        "cache_create": 1.375,
+        "cache_hit": 0.11
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -62,10 +70,12 @@
     {
       "id": "eu.anthropic.claude-opus-5",
       "name": "Claude Opus 5",
-      "cost_per_1m_in": 5.5,
-      "cost_per_1m_out": 27.5,
-      "cost_per_1m_in_cached": 6.875,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 5.5,
+        "output": 27.5,
+        "cache_create": 6.875,
+        "cache_hit": 0.55
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -76,10 +86,12 @@
     {
       "id": "eu.anthropic.claude-opus-4-8",
       "name": "Claude Opus 4.8",
-      "cost_per_1m_in": 5.5,
-      "cost_per_1m_out": 27.5,
-      "cost_per_1m_in_cached": 6.875,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 5.5,
+        "output": 27.5,
+        "cache_create": 6.875,
+        "cache_hit": 0.55
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -90,10 +102,12 @@
     {
       "id": "eu.anthropic.claude-opus-4-7",
       "name": "Claude Opus 4.7",
-      "cost_per_1m_in": 5.5,
-      "cost_per_1m_out": 27.5,
-      "cost_per_1m_in_cached": 6.875,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 5.5,
+        "output": 27.5,
+        "cache_create": 6.875,
+        "cache_hit": 0.55
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -104,10 +118,12 @@
     {
       "id": "eu.anthropic.claude-opus-4-6-v1",
       "name": "Claude Opus 4.6",
-      "cost_per_1m_in": 5.5,
-      "cost_per_1m_out": 27.5,
-      "cost_per_1m_in_cached": 6.875,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 5.5,
+        "output": 27.5,
+        "cache_create": 6.875,
+        "cache_hit": 0.55
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -118,10 +134,12 @@
     {
       "id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
       "name": "Claude Opus 4.5",
-      "cost_per_1m_in": 5.5,
-      "cost_per_1m_out": 27.5,
-      "cost_per_1m_in_cached": 6.875,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 5.5,
+        "output": 27.5,
+        "cache_create": 6.875,
+        "cache_hit": 0.55
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -130,10 +148,12 @@
     {
       "id": "eu.anthropic.claude-opus-4-1-20250805-v1:0",
       "name": "Claude Opus 4.1",
-      "cost_per_1m_in": 16.5,
-      "cost_per_1m_out": 82.5,
-      "cost_per_1m_in_cached": 20.625,
-      "cost_per_1m_out_cached": 1.65,
+      "pricing": {
+        "input": 16.5,
+        "output": 82.5,
+        "cache_create": 20.625,
+        "cache_hit": 1.65
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,

--- a/internal/providers/configs/bedrock-united-states.json
+++ b/internal/providers/configs/bedrock-united-states.json
@@ -21,7 +21,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "us.anthropic.claude-sonnet-4-6",
@@ -37,7 +39,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -51,7 +55,9 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -65,7 +71,9 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "us.anthropic.claude-opus-5",
@@ -81,7 +89,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "us.anthropic.claude-opus-4-8",
@@ -97,7 +107,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "us.anthropic.claude-opus-4-7",
@@ -113,7 +125,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "us.anthropic.claude-opus-4-6-v1",
@@ -129,7 +143,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
@@ -143,7 +159,9 @@
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
@@ -157,7 +175,9 @@
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "us.anthropic.claude-fable-5",
@@ -173,7 +193,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/bedrock-united-states.json
+++ b/internal/providers/configs/bedrock-united-states.json
@@ -10,10 +10,12 @@
     {
       "id": "us.anthropic.claude-sonnet-5",
       "name": "Claude Sonnet 5",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -24,10 +26,12 @@
     {
       "id": "us.anthropic.claude-sonnet-4-6",
       "name": "Claude Sonnet 4.6",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -38,10 +42,12 @@
     {
       "id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
       "name": "Claude Sonnet 4.5",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -50,10 +56,12 @@
     {
       "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
       "name": "Claude Haiku 4.5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 1.25,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 1,
+        "output": 5,
+        "cache_create": 1.25,
+        "cache_hit": 0.1
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -62,10 +70,12 @@
     {
       "id": "us.anthropic.claude-opus-5",
       "name": "Claude Opus 5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -76,10 +86,12 @@
     {
       "id": "us.anthropic.claude-opus-4-8",
       "name": "Claude Opus 4.8",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -90,10 +102,12 @@
     {
       "id": "us.anthropic.claude-opus-4-7",
       "name": "Claude Opus 4.7",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -104,10 +118,12 @@
     {
       "id": "us.anthropic.claude-opus-4-6-v1",
       "name": "Claude Opus 4.6",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -118,10 +134,12 @@
     {
       "id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
       "name": "Claude Opus 4.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -130,10 +148,12 @@
     {
       "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
       "name": "Claude Opus 4.1",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 75,
-      "cost_per_1m_in_cached": 18.75,
-      "cost_per_1m_out_cached": 1.5,
+      "pricing": {
+        "input": 15,
+        "output": 75,
+        "cache_create": 18.75,
+        "cache_hit": 1.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -142,10 +162,12 @@
     {
       "id": "us.anthropic.claude-fable-5",
       "name": "Claude Fable 5",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 1,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 1
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,

--- a/internal/providers/configs/cerebras.json
+++ b/internal/providers/configs/cerebras.json
@@ -26,7 +26,9 @@
                 "high"
             ],
             "default_reasoning_effort": "medium",
-            "supports_attachments": false
+            "capabilities": {
+                "vision": false
+            }
         },
         {
             "id": "gemma-4-31b",
@@ -44,7 +46,9 @@
                 "high"
             ],
             "default_reasoning_effort": "medium",
-            "supports_attachments": true,
+            "capabilities": {
+              "vision": true
+            },
             "temperature": 1,
             "top_p": 0.95
         }

--- a/internal/providers/configs/cerebras.json
+++ b/internal/providers/configs/cerebras.json
@@ -13,8 +13,10 @@
         {
             "id": "gpt-oss-120b",
             "name": "OpenAI GPT OSS",
-            "cost_per_1m_in": 0.35,
-            "cost_per_1m_out": 0.75,
+            "pricing": {
+              "input": 0.35,
+              "output": 0.75
+            },
             "context_window": 131072,
             "default_max_tokens": 25000,
             "can_reason": true,
@@ -29,8 +31,10 @@
         {
             "id": "gemma-4-31b",
             "name": "Gemma 4 31B",
-            "cost_per_1m_in": 0.99,
-            "cost_per_1m_out": 1.49,
+            "pricing": {
+              "input": 0.99,
+              "output": 1.49
+            },
             "context_window": 131072,
             "default_max_tokens": 25000,
             "can_reason": true,

--- a/internal/providers/configs/chutes.json
+++ b/internal/providers/configs/chutes.json
@@ -10,10 +10,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V3.2-TEE",
       "name": "DeepSeek-V3.2-TEE",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0.1,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 1,
+        "cache_create": 0.1
+      },
       "context_window": 131072,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -28,10 +29,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash-0731-TEE",
       "name": "DeepSeek-V4-Flash-0731-TEE",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 1.32,
-      "cost_per_1m_in_cached": 0.044,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.44,
+        "output": 1.32,
+        "cache_create": 0.044
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -46,10 +48,11 @@
     {
       "id": "zai-org/GLM-5.1-TEE",
       "name": "GLM-5.1-TEE",
-      "cost_per_1m_in": 0.98,
-      "cost_per_1m_out": 3.08,
-      "cost_per_1m_in_cached": 0.098,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.98,
+        "output": 3.08,
+        "cache_create": 0.098
+      },
       "context_window": 202752,
       "default_max_tokens": 65535,
       "can_reason": true,
@@ -64,10 +67,11 @@
     {
       "id": "zai-org/GLM-5.2-TEE",
       "name": "GLM-5.2-TEE",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 3.95,
-      "cost_per_1m_in_cached": 0.125,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.25,
+        "output": 3.95,
+        "cache_create": 0.125
+      },
       "context_window": 1048576,
       "default_max_tokens": 65535,
       "can_reason": true,
@@ -82,10 +86,11 @@
     {
       "id": "moonshotai/Kimi-K2.6-TEE",
       "name": "Kimi-K2.6-TEE",
-      "cost_per_1m_in": 0.58,
-      "cost_per_1m_out": 3.4,
-      "cost_per_1m_in_cached": 0.058,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.58,
+        "output": 3.4,
+        "cache_create": 0.058
+      },
       "context_window": 262144,
       "default_max_tokens": 65535,
       "can_reason": true,
@@ -100,10 +105,11 @@
     {
       "id": "moonshotai/Kimi-K3-TEE",
       "name": "Kimi-K3-TEE",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.3
+      },
       "context_window": 1048576,
       "default_max_tokens": 65535,
       "can_reason": true,
@@ -118,10 +124,11 @@
     {
       "id": "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
       "name": "Qwen3-235B-A22B-Thinking-2507-TEE",
-      "cost_per_1m_in": 0.2989,
-      "cost_per_1m_out": 1.1957,
-      "cost_per_1m_in_cached": 0.02989,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2989,
+        "output": 1.1957,
+        "cache_create": 0.02989
+      },
       "context_window": 262144,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -136,10 +143,11 @@
     {
       "id": "Qwen/Qwen3-32B-TEE",
       "name": "Qwen3-32B-TEE",
-      "cost_per_1m_in": 0.104,
-      "cost_per_1m_out": 0.416,
-      "cost_per_1m_in_cached": 0.0104,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.104,
+        "output": 0.416,
+        "cache_create": 0.0104
+      },
       "context_window": 40960,
       "default_max_tokens": 40960,
       "can_reason": true,
@@ -154,10 +162,11 @@
     {
       "id": "Qwen/Qwen3.5-397B-A17B-TEE",
       "name": "Qwen3.5-397B-A17B-TEE",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.045,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.45,
+        "output": 3,
+        "cache_create": 0.045
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -172,10 +181,11 @@
     {
       "id": "Qwen/Qwen3.6-27B-TEE",
       "name": "Qwen3.6-27B-TEE",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 2,
+        "cache_create": 0.03
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -190,10 +200,11 @@
     {
       "id": "Qwen/Qwen3.8-27B-TEE",
       "name": "Qwen3.8-27B-TEE",
-      "cost_per_1m_in": 0.32,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0.032,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.32,
+        "output": 2.5,
+        "cache_create": 0.032
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -208,10 +219,11 @@
     {
       "id": "google/gemma-4-31B-turbo-TEE",
       "name": "gemma-4-31B-turbo-TEE",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.37,
-      "cost_per_1m_in_cached": 0.012,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.37,
+        "cache_create": 0.012
+      },
       "context_window": 131072,
       "default_max_tokens": 65536,
       "can_reason": true,

--- a/internal/providers/configs/chutes.json
+++ b/internal/providers/configs/chutes.json
@@ -24,7 +24,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash-0731-TEE",
@@ -43,7 +45,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.1-TEE",
@@ -62,7 +66,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.2-TEE",
@@ -81,7 +87,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K2.6-TEE",
@@ -100,7 +108,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/Kimi-K3-TEE",
@@ -119,7 +129,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE",
@@ -138,7 +150,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3-32B-TEE",
@@ -157,7 +171,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3.5-397B-A17B-TEE",
@@ -176,7 +192,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "Qwen/Qwen3.6-27B-TEE",
@@ -195,7 +213,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "Qwen/Qwen3.8-27B-TEE",
@@ -214,7 +234,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemma-4-31B-turbo-TEE",
@@ -233,7 +255,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/copilot.json
+++ b/internal/providers/configs/copilot.json
@@ -9,10 +9,10 @@
     {
       "id": "claude-fable-5",
       "name": "Claude Fable 5",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -21,10 +21,10 @@
     {
       "id": "claude-fable-5.1",
       "name": "Claude Fable 5.1",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -33,10 +33,10 @@
     {
       "id": "claude-haiku-4.5",
       "name": "Claude Haiku 4.5",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -45,10 +45,10 @@
     {
       "id": "claude-opus-4.7",
       "name": "Claude Opus 4.7",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -57,10 +57,10 @@
     {
       "id": "claude-opus-4.8",
       "name": "Claude Opus 4.8",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -69,10 +69,10 @@
     {
       "id": "claude-opus-4.8-fast",
       "name": "Claude Opus 4.8 (fast mode)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -81,10 +81,10 @@
     {
       "id": "claude-opus-5",
       "name": "Claude Opus 5",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -93,10 +93,10 @@
     {
       "id": "claude-sonnet-5",
       "name": "Claude Sonnet 5",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -105,10 +105,10 @@
     {
       "id": "gemini-3.5-flash",
       "name": "Gemini 3.5 Flash",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -117,10 +117,10 @@
     {
       "id": "gemini-3.6-flash",
       "name": "Gemini 3.6 Flash",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -129,10 +129,10 @@
     {
       "id": "gemini-3.7-flash",
       "name": "Gemini 3.7 Flash",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -141,10 +141,10 @@
     {
       "id": "gpt-3.5-turbo",
       "name": "GPT 3.5 Turbo",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 16384,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -153,10 +153,10 @@
     {
       "id": "gpt-4",
       "name": "GPT 4",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 32768,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -165,10 +165,10 @@
     {
       "id": "gpt-4-0125-preview",
       "name": "GPT 4 Turbo",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -177,10 +177,10 @@
     {
       "id": "gpt-4.1",
       "name": "GPT-4.1",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -189,10 +189,10 @@
     {
       "id": "gpt-4o",
       "name": "GPT-4o",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -201,10 +201,10 @@
     {
       "id": "gpt-4o-mini",
       "name": "GPT-4o mini",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -213,10 +213,10 @@
     {
       "id": "gpt-5-mini",
       "name": "GPT-5 mini",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -225,10 +225,10 @@
     {
       "id": "gpt-5.3-codex",
       "name": "GPT-5.3-Codex",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -237,10 +237,10 @@
     {
       "id": "gpt-5.4",
       "name": "GPT-5.4",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -249,10 +249,10 @@
     {
       "id": "gpt-5.4-mini",
       "name": "GPT-5.4 mini",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -261,10 +261,10 @@
     {
       "id": "gpt-5.5",
       "name": "GPT-5.5",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -273,10 +273,10 @@
     {
       "id": "gpt-5.6-luna",
       "name": "GPT-5.6 Luna",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 328000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -285,10 +285,10 @@
     {
       "id": "gpt-5.6-sol",
       "name": "GPT-5.6 Sol",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -297,10 +297,10 @@
     {
       "id": "gpt-5.6-terra",
       "name": "GPT-5.6 Terra",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -309,10 +309,10 @@
     {
       "id": "grok-4.5",
       "name": "Grok 4.5",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 328000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -321,10 +321,10 @@
     {
       "id": "grok-4.6",
       "name": "Grok 4.6",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 328000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -333,10 +333,10 @@
     {
       "id": "kimi-k2.7-code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -345,10 +345,10 @@
     {
       "id": "kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": false,

--- a/internal/providers/configs/copilot.json
+++ b/internal/providers/configs/copilot.json
@@ -16,7 +16,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-fable-5.1",
@@ -28,7 +30,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-haiku-4.5",
@@ -40,7 +44,9 @@
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4.7",
@@ -52,7 +58,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4.8",
@@ -64,7 +72,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4.8-fast",
@@ -76,7 +86,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-5",
@@ -88,7 +100,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-5",
@@ -100,7 +114,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.5-flash",
@@ -112,7 +128,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.6-flash",
@@ -124,7 +142,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.7-flash",
@@ -136,7 +156,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-3.5-turbo",
@@ -148,7 +170,9 @@
       "context_window": 16384,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-4",
@@ -160,7 +184,9 @@
       "context_window": 32768,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-4-0125-preview",
@@ -172,7 +198,9 @@
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-4.1",
@@ -184,7 +212,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4o",
@@ -196,7 +226,9 @@
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4o-mini",
@@ -208,7 +240,9 @@
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-5-mini",
@@ -220,7 +254,9 @@
       "context_window": 264000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.3-codex",
@@ -232,7 +268,9 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4",
@@ -244,7 +282,9 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-mini",
@@ -256,7 +296,9 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.5",
@@ -268,7 +310,9 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-luna",
@@ -280,7 +324,9 @@
       "context_window": 328000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-sol",
@@ -292,7 +338,9 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-terra",
@@ -304,7 +352,9 @@
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.5",
@@ -316,7 +366,9 @@
       "context_window": 328000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.6",
@@ -328,7 +380,9 @@
       "context_window": 328000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code",
@@ -340,7 +394,9 @@
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k3",
@@ -352,7 +408,9 @@
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/coralbricks.json
+++ b/internal/providers/configs/coralbricks.json
@@ -17,7 +17,9 @@
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-k3",
@@ -29,7 +31,9 @@
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-oss-120b",
@@ -41,7 +45,9 @@
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/coralbricks.json
+++ b/internal/providers/configs/coralbricks.json
@@ -10,10 +10,10 @@
     {
       "id": "glm-5.3-fp4",
       "name": "GLM 5.3",
-      "cost_per_1m_in": 1.12,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.12,
+        "output": 4.4
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -22,10 +22,10 @@
     {
       "id": "kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -34,10 +34,10 @@
     {
       "id": "gpt-oss-120b",
       "name": "GPT-OSS 120B",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.6
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,

--- a/internal/providers/configs/cortecs.json
+++ b/internal/providers/configs/cortecs.json
@@ -10,10 +10,10 @@
     {
       "id": "deepseek-v4-pro-0813",
       "name": "deepseek-v4-pro-0813",
-      "cost_per_1m_in": 1.795,
-      "cost_per_1m_out": 3.59,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.795,
+        "output": 3.59
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -28,10 +28,10 @@
     {
       "id": "glm-5.3",
       "name": "glm-5.3",
-      "cost_per_1m_in": 1.257,
-      "cost_per_1m_out": 3.949,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.257,
+        "output": 3.949
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -46,10 +46,10 @@
     {
       "id": "qwen3.8-flash-next",
       "name": "qwen3.8-flash-next",
-      "cost_per_1m_in": 0.18,
-      "cost_per_1m_out": 0.449,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.18,
+        "output": 0.449
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -64,10 +64,10 @@
     {
       "id": "glm-5.3-flash",
       "name": "glm-5.3-flash",
-      "cost_per_1m_in": 0.18,
-      "cost_per_1m_out": 0.449,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.18,
+        "output": 0.449
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -82,10 +82,10 @@
     {
       "id": "qwen3.8-27b",
       "name": "qwen3.8-27b",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.2
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -100,10 +100,10 @@
     {
       "id": "gemini-3.7-flash",
       "name": "gemini-3.7-flash",
-      "cost_per_1m_in": 0.673,
-      "cost_per_1m_out": 3.366,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.673,
+        "output": 3.366
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -118,10 +118,10 @@
     {
       "id": "gemini-3.6-flash",
       "name": "gemini-3.6-flash",
-      "cost_per_1m_in": 0.673,
-      "cost_per_1m_out": 3.366,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.673,
+        "output": 3.366
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -136,10 +136,10 @@
     {
       "id": "qwen3.8-2.4t-a95b",
       "name": "qwen3.8-2.4t-a95b",
-      "cost_per_1m_in": 2.244,
-      "cost_per_1m_out": 5.386,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.244,
+        "output": 5.386
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -154,10 +154,10 @@
     {
       "id": "gemini-3.5-flash-lite",
       "name": "gemini-3.5-flash-lite",
-      "cost_per_1m_in": 0.296,
-      "cost_per_1m_out": 2.468,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.296,
+        "output": 2.468
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -172,10 +172,10 @@
     {
       "id": "deepseek-v4-flash-0731",
       "name": "deepseek-v4-flash-0731",
-      "cost_per_1m_in": 0.117,
-      "cost_per_1m_out": 0.251,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.117,
+        "output": 0.251
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -190,10 +190,10 @@
     {
       "id": "kimi-k3",
       "name": "kimi-k3",
-      "cost_per_1m_in": 2.693,
-      "cost_per_1m_out": 13.464,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.693,
+        "output": 13.464
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -208,10 +208,10 @@
     {
       "id": "claude-opus-5",
       "name": "claude-opus-5",
-      "cost_per_1m_in": 4.937,
-      "cost_per_1m_out": 24.684,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 4.937,
+        "output": 24.684
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -226,10 +226,10 @@
     {
       "id": "gpt-5.6-sol",
       "name": "gpt-5.6-sol",
-      "cost_per_1m_in": 4.937,
-      "cost_per_1m_out": 29.621,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 4.937,
+        "output": 29.621
+      },
       "context_window": 1050000,
       "default_max_tokens": 105000,
       "can_reason": true,
@@ -244,10 +244,10 @@
     {
       "id": "gpt-5.6-terra",
       "name": "gpt-5.6-terra",
-      "cost_per_1m_in": 1.975,
-      "cost_per_1m_out": 11.848,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.975,
+        "output": 11.848
+      },
       "context_window": 1050000,
       "default_max_tokens": 105000,
       "can_reason": true,
@@ -262,10 +262,10 @@
     {
       "id": "gpt-5.6-luna",
       "name": "gpt-5.6-luna",
-      "cost_per_1m_in": 0.197,
-      "cost_per_1m_out": 1.185,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.197,
+        "output": 1.185
+      },
       "context_window": 1050000,
       "default_max_tokens": 105000,
       "can_reason": true,
@@ -280,10 +280,10 @@
     {
       "id": "apertus-70b",
       "name": "apertus-70b",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.25,
+        "output": 2
+      },
       "context_window": 65536,
       "default_max_tokens": 6553,
       "can_reason": true,
@@ -298,10 +298,10 @@
     {
       "id": "claude-sonnet-5",
       "name": "claude-sonnet-5",
-      "cost_per_1m_in": 1.975,
-      "cost_per_1m_out": 9.874,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.975,
+        "output": 9.874
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -316,10 +316,10 @@
     {
       "id": "gemma-4-31b-it",
       "name": "gemma-4-31b-it",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.35,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.35
+      },
       "context_window": 262000,
       "default_max_tokens": 26200,
       "can_reason": true,
@@ -334,10 +334,10 @@
     {
       "id": "glm-5.2",
       "name": "glm-5.2",
-      "cost_per_1m_in": 1.077,
-      "cost_per_1m_out": 3.77,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.077,
+        "output": 3.77
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -352,10 +352,10 @@
     {
       "id": "kimi-k2.7-code",
       "name": "kimi-k2.7-code",
-      "cost_per_1m_in": 0.673,
-      "cost_per_1m_out": 3.142,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.673,
+        "output": 3.142
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -370,10 +370,10 @@
     {
       "id": "minimax-m3",
       "name": "minimax-m3",
-      "cost_per_1m_in": 0.355,
-      "cost_per_1m_out": 1.775,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.355,
+        "output": 1.775
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -388,10 +388,10 @@
     {
       "id": "qwen3.6-27b",
       "name": "qwen3.6-27b",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2.7,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 2.7
+      },
       "context_window": 262000,
       "default_max_tokens": 26200,
       "can_reason": true,
@@ -406,10 +406,10 @@
     {
       "id": "cosmos3-super-reasoner",
       "name": "cosmos3-super-reasoner",
-      "cost_per_1m_in": 0.089,
-      "cost_per_1m_out": 0.266,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.089,
+        "output": 0.266
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -424,10 +424,10 @@
     {
       "id": "claude-opus4-8",
       "name": "claude-opus4-8",
-      "cost_per_1m_in": 4.881,
-      "cost_per_1m_out": 24.404,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 4.881,
+        "output": 24.404
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -442,10 +442,10 @@
     {
       "id": "gemini-3.5-flash",
       "name": "gemini-3.5-flash",
-      "cost_per_1m_in": 1.48,
-      "cost_per_1m_out": 8.886,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.48,
+        "output": 8.886
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -460,10 +460,10 @@
     {
       "id": "gemini-3.1-flash-lite",
       "name": "gemini-3.1-flash-lite",
-      "cost_per_1m_in": 0.244,
-      "cost_per_1m_out": 1.464,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.244,
+        "output": 1.464
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -478,10 +478,10 @@
     {
       "id": "qwen3.6-35b-a3b",
       "name": "qwen3.6-35b-a3b",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.5
+      },
       "context_window": 262000,
       "default_max_tokens": 26200,
       "can_reason": true,
@@ -496,10 +496,10 @@
     {
       "id": "glm-5v-turbo",
       "name": "glm-5v-turbo",
-      "cost_per_1m_in": 1.065,
-      "cost_per_1m_out": 3.55,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.065,
+        "output": 3.55
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
@@ -514,10 +514,10 @@
     {
       "id": "glm-5-turbo",
       "name": "glm-5-turbo",
-      "cost_per_1m_in": 1.065,
-      "cost_per_1m_out": 3.55,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.065,
+        "output": 3.55
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
@@ -532,10 +532,10 @@
     {
       "id": "gemma-4-26b-a4b-it",
       "name": "gemma-4-26b-a4b-it",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.5
+      },
       "context_window": 262000,
       "default_max_tokens": 26200,
       "can_reason": true,
@@ -550,10 +550,10 @@
     {
       "id": "deepseek-v4-pro",
       "name": "deepseek-v4-pro",
-      "cost_per_1m_in": 1.553,
-      "cost_per_1m_out": 3.106,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.553,
+        "output": 3.106
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -568,10 +568,10 @@
     {
       "id": "mistral-medium-3.5",
       "name": "mistral-medium-3.5",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 6.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.25,
+        "output": 6.4
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -586,10 +586,10 @@
     {
       "id": "nvidia-nemotron-3-nano-omni",
       "name": "nvidia-nemotron-3-nano-omni",
-      "cost_per_1m_in": 0.053,
-      "cost_per_1m_out": 0.213,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.053,
+        "output": 0.213
+      },
       "context_window": 300000,
       "default_max_tokens": 30000,
       "can_reason": true,
@@ -604,10 +604,10 @@
     {
       "id": "gpt-5.4",
       "name": "gpt-5.4",
-      "cost_per_1m_in": 2.601,
-      "cost_per_1m_out": 13.872,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.601,
+        "output": 13.872
+      },
       "context_window": 1050000,
       "default_max_tokens": 105000,
       "can_reason": true,
@@ -622,10 +622,10 @@
     {
       "id": "kimi-k2.6",
       "name": "kimi-k2.6",
-      "cost_per_1m_in": 0.694,
-      "cost_per_1m_out": 3.034,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.694,
+        "output": 3.034
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -640,10 +640,10 @@
     {
       "id": "claude-opus4-7",
       "name": "claude-opus4-7",
-      "cost_per_1m_in": 4.881,
-      "cost_per_1m_out": 24.404,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 4.881,
+        "output": 24.404
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -658,10 +658,10 @@
     {
       "id": "minimax-m2.7",
       "name": "minimax-m2.7",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4
+      },
       "context_window": 196608,
       "default_max_tokens": 19660,
       "can_reason": true,
@@ -676,10 +676,10 @@
     {
       "id": "glm-5.1",
       "name": "glm-5.1",
-      "cost_per_1m_in": 1.242,
-      "cost_per_1m_out": 3.903,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.242,
+        "output": 3.903
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
@@ -694,10 +694,10 @@
     {
       "id": "qwen3.5-122b-a10b",
       "name": "qwen3.5-122b-a10b",
-      "cost_per_1m_in": 0.444,
-      "cost_per_1m_out": 3.106,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.444,
+        "output": 3.106
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -712,10 +712,10 @@
     {
       "id": "qwen3.5-9b",
       "name": "qwen3.5-9b",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.15
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -730,10 +730,10 @@
     {
       "id": "qwen3-coder-next",
       "name": "qwen3-coder-next",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.8
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -748,10 +748,10 @@
     {
       "id": "glm-5",
       "name": "glm-5",
-      "cost_per_1m_in": 0.887,
-      "cost_per_1m_out": 2.84,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.887,
+        "output": 2.84
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
@@ -766,10 +766,10 @@
     {
       "id": "qwen3.5-397b-a17b",
       "name": "qwen3.5-397b-a17b",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 3.6
+      },
       "context_window": 262000,
       "default_max_tokens": 26200,
       "can_reason": true,
@@ -784,10 +784,10 @@
     {
       "id": "deepseek-v3.2",
       "name": "deepseek-v3.2",
-      "cost_per_1m_in": 0.266,
-      "cost_per_1m_out": 0.444,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.266,
+        "output": 0.444
+      },
       "context_window": 163840,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -802,10 +802,10 @@
     {
       "id": "mistral-small-2603",
       "name": "mistral-small-2603",
-      "cost_per_1m_in": 0.128,
-      "cost_per_1m_out": 0.51,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.128,
+        "output": 0.51
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -820,10 +820,10 @@
     {
       "id": "minimax-m2.5",
       "name": "minimax-m2.5",
-      "cost_per_1m_in": 0.266,
-      "cost_per_1m_out": 1.065,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.266,
+        "output": 1.065
+      },
       "context_window": 196000,
       "default_max_tokens": 19600,
       "can_reason": true,
@@ -838,10 +838,10 @@
     {
       "id": "claude-4-6-sonnet",
       "name": "claude-4-6-sonnet",
-      "cost_per_1m_in": 2.869,
-      "cost_per_1m_out": 14.309,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.869,
+        "output": 14.309
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -856,10 +856,10 @@
     {
       "id": "glm-4.7-flash",
       "name": "glm-4.7-flash",
-      "cost_per_1m_in": 0.072,
-      "cost_per_1m_out": 0.429,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.072,
+        "output": 0.429
+      },
       "context_window": 203000,
       "default_max_tokens": 20300,
       "can_reason": false,
@@ -868,10 +868,10 @@
     {
       "id": "kimi-k2.5",
       "name": "kimi-k2.5",
-      "cost_per_1m_in": 0.444,
-      "cost_per_1m_out": 2.485,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.444,
+        "output": 2.485
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -886,10 +886,10 @@
     {
       "id": "claude-opus4-6",
       "name": "claude-opus4-6",
-      "cost_per_1m_in": 4.769,
-      "cost_per_1m_out": 23.843,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 4.769,
+        "output": 23.843
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -904,10 +904,10 @@
     {
       "id": "minimax-m2",
       "name": "minimax-m2",
-      "cost_per_1m_in": 0.313,
-      "cost_per_1m_out": 1.261,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.313,
+        "output": 1.261
+      },
       "context_window": 400000,
       "default_max_tokens": 40000,
       "can_reason": true,
@@ -922,10 +922,10 @@
     {
       "id": "glm-4.7",
       "name": "glm-4.7",
-      "cost_per_1m_in": 0.7,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.7,
+        "output": 2.5
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
@@ -940,10 +940,10 @@
     {
       "id": "minimax-m2.1",
       "name": "minimax-m2.1",
-      "cost_per_1m_in": 0.322,
-      "cost_per_1m_out": 1.288,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.322,
+        "output": 1.288
+      },
       "context_window": 196000,
       "default_max_tokens": 19600,
       "can_reason": true,
@@ -958,10 +958,10 @@
     {
       "id": "qwen3-vl-235b-a22b",
       "name": "qwen3-vl-235b-a22b",
-      "cost_per_1m_in": 0.554,
-      "cost_per_1m_out": 2.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.554,
+        "output": 2.8
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -976,10 +976,10 @@
     {
       "id": "nvidia-nemotron-3-nano-30b-a3b",
       "name": "nvidia-nemotron-3-nano-30b-a3b",
-      "cost_per_1m_in": 0.054,
-      "cost_per_1m_out": 0.215,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.054,
+        "output": 0.215
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -994,10 +994,10 @@
     {
       "id": "claude-opus4-5",
       "name": "claude-opus4-5",
-      "cost_per_1m_in": 4.769,
-      "cost_per_1m_out": 23.849,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 4.769,
+        "output": 23.849
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
@@ -1012,10 +1012,10 @@
     {
       "id": "qwen3-next-80b-a3b-thinking",
       "name": "qwen3-next-80b-a3b-thinking",
-      "cost_per_1m_in": 0.134,
-      "cost_per_1m_out": 1.073,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.134,
+        "output": 1.073
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -1030,10 +1030,10 @@
     {
       "id": "devstral-2512",
       "name": "devstral-2512",
-      "cost_per_1m_in": 0.429,
-      "cost_per_1m_out": 2.147,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.429,
+        "output": 2.147
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -1042,10 +1042,10 @@
     {
       "id": "nova-2-lite",
       "name": "nova-2-lite",
-      "cost_per_1m_in": 0.335,
-      "cost_per_1m_out": 2.822,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.335,
+        "output": 2.822
+      },
       "context_window": 1000000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -1060,10 +1060,10 @@
     {
       "id": "gpt-oss-safeguard-120b",
       "name": "gpt-oss-safeguard-120b",
-      "cost_per_1m_in": 0.161,
-      "cost_per_1m_out": 0.626,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.161,
+        "output": 0.626
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -1078,10 +1078,10 @@
     {
       "id": "mistral-large-2512",
       "name": "mistral-large-2512",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 1.5
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -1090,10 +1090,10 @@
     {
       "id": "ministral-8b-2512",
       "name": "ministral-8b-2512",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.15
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -1102,10 +1102,10 @@
     {
       "id": "ministral-3b-2512",
       "name": "ministral-3b-2512",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.1
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -1114,10 +1114,10 @@
     {
       "id": "ministral-14b-2512",
       "name": "ministral-14b-2512",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -1126,10 +1126,10 @@
     {
       "id": "gpt-5.1",
       "name": "gpt-5.1",
-      "cost_per_1m_in": 1.234,
-      "cost_per_1m_out": 9.838,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.234,
+        "output": 9.838
+      },
       "context_window": 400000,
       "default_max_tokens": 40000,
       "can_reason": true,
@@ -1144,10 +1144,10 @@
     {
       "id": "nemotron-nano-v2-12b",
       "name": "nemotron-nano-v2-12b",
-      "cost_per_1m_in": 0.215,
-      "cost_per_1m_out": 0.635,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.215,
+        "output": 0.635
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -1162,10 +1162,10 @@
     {
       "id": "claude-haiku-4-5",
       "name": "claude-haiku-4-5",
-      "cost_per_1m_in": 0.894,
-      "cost_per_1m_out": 4.472,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.894,
+        "output": 4.472
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
@@ -1180,10 +1180,10 @@
     {
       "id": "claude-4-5-sonnet",
       "name": "claude-4-5-sonnet",
-      "cost_per_1m_in": 2.683,
-      "cost_per_1m_out": 13.416,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.683,
+        "output": 13.416
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
@@ -1198,10 +1198,10 @@
     {
       "id": "hermes-4-70b",
       "name": "hermes-4-70b",
-      "cost_per_1m_in": 0.116,
-      "cost_per_1m_out": 0.358,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.116,
+        "output": 0.358
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -1210,10 +1210,10 @@
     {
       "id": "gpt-5",
       "name": "gpt-5",
-      "cost_per_1m_in": 1.234,
-      "cost_per_1m_out": 9.838,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.234,
+        "output": 9.838
+      },
       "context_window": 400000,
       "default_max_tokens": 40000,
       "can_reason": true,
@@ -1228,10 +1228,10 @@
     {
       "id": "gpt-oss-120b",
       "name": "gpt-oss-120b",
-      "cost_per_1m_in": 0.08,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.08,
+        "output": 0.4
+      },
       "context_window": 131000,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -1246,10 +1246,10 @@
     {
       "id": "qwen3-30b-a3b-instruct-2507",
       "name": "qwen3-30b-a3b-instruct-2507",
-      "cost_per_1m_in": 0.089,
-      "cost_per_1m_out": 0.268,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.089,
+        "output": 0.268
+      },
       "context_window": 262000,
       "default_max_tokens": 26200,
       "can_reason": true,
@@ -1264,10 +1264,10 @@
     {
       "id": "gpt-oss-20b",
       "name": "gpt-oss-20b",
-      "cost_per_1m_in": 0.04,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.04,
+        "output": 0.15
+      },
       "context_window": 131000,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -1282,10 +1282,10 @@
     {
       "id": "mistral-7b-instruct-v0.3",
       "name": "mistral-7b-instruct-v0.3",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.1
+      },
       "context_window": 127000,
       "default_max_tokens": 12700,
       "can_reason": false,
@@ -1294,10 +1294,10 @@
     {
       "id": "mistral-large-2402",
       "name": "mistral-large-2402",
-      "cost_per_1m_in": 3.846,
-      "cost_per_1m_out": 11.627,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.846,
+        "output": 11.627
+      },
       "context_window": 32000,
       "default_max_tokens": 3200,
       "can_reason": true,
@@ -1312,10 +1312,10 @@
     {
       "id": "pixtral-large-2502",
       "name": "pixtral-large-2502",
-      "cost_per_1m_in": 1.789,
-      "cost_per_1m_out": 5.366,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.789,
+        "output": 5.366
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -1330,10 +1330,10 @@
     {
       "id": "mistral-small-3.2-24b-instruct-2506",
       "name": "mistral-small-3.2-24b-instruct-2506",
-      "cost_per_1m_in": 0.09,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.09,
+        "output": 0.28
+      },
       "context_window": 131000,
       "default_max_tokens": 13100,
       "can_reason": false,
@@ -1342,10 +1342,10 @@
     {
       "id": "qwen3-32b",
       "name": "qwen3-32b",
-      "cost_per_1m_in": 0.089,
-      "cost_per_1m_out": 0.268,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.089,
+        "output": 0.268
+      },
       "context_window": 40000,
       "default_max_tokens": 4000,
       "can_reason": true,
@@ -1360,10 +1360,10 @@
     {
       "id": "qwen3-235b-a22b-instruct-2507",
       "name": "qwen3-235b-a22b-instruct-2507",
-      "cost_per_1m_in": 0.062,
-      "cost_per_1m_out": 0.408,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.062,
+        "output": 0.408
+      },
       "context_window": 262000,
       "default_max_tokens": 26200,
       "can_reason": true,
@@ -1378,10 +1378,10 @@
     {
       "id": "qwen3-coder-30b-a3b-instruct",
       "name": "qwen3-coder-30b-a3b-instruct",
-      "cost_per_1m_in": 0.06,
-      "cost_per_1m_out": 0.22,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.06,
+        "output": 0.22
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -1396,10 +1396,10 @@
     {
       "id": "gpt-4.1",
       "name": "gpt-4.1",
-      "cost_per_1m_in": 1.968,
-      "cost_per_1m_out": 7.872,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.968,
+        "output": 7.872
+      },
       "context_window": 1047576,
       "default_max_tokens": 104757,
       "can_reason": true,
@@ -1414,10 +1414,10 @@
     {
       "id": "gpt-4.1-mini",
       "name": "gpt-4.1-mini",
-      "cost_per_1m_in": 0.39,
-      "cost_per_1m_out": 1.53,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.39,
+        "output": 1.53
+      },
       "context_window": 1047576,
       "default_max_tokens": 104757,
       "can_reason": true,
@@ -1432,10 +1432,10 @@
     {
       "id": "gpt-4.1-nano",
       "name": "gpt-4.1-nano",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.39,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.39
+      },
       "context_window": 1047576,
       "default_max_tokens": 104757,
       "can_reason": true,
@@ -1450,10 +1450,10 @@
     {
       "id": "nova-micro-v1",
       "name": "nova-micro-v1",
-      "cost_per_1m_in": 0.036,
-      "cost_per_1m_out": 0.143,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.036,
+        "output": 0.143
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -1468,10 +1468,10 @@
     {
       "id": "nova-lite-v1",
       "name": "nova-lite-v1",
-      "cost_per_1m_in": 0.062,
-      "cost_per_1m_out": 0.247,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.062,
+        "output": 0.247
+      },
       "context_window": 300000,
       "default_max_tokens": 30000,
       "can_reason": true,
@@ -1486,10 +1486,10 @@
     {
       "id": "nova-pro-v1",
       "name": "nova-pro-v1",
-      "cost_per_1m_in": 0.824,
-      "cost_per_1m_out": 3.295,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.824,
+        "output": 3.295
+      },
       "context_window": 300000,
       "default_max_tokens": 30000,
       "can_reason": true,
@@ -1504,10 +1504,10 @@
     {
       "id": "claude-sonnet-4",
       "name": "claude-sonnet-4",
-      "cost_per_1m_in": 2.601,
-      "cost_per_1m_out": 13.01,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.601,
+        "output": 13.01
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
@@ -1522,10 +1522,10 @@
     {
       "id": "llama-3.1-nemotron-ultra-253b-v1",
       "name": "llama-3.1-nemotron-ultra-253b-v1",
-      "cost_per_1m_in": 0.537,
-      "cost_per_1m_out": 1.61,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.537,
+        "output": 1.61
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -1540,10 +1540,10 @@
     {
       "id": "mistral-small-2503",
       "name": "mistral-small-2503",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.3
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -1552,10 +1552,10 @@
     {
       "id": "gemini-2.5-flash",
       "name": "gemini-2.5-flash",
-      "cost_per_1m_in": 0.268,
-      "cost_per_1m_out": 2.236,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.268,
+        "output": 2.236
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -1570,10 +1570,10 @@
     {
       "id": "gemini-2.5-pro",
       "name": "gemini-2.5-pro",
-      "cost_per_1m_in": 1.342,
-      "cost_per_1m_out": 8.944,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.342,
+        "output": 8.944
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -1588,10 +1588,10 @@
     {
       "id": "gemma-3-27b-it",
       "name": "gemma-3-27b-it",
-      "cost_per_1m_in": 0.089,
-      "cost_per_1m_out": 0.268,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.089,
+        "output": 0.268
+      },
       "context_window": 131000,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -1606,10 +1606,10 @@
     {
       "id": "deepseek-r1-0528",
       "name": "deepseek-r1-0528",
-      "cost_per_1m_in": 0.585,
-      "cost_per_1m_out": 2.307,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.585,
+        "output": 2.307
+      },
       "context_window": 164000,
       "default_max_tokens": 16400,
       "can_reason": true,
@@ -1624,10 +1624,10 @@
     {
       "id": "codestral-2508",
       "name": "codestral-2508",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.9
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
@@ -1636,10 +1636,10 @@
     {
       "id": "llama-3.3-70b-instruct",
       "name": "llama-3.3-70b-instruct",
-      "cost_per_1m_in": 0.116,
-      "cost_per_1m_out": 0.358,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.116,
+        "output": 0.358
+      },
       "context_window": 131000,
       "default_max_tokens": 13100,
       "can_reason": true,
@@ -1654,10 +1654,10 @@
     {
       "id": "gpt-4o",
       "name": "gpt-4o",
-      "cost_per_1m_in": 2.387,
-      "cost_per_1m_out": 9.547,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.387,
+        "output": 9.547
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -1672,10 +1672,10 @@
     {
       "id": "gpt-5-mini",
       "name": "gpt-5-mini",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1.968,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 1.968
+      },
       "context_window": 400000,
       "default_max_tokens": 40000,
       "can_reason": true,
@@ -1690,10 +1690,10 @@
     {
       "id": "gpt-5-nano",
       "name": "gpt-5-nano",
-      "cost_per_1m_in": 0.054,
-      "cost_per_1m_out": 0.394,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.054,
+        "output": 0.394
+      },
       "context_window": 400000,
       "default_max_tokens": 40000,
       "can_reason": true,
@@ -1708,10 +1708,10 @@
     {
       "id": "hermes-4-405b",
       "name": "hermes-4-405b",
-      "cost_per_1m_in": 0.894,
-      "cost_per_1m_out": 2.683,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.894,
+        "output": 2.683
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -1720,10 +1720,10 @@
     {
       "id": "mistral-nemo-instruct-2407",
       "name": "mistral-nemo-instruct-2407",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.13,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.13,
+        "output": 0.13
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
@@ -1732,10 +1732,10 @@
     {
       "id": "llama-3.1-405b-instruct",
       "name": "llama-3.1-405b-instruct",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 1.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.75,
+        "output": 1.75
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -1750,10 +1750,10 @@
     {
       "id": "gpt-4o-mini",
       "name": "gpt-4o-mini",
-      "cost_per_1m_in": 0.143,
-      "cost_per_1m_out": 0.573,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.143,
+        "output": 0.573
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -1768,10 +1768,10 @@
     {
       "id": "llama-3.1-8b-instruct",
       "name": "llama-3.1-8b-instruct",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.15
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,

--- a/internal/providers/configs/cortecs.json
+++ b/internal/providers/configs/cortecs.json
@@ -23,7 +23,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.3",
@@ -41,7 +43,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.8-flash-next",
@@ -59,7 +63,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-5.3-flash",
@@ -77,7 +83,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.8-27b",
@@ -95,7 +103,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.7-flash",
@@ -113,7 +123,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.6-flash",
@@ -131,7 +143,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.8-2.4t-a95b",
@@ -149,7 +163,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gemini-3.5-flash-lite",
@@ -167,7 +183,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek-v4-flash-0731",
@@ -185,7 +203,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-k3",
@@ -203,7 +223,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-5",
@@ -221,7 +243,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-sol",
@@ -239,7 +263,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-terra",
@@ -257,7 +283,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-luna",
@@ -275,7 +303,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "apertus-70b",
@@ -293,7 +323,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-sonnet-5",
@@ -311,7 +343,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemma-4-31b-it",
@@ -329,7 +363,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-5.2",
@@ -347,7 +383,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-k2.7-code",
@@ -365,7 +403,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax-m3",
@@ -383,7 +423,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-27b",
@@ -401,7 +443,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "cosmos3-super-reasoner",
@@ -419,7 +463,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-opus4-8",
@@ -437,7 +483,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.5-flash",
@@ -455,7 +503,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.1-flash-lite",
@@ -473,7 +523,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-35b-a3b",
@@ -491,7 +543,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-5v-turbo",
@@ -509,7 +563,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-5-turbo",
@@ -527,7 +583,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gemma-4-26b-a4b-it",
@@ -545,7 +603,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek-v4-pro",
@@ -563,7 +623,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral-medium-3.5",
@@ -581,7 +643,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nvidia-nemotron-3-nano-omni",
@@ -599,7 +663,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-5.4",
@@ -617,7 +683,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.6",
@@ -635,7 +703,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus4-7",
@@ -653,7 +723,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax-m2.7",
@@ -671,7 +743,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.1",
@@ -689,7 +763,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.5-122b-a10b",
@@ -707,7 +783,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.5-9b",
@@ -725,7 +803,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-coder-next",
@@ -743,7 +823,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5",
@@ -761,7 +843,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.5-397b-a17b",
@@ -779,7 +863,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v3.2",
@@ -797,7 +883,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral-small-2603",
@@ -815,7 +903,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax-m2.5",
@@ -833,7 +923,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-4-6-sonnet",
@@ -851,7 +943,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-4.7-flash",
@@ -863,7 +957,9 @@
       "context_window": 203000,
       "default_max_tokens": 20300,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-k2.5",
@@ -881,7 +977,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus4-6",
@@ -899,7 +997,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax-m2",
@@ -917,7 +1017,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.7",
@@ -935,7 +1037,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m2.1",
@@ -953,7 +1057,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-vl-235b-a22b",
@@ -971,7 +1077,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nvidia-nemotron-3-nano-30b-a3b",
@@ -989,7 +1097,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-opus4-5",
@@ -1007,7 +1117,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-next-80b-a3b-thinking",
@@ -1025,7 +1137,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "devstral-2512",
@@ -1037,7 +1151,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nova-2-lite",
@@ -1055,7 +1171,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-oss-safeguard-120b",
@@ -1073,7 +1191,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral-large-2512",
@@ -1085,7 +1205,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ministral-8b-2512",
@@ -1097,7 +1219,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ministral-3b-2512",
@@ -1109,7 +1233,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ministral-14b-2512",
@@ -1121,7 +1247,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1",
@@ -1139,7 +1267,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nemotron-nano-v2-12b",
@@ -1157,7 +1287,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-haiku-4-5",
@@ -1175,7 +1307,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-4-5-sonnet",
@@ -1193,7 +1327,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "hermes-4-70b",
@@ -1205,7 +1341,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-5",
@@ -1223,7 +1361,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-oss-120b",
@@ -1241,7 +1381,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-30b-a3b-instruct-2507",
@@ -1259,7 +1401,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-oss-20b",
@@ -1277,7 +1421,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral-7b-instruct-v0.3",
@@ -1289,7 +1435,9 @@
       "context_window": 127000,
       "default_max_tokens": 12700,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral-large-2402",
@@ -1307,7 +1455,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "pixtral-large-2502",
@@ -1325,7 +1475,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral-small-3.2-24b-instruct-2506",
@@ -1337,7 +1489,9 @@
       "context_window": 131000,
       "default_max_tokens": 13100,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-32b",
@@ -1355,7 +1509,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-235b-a22b-instruct-2507",
@@ -1373,7 +1529,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-coder-30b-a3b-instruct",
@@ -1391,7 +1549,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-4.1",
@@ -1409,7 +1569,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-mini",
@@ -1427,7 +1589,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-nano",
@@ -1445,7 +1609,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nova-micro-v1",
@@ -1463,7 +1629,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nova-lite-v1",
@@ -1481,7 +1649,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nova-pro-v1",
@@ -1499,7 +1669,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4",
@@ -1517,7 +1689,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "llama-3.1-nemotron-ultra-253b-v1",
@@ -1535,7 +1709,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral-small-2503",
@@ -1547,7 +1723,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash",
@@ -1565,7 +1743,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-pro",
@@ -1583,7 +1763,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemma-3-27b-it",
@@ -1601,7 +1783,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek-r1-0528",
@@ -1619,7 +1803,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "codestral-2508",
@@ -1631,7 +1817,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "llama-3.3-70b-instruct",
@@ -1649,7 +1837,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-4o",
@@ -1667,7 +1857,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-mini",
@@ -1685,7 +1877,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-nano",
@@ -1703,7 +1897,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "hermes-4-405b",
@@ -1715,7 +1911,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral-nemo-instruct-2407",
@@ -1727,7 +1925,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "llama-3.1-405b-instruct",
@@ -1745,7 +1945,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-4o-mini",
@@ -1763,7 +1965,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "llama-3.1-8b-instruct",
@@ -1781,7 +1985,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -10,10 +10,11 @@
     {
       "id": "deepseek-v4-flash",
       "name": "DeepSeek-V4-Flash",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0.0028,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_create": 0.0028
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -28,10 +29,11 @@
     {
       "id": "deepseek-v4-pro",
       "name": "DeepSeek-V4-Pro",
-      "cost_per_1m_in": 0.435,
-      "cost_per_1m_out": 0.87,
-      "cost_per_1m_in_cached": 0.003625,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.435,
+        "output": 0.87,
+        "cache_create": 0.003625
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,

--- a/internal/providers/configs/deepseek.json
+++ b/internal/providers/configs/deepseek.json
@@ -24,7 +24,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-pro",
@@ -43,7 +45,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/fireworks.json
+++ b/internal/providers/configs/fireworks.json
@@ -18,7 +18,9 @@
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "accounts/fireworks/models/qwen3p7-plus",
@@ -31,7 +33,9 @@
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "accounts/fireworks/models/glm-5p2",
@@ -46,7 +50,9 @@
       "can_reason": true,
       "reasoning_levels": ["high", "max"],
       "default_reasoning_effort": "max",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "accounts/fireworks/models/glm-5p3",
@@ -61,7 +67,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "accounts/fireworks/models/glm-5p3-flash",
@@ -76,7 +84,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "accounts/fireworks/models/kimi-k3",
@@ -95,7 +105,9 @@
         "max"
       ],
       "default_reasoning_effort": "max",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "accounts/fireworks/models/kimi-k2p7-code",
@@ -108,7 +120,9 @@
       "context_window": 262000,
       "default_max_tokens": 262000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "accounts/fireworks/models/kimi-k2p6",
@@ -121,7 +135,9 @@
       "context_window": 262000,
       "default_max_tokens": 262000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "accounts/fireworks/models/minimax-m3",
@@ -136,7 +152,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "accounts/fireworks/models/minimax-m2p7",
@@ -151,7 +169,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "accounts/fireworks/models/deepseek-v4-pro",
@@ -166,7 +186,9 @@
       "can_reason": true,
       "reasoning_levels": ["none", "high", "xhigh"],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "accounts/fireworks/models/deepseek-v4-pro-0813",
@@ -181,7 +203,9 @@
       "can_reason": true,
       "reasoning_levels": ["none", "low", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "accounts/fireworks/models/deepseek-v4-flash",
@@ -196,7 +220,9 @@
       "can_reason": true,
       "reasoning_levels": ["none", "high", "xhigh"],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "accounts/fireworks/models/deepseek-v4-flash-0731",
@@ -211,7 +237,9 @@
       "can_reason": true,
       "reasoning_levels": ["none", "low", "high", "max"],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "accounts/fireworks/models/gpt-oss-120b",
@@ -226,7 +254,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "accounts/fireworks/models/gpt-oss-20b",
@@ -241,7 +271,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "accounts/fireworks/models/inkling",
@@ -256,7 +288,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b",
@@ -271,7 +305,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "accounts/fireworks/models/nemotron-3-ultra-nvfp4",
@@ -286,7 +322,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/fireworks.json
+++ b/internal/providers/configs/fireworks.json
@@ -10,10 +10,11 @@
     {
       "id": "accounts/fireworks/models/qwen3p8-max",
       "name": "Qwen 3.8 Max",
-      "cost_per_1m_in": 2.00,
-      "cost_per_1m_out": 6.00,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.25
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -22,10 +23,11 @@
     {
       "id": "accounts/fireworks/models/qwen3p7-plus",
       "name": "Qwen3.7-Plus",
-      "cost_per_1m_in": 0.40,
-      "cost_per_1m_out": 1.60,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.08,
+      "pricing": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_hit": 0.08
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -34,10 +36,11 @@
     {
       "id": "accounts/fireworks/models/glm-5p2",
       "name": "GLM-5.2",
-      "cost_per_1m_in": 1.40,
-      "cost_per_1m_out": 4.40,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.14,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.14
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -48,10 +51,11 @@
     {
       "id": "accounts/fireworks/models/glm-5p3",
       "name": "GLM-5.3",
-      "cost_per_1m_in": 1.40,
-      "cost_per_1m_out": 4.40,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.26,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.26
+      },
       "context_window": 1048576,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -62,10 +66,11 @@
     {
       "id": "accounts/fireworks/models/glm-5p3-flash",
       "name": "GLM-5.3 Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.50,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.029,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.5,
+        "cache_hit": 0.029
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -76,10 +81,11 @@
     {
       "id": "accounts/fireworks/models/kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3.00,
-      "cost_per_1m_out": 15.00,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.30,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_hit": 0.3
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -94,10 +100,11 @@
     {
       "id": "accounts/fireworks/models/kimi-k2p7-code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4.00,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.19,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_hit": 0.19
+      },
       "context_window": 262000,
       "default_max_tokens": 262000,
       "can_reason": false,
@@ -106,10 +113,11 @@
     {
       "id": "accounts/fireworks/models/kimi-k2p6",
       "name": "Kimi K2.6",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4.00,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.16,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_hit": 0.16
+      },
       "context_window": 262000,
       "default_max_tokens": 262000,
       "can_reason": true,
@@ -118,10 +126,11 @@
     {
       "id": "accounts/fireworks/models/minimax-m3",
       "name": "Minimax M3",
-      "cost_per_1m_in": 0.30,
-      "cost_per_1m_out": 1.20,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.059,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.059
+      },
       "context_window": 512000,
       "default_max_tokens": 512000,
       "can_reason": true,
@@ -132,10 +141,11 @@
     {
       "id": "accounts/fireworks/models/minimax-m2p7",
       "name": "MiniMax M2.7",
-      "cost_per_1m_in": 0.30,
-      "cost_per_1m_out": 1.20,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.059,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.059
+      },
       "context_window": 196608,
       "default_max_tokens": 196608,
       "can_reason": true,
@@ -146,10 +156,11 @@
     {
       "id": "accounts/fireworks/models/deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
-      "cost_per_1m_in": 1.74,
-      "cost_per_1m_out": 3.48,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.145,
+      "pricing": {
+        "input": 1.74,
+        "output": 3.48,
+        "cache_hit": 0.145
+      },
       "context_window": 1048576,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -160,10 +171,11 @@
     {
       "id": "accounts/fireworks/models/deepseek-v4-pro-0813",
       "name": "DeepSeek V4 Pro 0813",
-      "cost_per_1m_in": 1.32,
-      "cost_per_1m_out": 3.96,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.044,
+      "pricing": {
+        "input": 1.32,
+        "output": 3.96,
+        "cache_hit": 0.044
+      },
       "context_window": 1048576,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -174,10 +186,11 @@
     {
       "id": "accounts/fireworks/models/deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_hit": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -188,10 +201,11 @@
     {
       "id": "accounts/fireworks/models/deepseek-v4-flash-0731",
       "name": "DeepSeek V4 Flash 0731",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 0.66,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.007,
+      "pricing": {
+        "input": 0.22,
+        "output": 0.66,
+        "cache_hit": 0.007
+      },
       "context_window": 1048576,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -202,10 +216,11 @@
     {
       "id": "accounts/fireworks/models/gpt-oss-120b",
       "name": "gpt-oss-120b",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.60,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.014,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.014
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -216,10 +231,11 @@
     {
       "id": "accounts/fireworks/models/gpt-oss-20b",
       "name": "gpt-oss-20b",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.035,
+      "pricing": {
+        "input": 0.07,
+        "output": 0.3,
+        "cache_hit": 0.035
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -230,10 +246,11 @@
     {
       "id": "accounts/fireworks/models/inkling",
       "name": "Inkling",
-      "cost_per_1m_in": 1.00,
-      "cost_per_1m_out": 4.05,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.17,
+      "pricing": {
+        "input": 1,
+        "output": 4.05,
+        "cache_hit": 0.17
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -244,10 +261,11 @@
     {
       "id": "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b",
       "name": "Nemotron Lightning 3.5 30B A3B",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.20,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.2,
+        "cache_hit": 0.01
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -258,10 +276,11 @@
     {
       "id": "accounts/fireworks/models/nemotron-3-ultra-nvfp4",
       "name": "NVIDIA Nemotron 3 Ultra NVFP4",
-      "cost_per_1m_in": 0.60,
-      "cost_per_1m_out": 2.40,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.119,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_hit": 0.119
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,

--- a/internal/providers/configs/gemini.json
+++ b/internal/providers/configs/gemini.json
@@ -10,10 +10,12 @@
     {
       "id": "gemini-3.7-flash",
       "name": "Gemini 3.7 Flash",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 3.75,
-      "cost_per_1m_in_cached": 0.075,
-      "cost_per_1m_out_cached": 3.75,
+      "pricing": {
+        "input": 0.75,
+        "output": 3.75,
+        "cache_create": 0.075,
+        "cache_hit": 3.75
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -24,10 +26,11 @@
     {
       "id": "gemini-3.6-flash",
       "name": "Gemini 3.6 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.5,
+        "output": 7.5,
+        "cache_hit": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -38,10 +41,11 @@
     {
       "id": "gemini-3.5-flash",
       "name": "Gemini 3.5 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1,
+      "pricing": {
+        "input": 1.5,
+        "output": 9,
+        "cache_hit": 1
+      },
       "context_window": 1048576,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -52,10 +56,12 @@
     {
       "id": "gemini-3.5-flash-lite",
       "name": "Gemini 3.5 Flash-Lite",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 2.5,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_create": 0.03,
+        "cache_hit": 2.5
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -66,10 +72,11 @@
     {
       "id": "gemini-3.1-pro-preview-customtools",
       "name": "Gemini 3.1 Pro",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_hit": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -80,10 +87,12 @@
     {
       "id": "gemini-3.1-flash-lite",
       "name": "Gemini 3.1 Flash-Lite",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0.025,
-      "cost_per_1m_out_cached": 1.5,
+      "pricing": {
+        "input": 0.25,
+        "output": 1.5,
+        "cache_create": 0.025,
+        "cache_hit": 1.5
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -94,10 +103,11 @@
     {
       "id": "gemini-3-pro-preview",
       "name": "Gemini 3 Pro",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_hit": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -108,10 +118,11 @@
     {
       "id": "gemini-3-flash-preview",
       "name": "Gemini 3 Flash",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_hit": 0.05
+      },
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -122,10 +133,11 @@
     {
       "id": "gemini-2.5-pro",
       "name": "Gemini 2.5 Pro",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -134,10 +146,11 @@
     {
       "id": "gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_hit": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,

--- a/internal/providers/configs/gemini.json
+++ b/internal/providers/configs/gemini.json
@@ -21,7 +21,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.6-flash",
@@ -36,7 +38,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.5-flash",
@@ -51,7 +55,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.5-flash-lite",
@@ -67,7 +73,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "minimal",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.1-pro-preview-customtools",
@@ -82,7 +90,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.1-flash-lite",
@@ -98,7 +108,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "minimal",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-pro-preview",
@@ -113,7 +125,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "high"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-flash-preview",
@@ -128,7 +142,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "minimal",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-pro",
@@ -141,7 +157,9 @@
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash",
@@ -154,7 +172,9 @@
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/groq.json
+++ b/internal/providers/configs/groq.json
@@ -24,7 +24,10 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "default_max_tokens": 10000
+      "default_max_tokens": 10000,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-32b",
@@ -34,7 +37,10 @@
         "output": 0.59
       },
       "context_window": 131072,
-      "default_max_tokens": 10000
+      "default_max_tokens": 10000,
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/groq.json
+++ b/internal/providers/configs/groq.json
@@ -10,10 +10,12 @@
     {
       "id": "moonshotai/kimi-k2-instruct-0905",
       "name": "Kimi K2 0905",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 1,
+        "output": 3,
+        "cache_create": 0.5,
+        "cache_hit": 0.5
+      },
       "context_window": 131072,
       "can_reason": true,
       "reasoning_levels": [
@@ -27,8 +29,10 @@
     {
       "id": "qwen/qwen3-32b",
       "name": "Qwen3 32B",
-      "cost_per_1m_in": 0.29,
-      "cost_per_1m_out": 0.59,
+      "pricing": {
+        "input": 0.29,
+        "output": 0.59
+      },
       "context_window": 131072,
       "default_max_tokens": 10000
     }

--- a/internal/providers/configs/huggingface.json
+++ b/internal/providers/configs/huggingface.json
@@ -10,10 +10,10 @@
     {
       "id": "MiniMaxAI/MiniMax-M3:fireworks-ai",
       "name": "MiniMaxAI/MiniMax-M3 (fireworks-ai)",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2
+      },
       "context_window": 512000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -22,10 +22,10 @@
     {
       "id": "Qwen/Qwen3.8-2.4T-A95B:fireworks-ai",
       "name": "Qwen/Qwen3.8-2.4T-A95B (fireworks-ai)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -34,10 +34,10 @@
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash-0731:fireworks-ai",
       "name": "deepseek-ai/DeepSeek-V4-Flash-0731 (fireworks-ai)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -46,10 +46,10 @@
     {
       "id": "deepseek-ai/DeepSeek-V4-Pro-0813:fireworks-ai",
       "name": "deepseek-ai/DeepSeek-V4-Pro-0813 (fireworks-ai)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -58,10 +58,10 @@
     {
       "id": "google/gemma-4-31B-it:cerebras",
       "name": "google/gemma-4-31B-it (cerebras)",
-      "cost_per_1m_in": 0.99,
-      "cost_per_1m_out": 1.49,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.99,
+        "output": 1.49
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -70,10 +70,10 @@
     {
       "id": "meta-models/Muse-Glimmer-30B:fireworks-ai",
       "name": "meta-models/Muse-Glimmer-30B (fireworks-ai)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -82,10 +82,10 @@
     {
       "id": "moonshotai/Kimi-K2.6:fireworks-ai",
       "name": "moonshotai/Kimi-K2.6 (fireworks-ai)",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4
+      },
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -94,10 +94,10 @@
     {
       "id": "moonshotai/Kimi-K2.7-Code:fireworks-ai",
       "name": "moonshotai/Kimi-K2.7-Code (fireworks-ai)",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4
+      },
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -106,10 +106,10 @@
     {
       "id": "moonshotai/Kimi-K3:fireworks-ai",
       "name": "moonshotai/Kimi-K3 (fireworks-ai)",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15
+      },
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -118,10 +118,10 @@
     {
       "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4:fireworks-ai",
       "name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 (fireworks-ai)",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4
+      },
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -130,10 +130,10 @@
     {
       "id": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16:fireworks-ai",
       "name": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16 (fireworks-ai)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -142,10 +142,10 @@
     {
       "id": "openai/gpt-oss-120b:cerebras",
       "name": "openai/gpt-oss-120b (cerebras)",
-      "cost_per_1m_in": 0.35,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.35,
+        "output": 0.75
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -154,10 +154,10 @@
     {
       "id": "openai/gpt-oss-120b:fireworks-ai",
       "name": "openai/gpt-oss-120b (fireworks-ai)",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -166,10 +166,10 @@
     {
       "id": "openai/gpt-oss-120b:groq",
       "name": "openai/gpt-oss-120b (groq)",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.75
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -178,10 +178,10 @@
     {
       "id": "openai/gpt-oss-20b:groq",
       "name": "openai/gpt-oss-20b (groq)",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.5
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -190,10 +190,10 @@
     {
       "id": "openai/gpt-oss-safeguard-20b:groq",
       "name": "openai/gpt-oss-safeguard-20b (groq)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -202,10 +202,10 @@
     {
       "id": "thinkingmachines/Inkling:fireworks-ai",
       "name": "thinkingmachines/Inkling (fireworks-ai)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -214,10 +214,10 @@
     {
       "id": "zai-org/GLM-5.2:fireworks-ai",
       "name": "zai-org/GLM-5.2 (fireworks-ai)",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4
+      },
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -226,10 +226,10 @@
     {
       "id": "zai-org/GLM-5.3:fireworks-ai",
       "name": "zai-org/GLM-5.3 (fireworks-ai)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -238,10 +238,10 @@
     {
       "id": "zai-org/GLM-5.3-Flash:fireworks-ai",
       "name": "zai-org/GLM-5.3-Flash (fireworks-ai)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,

--- a/internal/providers/configs/huggingface.json
+++ b/internal/providers/configs/huggingface.json
@@ -17,7 +17,9 @@
       "context_window": 512000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3.8-2.4T-A95B:fireworks-ai",
@@ -29,7 +31,9 @@
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash-0731:fireworks-ai",
@@ -41,7 +45,9 @@
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V4-Pro-0813:fireworks-ai",
@@ -53,7 +59,9 @@
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "google/gemma-4-31B-it:cerebras",
@@ -65,7 +73,9 @@
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta-models/Muse-Glimmer-30B:fireworks-ai",
@@ -77,7 +87,9 @@
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K2.6:fireworks-ai",
@@ -89,7 +101,9 @@
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K2.7-Code:fireworks-ai",
@@ -101,7 +115,9 @@
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K3:fireworks-ai",
@@ -113,7 +129,9 @@
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4:fireworks-ai",
@@ -125,7 +143,9 @@
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16:fireworks-ai",
@@ -137,7 +157,9 @@
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-120b:cerebras",
@@ -149,7 +171,9 @@
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-120b:fireworks-ai",
@@ -161,7 +185,9 @@
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-120b:groq",
@@ -173,7 +199,9 @@
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-20b:groq",
@@ -185,7 +213,9 @@
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-safeguard-20b:groq",
@@ -197,7 +227,9 @@
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "thinkingmachines/Inkling:fireworks-ai",
@@ -209,7 +241,9 @@
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.2:fireworks-ai",
@@ -221,7 +255,9 @@
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.3:fireworks-ai",
@@ -233,7 +269,9 @@
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.3-Flash:fireworks-ai",
@@ -245,7 +283,9 @@
       "context_window": 1048576,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ],
   "default_headers": {

--- a/internal/providers/configs/ionet.json
+++ b/internal/providers/configs/ionet.json
@@ -18,7 +18,9 @@
       "context_window": 163840,
       "default_max_tokens": 16384,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash",
@@ -31,7 +33,9 @@
       "context_window": 32768,
       "default_max_tokens": 3276,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMaxAI/MiniMax-M2.7",
@@ -44,7 +48,9 @@
       "context_window": 262100,
       "default_max_tokens": 6553,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash-0731",
@@ -57,7 +63,9 @@
       "context_window": 262100,
       "default_max_tokens": 6553,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V4-Pro",
@@ -70,7 +78,9 @@
       "context_window": 1048576,
       "default_max_tokens": 60000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "google/gemma-4-26b-a4b-it",
@@ -83,7 +93,9 @@
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Intel/Qwen3-Coder-480B-A35B-Instruct-int4-mixed-ar",
@@ -96,7 +108,9 @@
       "context_window": 106000,
       "default_max_tokens": 10600,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
@@ -109,7 +123,9 @@
       "context_window": 430000,
       "default_max_tokens": 43000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta-llama/Llama-3.3-70B-Instruct",
@@ -122,7 +138,9 @@
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMaxAI/MiniMax-M2.5",
@@ -135,7 +153,9 @@
       "context_window": 196600,
       "default_max_tokens": 19660,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K2-Instruct-0905",
@@ -148,7 +168,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K2-Thinking",
@@ -161,7 +183,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K2.5",
@@ -174,7 +198,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K2.6",
@@ -187,7 +213,9 @@
       "context_window": 262142,
       "default_max_tokens": 26214,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K2.7-Code",
@@ -200,7 +228,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K3",
@@ -213,7 +243,9 @@
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -232,7 +264,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-20b",
@@ -251,7 +285,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -264,7 +300,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3.6-27B",
@@ -277,7 +315,9 @@
       "context_window": 32768,
       "default_max_tokens": 3276,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3.6-35B-A3B",
@@ -290,7 +330,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3.8-27B",
@@ -303,7 +345,9 @@
       "context_window": 65536,
       "default_max_tokens": 6553,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "XiaomiMiMo/MiMo-V2.5",
@@ -316,7 +360,9 @@
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-4.6",
@@ -329,7 +375,9 @@
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-4.7",
@@ -342,7 +390,9 @@
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-4.7-Flash",
@@ -355,7 +405,9 @@
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5",
@@ -368,7 +420,9 @@
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.1",
@@ -381,7 +435,9 @@
       "context_window": 202750,
       "default_max_tokens": 3276,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.2",
@@ -394,7 +450,9 @@
       "context_window": 262144,
       "default_max_tokens": 13107,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.3",
@@ -407,7 +465,9 @@
       "context_window": 262144,
       "default_max_tokens": 13107,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.3-Flash",
@@ -420,7 +480,9 @@
       "context_window": 262144,
       "default_max_tokens": 13107,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-4.5-Air",
@@ -433,7 +495,9 @@
       "context_window": 131070,
       "default_max_tokens": 13107,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/ionet.json
+++ b/internal/providers/configs/ionet.json
@@ -10,10 +10,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V3.2",
       "name": "DeepSeek: DeepSeek V3.2",
-      "cost_per_1m_in": 1.4301,
-      "cost_per_1m_out": 2.4063,
-      "cost_per_1m_in_cached": 0.71505,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.4301,
+        "output": 2.4063,
+        "cache_create": 0.71505
+      },
       "context_window": 163840,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -22,10 +23,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash",
       "name": "DeepSeek: DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.199,
-      "cost_per_1m_out": 0.512,
-      "cost_per_1m_in_cached": 0.0995,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.199,
+        "output": 0.512,
+        "cache_create": 0.0995
+      },
       "context_window": 32768,
       "default_max_tokens": 3276,
       "can_reason": true,
@@ -34,10 +36,11 @@
     {
       "id": "MiniMaxAI/MiniMax-M2.7",
       "name": "DeepSeek: DeepSeek V4 Flash 0731",
-      "cost_per_1m_in": 0.426,
-      "cost_per_1m_out": 1.62,
-      "cost_per_1m_in_cached": 0.213,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.426,
+        "output": 1.62,
+        "cache_create": 0.213
+      },
       "context_window": 262100,
       "default_max_tokens": 6553,
       "can_reason": false,
@@ -46,10 +49,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash-0731",
       "name": "DeepSeek: DeepSeek V4 Flash 0731",
-      "cost_per_1m_in": 0.196,
-      "cost_per_1m_out": 0.534,
-      "cost_per_1m_in_cached": 0.098,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.196,
+        "output": 0.534,
+        "cache_create": 0.098
+      },
       "context_window": 262100,
       "default_max_tokens": 6553,
       "can_reason": true,
@@ -58,10 +62,11 @@
     {
       "id": "deepseek-ai/DeepSeek-V4-Pro",
       "name": "DeepSeek: DeepSeek V4 Pro",
-      "cost_per_1m_in": 1.618,
-      "cost_per_1m_out": 3.288,
-      "cost_per_1m_in_cached": 0.809,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.618,
+        "output": 3.288,
+        "cache_create": 0.809
+      },
       "context_window": 1048576,
       "default_max_tokens": 60000,
       "can_reason": true,
@@ -70,10 +75,11 @@
     {
       "id": "google/gemma-4-26b-a4b-it",
       "name": "Google: Gemma 4 26B A4B",
-      "cost_per_1m_in": 0.116,
-      "cost_per_1m_out": 0.38,
-      "cost_per_1m_in_cached": 0.058,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.116,
+        "output": 0.38,
+        "cache_create": 0.058
+      },
       "context_window": 256000,
       "default_max_tokens": 25600,
       "can_reason": true,
@@ -82,10 +88,11 @@
     {
       "id": "Intel/Qwen3-Coder-480B-A35B-Instruct-int4-mixed-ar",
       "name": "Intel: Qwen3 Coder 480B A35B Instruct INT4 Mixed AR",
-      "cost_per_1m_in": 0.445,
-      "cost_per_1m_out": 2.145,
-      "cost_per_1m_in_cached": 0.2225,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.445,
+        "output": 2.145,
+        "cache_create": 0.2225
+      },
       "context_window": 106000,
       "default_max_tokens": 10600,
       "can_reason": false,
@@ -94,10 +101,11 @@
     {
       "id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
       "name": "Meta-Llama: Llama 4 Maverick 17B 128E Instruct FP8",
-      "cost_per_1m_in": 0.274,
-      "cost_per_1m_out": 0.8992,
-      "cost_per_1m_in_cached": 0.137,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.274,
+        "output": 0.8992,
+        "cache_create": 0.137
+      },
       "context_window": 430000,
       "default_max_tokens": 43000,
       "can_reason": true,
@@ -106,10 +114,11 @@
     {
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "name": "Meta: Llama 3.3 70B Instruct",
-      "cost_per_1m_in": 0.6066,
-      "cost_per_1m_out": 1.0386,
-      "cost_per_1m_in_cached": 0.3033,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6066,
+        "output": 1.0386,
+        "cache_create": 0.3033
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -118,10 +127,11 @@
     {
       "id": "MiniMaxAI/MiniMax-M2.5",
       "name": "MiniMaxAI/MiniMax-M2.5",
-      "cost_per_1m_in": 0.294,
-      "cost_per_1m_out": 1.176,
-      "cost_per_1m_in_cached": 0.147,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.294,
+        "output": 1.176,
+        "cache_create": 0.147
+      },
       "context_window": 196600,
       "default_max_tokens": 19660,
       "can_reason": false,
@@ -130,10 +140,11 @@
     {
       "id": "moonshotai/Kimi-K2-Instruct-0905",
       "name": "MoonshotAI: Kimi K2 Instruct 0905",
-      "cost_per_1m_in": 0.57,
-      "cost_per_1m_out": 2.3,
-      "cost_per_1m_in_cached": 0.285,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.57,
+        "output": 2.3,
+        "cache_create": 0.285
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -142,10 +153,11 @@
     {
       "id": "moonshotai/Kimi-K2-Thinking",
       "name": "MoonshotAI: Kimi K2 Thinking",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.5,
+        "cache_create": 0.3
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -154,10 +166,11 @@
     {
       "id": "moonshotai/Kimi-K2.5",
       "name": "MoonshotAI: Kimi K2.5",
-      "cost_per_1m_in": 0.5284,
-      "cost_per_1m_out": 2.785,
-      "cost_per_1m_in_cached": 0.2642,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5284,
+        "output": 2.785,
+        "cache_create": 0.2642
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -166,10 +179,11 @@
     {
       "id": "moonshotai/Kimi-K2.6",
       "name": "MoonshotAI: Kimi K2.6",
-      "cost_per_1m_in": 0.76744,
-      "cost_per_1m_out": 3.43436,
-      "cost_per_1m_in_cached": 0.38372,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.76744,
+        "output": 3.43436,
+        "cache_create": 0.38372
+      },
       "context_window": 262142,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -178,10 +192,11 @@
     {
       "id": "moonshotai/Kimi-K2.7-Code",
       "name": "MoonshotAI: Kimi K2.7 Code",
-      "cost_per_1m_in": 1.026,
-      "cost_per_1m_out": 4.53,
-      "cost_per_1m_in_cached": 0.513,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.026,
+        "output": 4.53,
+        "cache_create": 0.513
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -190,10 +205,11 @@
     {
       "id": "moonshotai/Kimi-K3",
       "name": "MoonshotAI: Kimi K3",
-      "cost_per_1m_in": 3.18,
-      "cost_per_1m_out": 15.9,
-      "cost_per_1m_in_cached": 1.59,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.18,
+        "output": 15.9,
+        "cache_create": 1.59
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -202,10 +218,11 @@
     {
       "id": "openai/gpt-oss-120b",
       "name": "OpenAI: gpt-oss-120b",
-      "cost_per_1m_in": 0.188,
-      "cost_per_1m_out": 0.7,
-      "cost_per_1m_in_cached": 0.094,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.188,
+        "output": 0.7,
+        "cache_create": 0.094
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": true,
@@ -220,10 +237,11 @@
     {
       "id": "openai/gpt-oss-20b",
       "name": "OpenAI: gpt-oss-20b",
-      "cost_per_1m_in": 0.067,
-      "cost_per_1m_out": 0.24,
-      "cost_per_1m_in_cached": 0.0335,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.067,
+        "output": 0.24,
+        "cache_create": 0.0335
+      },
       "context_window": 64000,
       "default_max_tokens": 6400,
       "can_reason": true,
@@ -238,10 +256,11 @@
     {
       "id": "Qwen/Qwen3-Next-80B-A3B-Instruct",
       "name": "Qwen: Qwen3 Next 80B A3B Instruct",
-      "cost_per_1m_in": 0.1175,
-      "cost_per_1m_out": 1.136,
-      "cost_per_1m_in_cached": 0.05875,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1175,
+        "output": 1.136,
+        "cache_create": 0.05875
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -250,10 +269,11 @@
     {
       "id": "Qwen/Qwen3.6-27B",
       "name": "Qwen: Qwen3.6 27B",
-      "cost_per_1m_in": 0.399,
-      "cost_per_1m_out": 3.19,
-      "cost_per_1m_in_cached": 0.1995,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.399,
+        "output": 3.19,
+        "cache_create": 0.1995
+      },
       "context_window": 32768,
       "default_max_tokens": 3276,
       "can_reason": false,
@@ -262,10 +282,11 @@
     {
       "id": "Qwen/Qwen3.6-35B-A3B",
       "name": "Qwen: Qwen3.6 35B A3B",
-      "cost_per_1m_in": 0.1872,
-      "cost_per_1m_out": 1.24675,
-      "cost_per_1m_in_cached": 0.0936,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1872,
+        "output": 1.24675,
+        "cache_create": 0.0936
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -274,10 +295,11 @@
     {
       "id": "Qwen/Qwen3.8-27B",
       "name": "Qwen: Qwen3.8 27B",
-      "cost_per_1m_in": 0.39,
-      "cost_per_1m_out": 2.99,
-      "cost_per_1m_in_cached": 0.195,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.39,
+        "output": 2.99,
+        "cache_create": 0.195
+      },
       "context_window": 65536,
       "default_max_tokens": 6553,
       "can_reason": false,
@@ -286,10 +308,11 @@
     {
       "id": "XiaomiMiMo/MiMo-V2.5",
       "name": "Xiaomi: MiMo-V2.5",
-      "cost_per_1m_in": 0.1934,
-      "cost_per_1m_out": 0.6268,
-      "cost_per_1m_in_cached": 0.0967,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1934,
+        "output": 0.6268,
+        "cache_create": 0.0967
+      },
       "context_window": 1048576,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -298,10 +321,11 @@
     {
       "id": "zai-org/GLM-4.6",
       "name": "Z.ai: GLM 4.6",
-      "cost_per_1m_in": 0.536,
-      "cost_per_1m_out": 2.07,
-      "cost_per_1m_in_cached": 0.268,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.536,
+        "output": 2.07,
+        "cache_create": 0.268
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": true,
@@ -310,10 +334,11 @@
     {
       "id": "zai-org/GLM-4.7",
       "name": "Z.ai: GLM 4.7",
-      "cost_per_1m_in": 0.88,
-      "cost_per_1m_out": 2.37,
-      "cost_per_1m_in_cached": 0.44,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.88,
+        "output": 2.37,
+        "cache_create": 0.44
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
@@ -322,10 +347,11 @@
     {
       "id": "zai-org/GLM-4.7-Flash",
       "name": "Z.ai: GLM 4.7 Flash",
-      "cost_per_1m_in": 0.06263,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.03131,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.06263,
+        "output": 0.4,
+        "cache_create": 0.03131
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": true,
@@ -334,10 +360,11 @@
     {
       "id": "zai-org/GLM-5",
       "name": "Z.ai: GLM 5",
-      "cost_per_1m_in": 0.85,
-      "cost_per_1m_out": 2.774,
-      "cost_per_1m_in_cached": 0.425,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.85,
+        "output": 2.774,
+        "cache_create": 0.425
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
@@ -346,10 +373,11 @@
     {
       "id": "zai-org/GLM-5.1",
       "name": "Z.ai: GLM 5.1",
-      "cost_per_1m_in": 1.29,
-      "cost_per_1m_out": 4.22,
-      "cost_per_1m_in_cached": 0.645,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.29,
+        "output": 4.22,
+        "cache_create": 0.645
+      },
       "context_window": 202750,
       "default_max_tokens": 3276,
       "can_reason": true,
@@ -358,10 +386,11 @@
     {
       "id": "zai-org/GLM-5.2",
       "name": "Z.ai: GLM 5.2",
-      "cost_per_1m_in": 1.552,
-      "cost_per_1m_out": 4.884,
-      "cost_per_1m_in_cached": 0.776,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.552,
+        "output": 4.884,
+        "cache_create": 0.776
+      },
       "context_window": 262144,
       "default_max_tokens": 13107,
       "can_reason": true,
@@ -370,10 +399,11 @@
     {
       "id": "zai-org/GLM-5.3",
       "name": "Z.ai: GLM 5.3",
-      "cost_per_1m_in": 1.39,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0.695,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.39,
+        "output": 4.4,
+        "cache_create": 0.695
+      },
       "context_window": 262144,
       "default_max_tokens": 13107,
       "can_reason": true,
@@ -382,10 +412,11 @@
     {
       "id": "zai-org/GLM-5.3-Flash",
       "name": "Z.ai: GLM 5.3 Flash",
-      "cost_per_1m_in": 0.148,
-      "cost_per_1m_out": 0.49399,
-      "cost_per_1m_in_cached": 0.074,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.148,
+        "output": 0.49399,
+        "cache_create": 0.074
+      },
       "context_window": 262144,
       "default_max_tokens": 13107,
       "can_reason": true,
@@ -394,10 +425,11 @@
     {
       "id": "zai-org/GLM-4.5-Air",
       "name": "Z.ai: GLM-4.5-Air",
-      "cost_per_1m_in": 0.165,
-      "cost_per_1m_out": 0.975,
-      "cost_per_1m_in_cached": 0.0825,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.165,
+        "output": 0.975,
+        "cache_create": 0.0825
+      },
       "context_window": 131070,
       "default_max_tokens": 13107,
       "can_reason": true,

--- a/internal/providers/configs/kimi.json
+++ b/internal/providers/configs/kimi.json
@@ -10,10 +10,10 @@
     {
       "id": "k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -22,10 +22,10 @@
     {
       "id": "k3-256k",
       "name": "Kimi K3 256K",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -34,10 +34,10 @@
     {
       "id": "kimi-for-coding",
       "name": "Kimi for Coding",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -46,10 +46,10 @@
     {
       "id": "kimi-for-coding-highspeed",
       "name": "Kimi for Coding Highspeed",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,

--- a/internal/providers/configs/kimi.json
+++ b/internal/providers/configs/kimi.json
@@ -17,7 +17,9 @@
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "k3-256k",
@@ -29,7 +31,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-for-coding",
@@ -41,7 +45,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-for-coding-highspeed",
@@ -53,7 +59,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/minimax-china.json
+++ b/internal/providers/configs/minimax-china.json
@@ -10,80 +10,96 @@
     {
       "id": "MiniMax-M3",
       "name": "MiniMax-M3",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.12,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_create": 0.12,
+        "cache_hit": 0.375
+      },
       "context_window": 1000000,
       "default_max_tokens": 512000
     },
     {
       "id": "MiniMax-M2.7-highspeed",
       "name": "MiniMax-M2.7-highspeed",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.06,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_create": 0.06,
+        "cache_hit": 0.375
+      },
       "context_window": 204800,
       "default_max_tokens": 131072
     },
     {
       "id": "MiniMax-M2.7",
       "name": "MiniMax-M2.7",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.06,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.06,
+        "cache_hit": 0.375
+      },
       "context_window": 204800,
       "default_max_tokens": 131072
     },
     {
       "id": "MiniMax-M2.5-highspeed",
       "name": "MiniMax-M2.5-highspeed",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_create": 0.03,
+        "cache_hit": 0.375
+      },
       "context_window": 204800,
       "default_max_tokens": 131072
     },
     {
       "id": "MiniMax-M2.5",
       "name": "MiniMax-M2.5",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.03,
+        "cache_hit": 0.375
+      },
       "context_window": 204800,
       "default_max_tokens": 131072
     },
     {
       "id": "MiniMax-M2.1-highspeed",
       "name": "MiniMax-M2.1-highspeed",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_create": 0.03,
+        "cache_hit": 0.375
+      },
       "context_window": 204800,
       "default_max_tokens": 131072
     },
     {
       "id": "MiniMax-M2.1",
       "name": "MiniMax-M2.1",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.03,
+        "cache_hit": 0.375
+      },
       "context_window": 204800,
       "default_max_tokens": 131072
     },
     {
       "id": "MiniMax-M2",
       "name": "MiniMax-M2",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.03,
+        "cache_hit": 0.375
+      },
       "context_window": 196608,
       "default_max_tokens": 128000
     }

--- a/internal/providers/configs/minimax-china.json
+++ b/internal/providers/configs/minimax-china.json
@@ -17,7 +17,10 @@
         "cache_hit": 0.375
       },
       "context_window": 1000000,
-      "default_max_tokens": 512000
+      "default_max_tokens": 512000,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.7-highspeed",
@@ -29,7 +32,10 @@
         "cache_hit": 0.375
       },
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.7",
@@ -41,7 +47,10 @@
         "cache_hit": 0.375
       },
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.5-highspeed",
@@ -53,7 +62,10 @@
         "cache_hit": 0.375
       },
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.5",
@@ -65,7 +77,10 @@
         "cache_hit": 0.375
       },
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.1-highspeed",
@@ -77,7 +92,10 @@
         "cache_hit": 0.375
       },
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.1",
@@ -89,7 +107,10 @@
         "cache_hit": 0.375
       },
       "context_window": 204800,
-      "default_max_tokens": 131072
+      "default_max_tokens": 131072,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2",
@@ -101,7 +122,10 @@
         "cache_hit": 0.375
       },
       "context_window": 196608,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/minimax.json
+++ b/internal/providers/configs/minimax.json
@@ -10,80 +10,96 @@
     {
       "id": "MiniMax-M3",
       "name": "MiniMax-M3",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.12,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_create": 0.12,
+        "cache_hit": 0.375
+      },
       "context_window": 1000000,
       "default_max_tokens": 512000
     },
     {
       "id": "MiniMax-M2.7-highspeed",
       "name": "MiniMax-M2.7-highspeed",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.06,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_create": 0.06,
+        "cache_hit": 0.375
+      },
       "context_window": 200000,
       "default_max_tokens": 128000
     },
     {
       "id": "MiniMax-M2.7",
       "name": "MiniMax-M2.7",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.06,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.06,
+        "cache_hit": 0.375
+      },
       "context_window": 200000,
       "default_max_tokens": 128000
     },
     {
       "id": "MiniMax-M2.5-highspeed",
       "name": "MiniMax-M2.5-highspeed",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_create": 0.03,
+        "cache_hit": 0.375
+      },
       "context_window": 200000,
       "default_max_tokens": 128000
     },
     {
       "id": "MiniMax-M2.5",
       "name": "MiniMax-M2.5",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.03,
+        "cache_hit": 0.375
+      },
       "context_window": 200000,
       "default_max_tokens": 128000
     },
     {
       "id": "MiniMax-M2.1-highspeed",
       "name": "MiniMax-M2.1-highspeed",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_create": 0.03,
+        "cache_hit": 0.375
+      },
       "context_window": 200000,
       "default_max_tokens": 128000
     },
     {
       "id": "MiniMax-M2.1",
       "name": "MiniMax-M2.1",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.03,
+        "cache_hit": 0.375
+      },
       "context_window": 200000,
       "default_max_tokens": 128000
     },
     {
       "id": "MiniMax-M2",
       "name": "MiniMax-M2",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0.375,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.03,
+        "cache_hit": 0.375
+      },
       "context_window": 200000,
       "default_max_tokens": 20000
     }

--- a/internal/providers/configs/minimax.json
+++ b/internal/providers/configs/minimax.json
@@ -17,7 +17,10 @@
         "cache_hit": 0.375
       },
       "context_window": 1000000,
-      "default_max_tokens": 512000
+      "default_max_tokens": 512000,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.7-highspeed",
@@ -29,7 +32,10 @@
         "cache_hit": 0.375
       },
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.7",
@@ -41,7 +47,10 @@
         "cache_hit": 0.375
       },
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.5-highspeed",
@@ -53,7 +62,10 @@
         "cache_hit": 0.375
       },
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.5",
@@ -65,7 +77,10 @@
         "cache_hit": 0.375
       },
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.1-highspeed",
@@ -77,7 +92,10 @@
         "cache_hit": 0.375
       },
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2.1",
@@ -89,7 +107,10 @@
         "cache_hit": 0.375
       },
       "context_window": 200000,
-      "default_max_tokens": 128000
+      "default_max_tokens": 128000,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMax-M2",
@@ -101,7 +122,10 @@
         "cache_hit": 0.375
       },
       "context_window": 200000,
-      "default_max_tokens": 20000
+      "default_max_tokens": 20000,
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/moonshot.json
+++ b/internal/providers/configs/moonshot.json
@@ -18,7 +18,9 @@
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code",
@@ -31,7 +33,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code-highspeed",
@@ -44,7 +48,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.6",
@@ -57,7 +63,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.5",
@@ -70,7 +78,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshot-v1-8k",
@@ -82,7 +92,9 @@
       "context_window": 8192,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshot-v1-32k",
@@ -94,7 +106,9 @@
       "context_window": 32768,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshot-v1-128k",
@@ -106,7 +120,9 @@
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshot-v1-8k-vision-preview",
@@ -118,7 +134,9 @@
       "context_window": 8192,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshot-v1-32k-vision-preview",
@@ -130,7 +148,9 @@
       "context_window": 32768,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshot-v1-128k-vision-preview",
@@ -142,7 +162,9 @@
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/moonshot.json
+++ b/internal/providers/configs/moonshot.json
@@ -10,10 +10,11 @@
     {
       "id": "kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.30,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.3
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -22,10 +23,11 @@
     {
       "id": "kimi-k2.7-code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4.0,
-      "cost_per_1m_in_cached": 0.19,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_create": 0.19
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -34,10 +36,11 @@
     {
       "id": "kimi-k2.7-code-highspeed",
       "name": "Kimi K2.7 Code High Speed",
-      "cost_per_1m_in": 1.90,
-      "cost_per_1m_out": 8.0,
-      "cost_per_1m_in_cached": 0.38,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.9,
+        "output": 8,
+        "cache_create": 0.38
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -46,10 +49,11 @@
     {
       "id": "kimi-k2.6",
       "name": "Kimi K2.6",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4.0,
-      "cost_per_1m_in_cached": 0.16,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_create": 0.16
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -58,10 +62,11 @@
     {
       "id": "kimi-k2.5",
       "name": "Kimi K2.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3.0,
-      "cost_per_1m_in_cached": 0.1,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 3,
+        "cache_create": 0.1
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -70,10 +75,10 @@
     {
       "id": "moonshot-v1-8k",
       "name": "Moonshot V1 8K",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 2.0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 2
+      },
       "context_window": 8192,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -82,10 +87,10 @@
     {
       "id": "moonshot-v1-32k",
       "name": "Moonshot V1 32K",
-      "cost_per_1m_in": 1.0,
-      "cost_per_1m_out": 3.0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 3
+      },
       "context_window": 32768,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -94,10 +99,10 @@
     {
       "id": "moonshot-v1-128k",
       "name": "Moonshot V1 128K",
-      "cost_per_1m_in": 2.0,
-      "cost_per_1m_out": 5.0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 5
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -106,10 +111,10 @@
     {
       "id": "moonshot-v1-8k-vision-preview",
       "name": "Moonshot V1 8K Vision Preview",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 2.0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 2
+      },
       "context_window": 8192,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -118,10 +123,10 @@
     {
       "id": "moonshot-v1-32k-vision-preview",
       "name": "Moonshot V1 32K Vision Preview",
-      "cost_per_1m_in": 1.0,
-      "cost_per_1m_out": 3.0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 3
+      },
       "context_window": 32768,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -130,10 +135,10 @@
     {
       "id": "moonshot-v1-128k-vision-preview",
       "name": "Moonshot V1 128K Vision Preview",
-      "cost_per_1m_in": 2.0,
-      "cost_per_1m_out": 5.0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 5
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": false,

--- a/internal/providers/configs/nebius.json
+++ b/internal/providers/configs/nebius.json
@@ -10,10 +10,10 @@
     {
       "id": "deepseek-ai/DeepSeek-V3.2",
       "name": "DeepSeek-V3.2",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.45,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.45
+      },
       "context_window": 163000,
       "default_max_tokens": 16300,
       "can_reason": true,
@@ -28,10 +28,10 @@
     {
       "id": "deepseek-ai/DeepSeek-V3.2-fast",
       "name": "DeepSeek-V3.2 (fast)",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 2
+      },
       "context_window": 8000,
       "default_max_tokens": 800,
       "can_reason": true,
@@ -46,10 +46,10 @@
     {
       "id": "zai-org/GLM-5",
       "name": "GLM-5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 3.2
+      },
       "context_window": 202752,
       "default_max_tokens": 20275,
       "can_reason": true,
@@ -64,10 +64,10 @@
     {
       "id": "NousResearch/Hermes-4-405B",
       "name": "Hermes-4-405B",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 3
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": true,
@@ -82,10 +82,10 @@
     {
       "id": "NousResearch/Hermes-4-70B",
       "name": "Hermes-4-70B",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.13,
+        "output": 0.4
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": true,
@@ -100,10 +100,10 @@
     {
       "id": "PrimeIntellect/INTELLECT-3",
       "name": "INTELLECT-3",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.1
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": true,
@@ -118,10 +118,10 @@
     {
       "id": "moonshotai/Kimi-K2.5",
       "name": "Kimi-K2.5",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 2.5
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -136,10 +136,10 @@
     {
       "id": "moonshotai/Kimi-K2.5-fast",
       "name": "Kimi-K2.5 (fast)",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 2.5
+      },
       "context_window": 8000,
       "default_max_tokens": 800,
       "can_reason": true,
@@ -154,10 +154,10 @@
     {
       "id": "meta-llama/Llama-3.3-70B-Instruct",
       "name": "Llama-3.3-70B-Instruct",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.13,
+        "output": 0.4
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
@@ -166,10 +166,10 @@
     {
       "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
       "name": "Meta-Llama-3.1-8B-Instruct",
-      "cost_per_1m_in": 0.02,
-      "cost_per_1m_out": 0.06,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.02,
+        "output": 0.06
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
@@ -178,10 +178,10 @@
     {
       "id": "MiniMaxAI/MiniMax-M2.5",
       "name": "MiniMax-M2.5",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2
+      },
       "context_window": 196608,
       "default_max_tokens": 19660,
       "can_reason": true,
@@ -196,10 +196,10 @@
     {
       "id": "MiniMaxAI/MiniMax-M2.5-fast",
       "name": "MiniMax-M2.5 (fast)",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2
+      },
       "context_window": 8000,
       "default_max_tokens": 800,
       "can_reason": true,
@@ -214,10 +214,10 @@
     {
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
       "name": "Nemotron-3-Nano-30B-A3B",
-      "cost_per_1m_in": 0.06,
-      "cost_per_1m_out": 0.24,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.06,
+        "output": 0.24
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -232,10 +232,10 @@
     {
       "id": "nvidia/nemotron-3-super-120b-a12b",
       "name": "Nemotron-3-Super-120b-a12b",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.9
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -250,10 +250,10 @@
     {
       "id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
       "name": "Qwen3-235B-A22B-Instruct-2507",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.6
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -262,10 +262,10 @@
     {
       "id": "Qwen/Qwen3-235B-A22B-Thinking-2507-fast",
       "name": "Qwen3-235B-A22B-Thinking-2507 (fast)",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 2
+      },
       "context_window": 8000,
       "default_max_tokens": 800,
       "can_reason": true,
@@ -280,10 +280,10 @@
     {
       "id": "Qwen/Qwen3-30B-A3B-Instruct-2507",
       "name": "Qwen3-30B-A3B-Instruct-2507",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.3
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -292,10 +292,10 @@
     {
       "id": "Qwen/Qwen3-32B",
       "name": "Qwen3-32B",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.3
+      },
       "context_window": 40960,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -310,10 +310,10 @@
     {
       "id": "Qwen/Qwen3-Next-80B-A3B-Thinking",
       "name": "Qwen3-Next-80B-A3B-Thinking",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 1.2
+      },
       "context_window": 128000,
       "default_max_tokens": 12800,
       "can_reason": true,
@@ -328,10 +328,10 @@
     {
       "id": "Qwen/Qwen3-Next-80B-A3B-Thinking-fast",
       "name": "Qwen3-Next-80B-A3B-Thinking (fast)",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 1.2
+      },
       "context_window": 8000,
       "default_max_tokens": 800,
       "can_reason": true,
@@ -346,10 +346,10 @@
     {
       "id": "Qwen/Qwen3.5-397B-A17B",
       "name": "Qwen3.5-397B-A17B",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 3.6
+      },
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": true,
@@ -364,10 +364,10 @@
     {
       "id": "Qwen/Qwen3.5-397B-A17B-fast",
       "name": "Qwen3.5-397B-A17B (fast)",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 3.6
+      },
       "context_window": 8000,
       "default_max_tokens": 800,
       "can_reason": true,
@@ -382,10 +382,10 @@
     {
       "id": "openai/gpt-oss-120b",
       "name": "gpt-oss-120b",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": true,
@@ -400,10 +400,10 @@
     {
       "id": "openai/gpt-oss-120b-fast",
       "name": "gpt-oss-120b (fast)",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.5
+      },
       "context_window": 8000,
       "default_max_tokens": 800,
       "can_reason": true,

--- a/internal/providers/configs/nebius.json
+++ b/internal/providers/configs/nebius.json
@@ -23,7 +23,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V3.2-fast",
@@ -41,7 +43,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5",
@@ -59,7 +63,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "NousResearch/Hermes-4-405B",
@@ -77,7 +83,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "NousResearch/Hermes-4-70B",
@@ -95,7 +103,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "PrimeIntellect/INTELLECT-3",
@@ -113,7 +123,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K2.5",
@@ -131,7 +143,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K2.5-fast",
@@ -149,7 +163,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta-llama/Llama-3.3-70B-Instruct",
@@ -161,7 +177,9 @@
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
@@ -173,7 +191,9 @@
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMaxAI/MiniMax-M2.5",
@@ -191,7 +211,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "MiniMaxAI/MiniMax-M2.5-fast",
@@ -209,7 +231,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
@@ -227,7 +251,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/nemotron-3-super-120b-a12b",
@@ -245,7 +271,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
@@ -257,7 +285,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3-235B-A22B-Thinking-2507-fast",
@@ -275,7 +305,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3-30B-A3B-Instruct-2507",
@@ -287,7 +319,9 @@
       "context_window": 262144,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3-32B",
@@ -305,7 +339,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3-Next-80B-A3B-Thinking",
@@ -323,7 +359,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3-Next-80B-A3B-Thinking-fast",
@@ -341,7 +379,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3.5-397B-A17B",
@@ -359,7 +399,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "Qwen/Qwen3.5-397B-A17B-fast",
@@ -377,7 +419,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -395,7 +439,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-120b-fast",
@@ -413,7 +459,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/neuralwatt.json
+++ b/internal/providers/configs/neuralwatt.json
@@ -10,10 +10,11 @@
     {
       "id": "deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0.028,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_create": 0.028
+      },
       "context_window": 1048560,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -28,10 +29,11 @@
     {
       "id": "deepseek-v4-flash-flex",
       "name": "DeepSeek V4 Flash (flex)",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0.028,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_create": 0.028
+      },
       "context_window": 1048560,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -46,10 +48,11 @@
     {
       "id": "glm-5.3",
       "name": "GLM 5.3",
-      "cost_per_1m_in": 1.45,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0.145,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.45,
+        "output": 4.5,
+        "cache_create": 0.145
+      },
       "context_window": 1048560,
       "default_max_tokens": 104856,
       "can_reason": true,
@@ -64,10 +67,11 @@
     {
       "id": "glm-5.2",
       "name": "GLM-5.2",
-      "cost_per_1m_in": 1.45,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0.145,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.45,
+        "output": 4.5,
+        "cache_create": 0.145
+      },
       "context_window": 1048560,
       "default_max_tokens": 104856,
       "can_reason": true,
@@ -82,10 +86,11 @@
     {
       "id": "glm-5.2-fast",
       "name": "GLM-5.2 (fast)",
-      "cost_per_1m_in": 1.45,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0.145,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.45,
+        "output": 4.5,
+        "cache_create": 0.145
+      },
       "context_window": 1048560,
       "default_max_tokens": 104856,
       "can_reason": true,
@@ -100,10 +105,11 @@
     {
       "id": "glm-5.2-flex",
       "name": "GLM-5.2 (flex)",
-      "cost_per_1m_in": 1.45,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0.145,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.45,
+        "output": 4.5,
+        "cache_create": 0.145
+      },
       "context_window": 1048560,
       "default_max_tokens": 104856,
       "can_reason": true,
@@ -118,10 +124,11 @@
     {
       "id": "glm-5.2-short",
       "name": "GLM-5.2 (short)",
-      "cost_per_1m_in": 1.45,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0.145,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.45,
+        "output": 4.5,
+        "cache_create": 0.145
+      },
       "context_window": 199984,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -136,10 +143,11 @@
     {
       "id": "glm-5.2-short-fast",
       "name": "GLM-5.2 (short, fast)",
-      "cost_per_1m_in": 1.45,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0.145,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.45,
+        "output": 4.5,
+        "cache_create": 0.145
+      },
       "context_window": 199984,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -154,10 +162,11 @@
     {
       "id": "glm-5.2-short-fast-flex",
       "name": "GLM-5.2 (short, fast, flex)",
-      "cost_per_1m_in": 1.45,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0.145,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.45,
+        "output": 4.5,
+        "cache_create": 0.145
+      },
       "context_window": 199984,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -172,10 +181,11 @@
     {
       "id": "glm-5.2-short-flex",
       "name": "GLM-5.2 (short, flex)",
-      "cost_per_1m_in": 1.45,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0.145,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.45,
+        "output": 4.5,
+        "cache_create": 0.145
+      },
       "context_window": 199984,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -190,10 +200,11 @@
     {
       "id": "gemma-4-31b",
       "name": "Gemma 4 31B",
-      "cost_per_1m_in": 0.144,
-      "cost_per_1m_out": 0.42,
-      "cost_per_1m_in_cached": 0.0144,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.144,
+        "output": 0.42,
+        "cache_create": 0.0144
+      },
       "context_window": 262128,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -208,10 +219,11 @@
     {
       "id": "kimi-k2.7-code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0.095,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_create": 0.095
+      },
       "context_window": 262128,
       "default_max_tokens": 26212,
       "can_reason": true,
@@ -220,10 +232,11 @@
     {
       "id": "kimi-k2.7-code-flex",
       "name": "Kimi K2.7 Code (flex)",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0.095,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_create": 0.095
+      },
       "context_window": 262128,
       "default_max_tokens": 26212,
       "can_reason": true,
@@ -232,10 +245,11 @@
     {
       "id": "kimi-k2.7-code-fast",
       "name": "Kimi K2.7 Code Fast",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0.095,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_create": 0.095
+      },
       "context_window": 262128,
       "default_max_tokens": 26212,
       "can_reason": true,
@@ -244,10 +258,11 @@
     {
       "id": "kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.3
+      },
       "context_window": 1048560,
       "default_max_tokens": 104856,
       "can_reason": true,
@@ -262,10 +277,11 @@
     {
       "id": "kimi-k3-flex",
       "name": "Kimi K3 (flex)",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.3
+      },
       "context_window": 1048560,
       "default_max_tokens": 104856,
       "can_reason": true,
@@ -280,10 +296,11 @@
     {
       "id": "kimi-k3-fast",
       "name": "Kimi K3 Fast",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.3
+      },
       "context_window": 1048560,
       "default_max_tokens": 104856,
       "can_reason": false,
@@ -292,10 +309,11 @@
     {
       "id": "qwen3.6-35b",
       "name": "Qwen3.6 35B",
-      "cost_per_1m_in": 0.29,
-      "cost_per_1m_out": 1.15,
-      "cost_per_1m_in_cached": 0.029,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.29,
+        "output": 1.15,
+        "cache_create": 0.029
+      },
       "context_window": 131056,
       "default_max_tokens": 13105,
       "can_reason": true,
@@ -310,10 +328,11 @@
     {
       "id": "qwen3.6-35b-fast",
       "name": "Qwen3.6 35B Fast",
-      "cost_per_1m_in": 0.29,
-      "cost_per_1m_out": 1.15,
-      "cost_per_1m_in_cached": 0.029,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.29,
+        "output": 1.15,
+        "cache_create": 0.029
+      },
       "context_window": 131056,
       "default_max_tokens": 13105,
       "can_reason": false,

--- a/internal/providers/configs/neuralwatt.json
+++ b/internal/providers/configs/neuralwatt.json
@@ -24,7 +24,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash-flex",
@@ -43,7 +45,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.3",
@@ -62,7 +66,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2",
@@ -81,7 +87,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2-fast",
@@ -100,7 +108,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2-flex",
@@ -119,7 +129,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2-short",
@@ -138,7 +150,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2-short-fast",
@@ -157,7 +171,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2-short-fast-flex",
@@ -176,7 +192,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2-short-flex",
@@ -195,7 +213,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gemma-4-31b",
@@ -214,7 +234,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code",
@@ -227,7 +249,9 @@
       "context_window": 262128,
       "default_max_tokens": 26212,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code-flex",
@@ -240,7 +264,9 @@
       "context_window": 262128,
       "default_max_tokens": 26212,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code-fast",
@@ -253,7 +279,9 @@
       "context_window": 262128,
       "default_max_tokens": 26212,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k3",
@@ -272,7 +300,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k3-flex",
@@ -291,7 +321,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k3-fast",
@@ -304,7 +336,9 @@
       "context_window": 1048560,
       "default_max_tokens": 104856,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-35b",
@@ -323,7 +357,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-35b-fast",
@@ -336,7 +372,9 @@
       "context_window": 131056,
       "default_max_tokens": 13105,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/openai.json
+++ b/internal/providers/configs/openai.json
@@ -10,10 +10,12 @@
     {
       "id": "gpt-5.6-sol",
       "name": "GPT-5.6 Sol",
-      "cost_per_1m_in": 4,
-      "cost_per_1m_out": 20,
-      "cost_per_1m_in_cached": 5,
-      "cost_per_1m_out_cached": 0.4,
+      "pricing": {
+        "input": 4,
+        "output": 20,
+        "cache_create": 5,
+        "cache_hit": 0.4
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -24,10 +26,12 @@
     {
       "id": "gpt-5.6-terra",
       "name": "GPT-5.6 Terra",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -38,10 +42,12 @@
     {
       "id": "gpt-5.6-luna",
       "name": "GPT-5.6 Luna",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.25,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.2,
+        "cache_create": 0.25,
+        "cache_hit": 0.02
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -52,10 +58,11 @@
     {
       "id": "gpt-5.5",
       "name": "GPT-5.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 30,
+        "cache_hit": 0.5
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -66,10 +73,10 @@
     {
       "id": "gpt-5.5-pro",
       "name": "GPT-5.5 Pro",
-      "cost_per_1m_in": 30,
-      "cost_per_1m_out": 180,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 30,
+        "output": 180
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -80,10 +87,11 @@
     {
       "id": "gpt-5.4",
       "name": "GPT-5.4",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 15,
+        "cache_hit": 0.25
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -94,10 +102,10 @@
     {
       "id": "gpt-5.4-pro",
       "name": "GPT-5.4 Pro",
-      "cost_per_1m_in": 30,
-      "cost_per_1m_out": 180,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 30,
+        "output": 180
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -108,10 +116,11 @@
     {
       "id": "gpt-5.4-mini",
       "name": "GPT-5.4 Mini",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.75,
+        "output": 4.5,
+        "cache_hit": 0.075
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -122,10 +131,11 @@
     {
       "id": "gpt-5.4-nano",
       "name": "GPT-5.4 Nano",
-      "cost_per_1m_in": 0.20,
-      "cost_per_1m_out": 1.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.25,
+        "cache_hit": 0.02
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -136,10 +146,12 @@
     {
       "id": "gpt-5.3-codex",
       "name": "GPT-5.3 Codex",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0.175,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_create": 0.175,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -150,10 +162,12 @@
     {
       "id": "gpt-5.2",
       "name": "GPT-5.2",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0.175,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_create": 0.175,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -164,10 +178,12 @@
     {
       "id": "gpt-5.2-codex",
       "name": "GPT-5.2 Codex",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0.175,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_create": 0.175,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -178,10 +194,12 @@
     {
       "id": "gpt-5.1",
       "name": "GPT-5.1",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0.125,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_create": 0.125,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -192,10 +210,12 @@
     {
       "id": "gpt-5.1-codex",
       "name": "GPT-5.1 Codex",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0.125,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_create": 0.125,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -206,10 +226,12 @@
     {
       "id": "gpt-5.1-codex-max",
       "name": "GPT-5.1 Codex Max",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0.125,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_create": 0.125,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -220,10 +242,12 @@
     {
       "id": "gpt-5.1-codex-mini",
       "name": "GPT-5.1 Codex Mini",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0.025,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_create": 0.025,
+        "cache_hit": 0.025
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -234,10 +258,12 @@
     {
       "id": "gpt-5-codex",
       "name": "GPT-5 Codex",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0.125,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_create": 0.125,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -248,10 +274,12 @@
     {
       "id": "gpt-5",
       "name": "GPT-5",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0.125,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_create": 0.125,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -262,10 +290,12 @@
     {
       "id": "gpt-5-mini",
       "name": "GPT-5 Mini",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0.025,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_create": 0.025,
+        "cache_hit": 0.025
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -276,10 +306,12 @@
     {
       "id": "gpt-5-nano",
       "name": "GPT-5 Nano",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.005,
-      "cost_per_1m_out_cached": 0.005,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.4,
+        "cache_create": 0.005,
+        "cache_hit": 0.005
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -290,10 +322,11 @@
     {
       "id": "o4-mini",
       "name": "o4 Mini",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.275,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.275
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -304,10 +337,11 @@
     {
       "id": "o3",
       "name": "o3",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -318,10 +352,11 @@
     {
       "id": "gpt-4.1",
       "name": "GPT-4.1",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 1047576,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -330,10 +365,11 @@
     {
       "id": "gpt-4.1-mini",
       "name": "GPT-4.1 Mini",
-      "cost_per_1m_in": 0.39999999999999997,
-      "cost_per_1m_out": 1.5999999999999999,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.09999999999999999,
+      "pricing": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_hit": 0.1
+      },
       "context_window": 1047576,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -342,10 +378,11 @@
     {
       "id": "gpt-4.1-nano",
       "name": "GPT-4.1 Nano",
-      "cost_per_1m_in": 0.09999999999999999,
-      "cost_per_1m_out": 0.39999999999999997,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.024999999999999998,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_hit": 0.025
+      },
       "context_window": 1047576,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -354,10 +391,11 @@
     {
       "id": "o3-mini",
       "name": "o3 Mini",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.55
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -368,10 +406,11 @@
     {
       "id": "gpt-4o",
       "name": "GPT-4o",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 10,
+        "cache_hit": 1.25
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -380,10 +419,11 @@
     {
       "id": "gpt-4o-mini",
       "name": "GPT-4o-mini",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.075
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,

--- a/internal/providers/configs/openai.json
+++ b/internal/providers/configs/openai.json
@@ -21,7 +21,9 @@
       "can_reason": true,
       "reasoning_levels": ["none", "low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-terra",
@@ -37,7 +39,9 @@
       "can_reason": true,
       "reasoning_levels": ["none", "low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-luna",
@@ -53,7 +57,9 @@
       "can_reason": true,
       "reasoning_levels": ["none", "low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.5",
@@ -68,7 +74,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.5-pro",
@@ -82,7 +90,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4",
@@ -97,7 +107,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-pro",
@@ -111,7 +123,9 @@
       "can_reason": true,
       "reasoning_levels": ["medium", "high", "xhigh"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-mini",
@@ -126,7 +140,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-nano",
@@ -141,7 +157,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "xhigh"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.3-codex",
@@ -157,7 +175,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.2",
@@ -173,7 +193,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.2-codex",
@@ -189,7 +211,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1",
@@ -205,7 +229,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1-codex",
@@ -221,7 +247,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1-codex-max",
@@ -237,7 +265,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1-codex-mini",
@@ -253,7 +283,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-codex",
@@ -269,7 +301,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5",
@@ -285,7 +319,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-mini",
@@ -301,7 +337,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-nano",
@@ -317,7 +355,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "o4-mini",
@@ -332,7 +372,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "o3",
@@ -347,7 +389,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1",
@@ -360,7 +404,9 @@
       "context_window": 1047576,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-mini",
@@ -373,7 +419,9 @@
       "context_window": 1047576,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4.1-nano",
@@ -386,7 +434,9 @@
       "context_window": 1047576,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "o3-mini",
@@ -401,7 +451,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-4o",
@@ -414,7 +466,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-4o-mini",
@@ -428,7 +482,9 @@
       "default_max_tokens": 8192,
       "can_reason": false,
       "reasoning_effort": "",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/opencode-go.json
+++ b/internal/providers/configs/opencode-go.json
@@ -24,7 +24,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash-vision-exp",
@@ -43,7 +45,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek-v4-pro",
@@ -62,7 +66,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5",
@@ -81,7 +87,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.1",
@@ -100,7 +108,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2",
@@ -119,7 +129,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.3",
@@ -138,7 +150,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.3-flash",
@@ -157,7 +171,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-luna",
@@ -176,7 +192,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.5",
@@ -195,7 +213,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.6",
@@ -214,7 +234,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "hy3",
@@ -233,7 +255,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "hy4-preview",
@@ -252,7 +276,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kimi-k2.5",
@@ -271,7 +297,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.6",
@@ -290,7 +318,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code",
@@ -309,7 +339,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k3",
@@ -328,7 +360,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "longcat-2.0",
@@ -347,7 +381,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mimo-v2-omni",
@@ -366,7 +402,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mimo-v2-pro",
@@ -385,7 +423,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mimo-v2.5",
@@ -403,7 +443,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mimo-v2.5-pro",
@@ -421,7 +463,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax-m2.5",
@@ -440,7 +484,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m2.7",
@@ -459,7 +505,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m3",
@@ -478,7 +526,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "muse-spark-1.2-contributor",
@@ -496,7 +546,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "muse-spark-1.3-contributor",
@@ -514,7 +566,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ox-alpha-free",
@@ -532,7 +586,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.5-plus",
@@ -551,7 +607,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-plus",
@@ -570,7 +628,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.7-max",
@@ -589,7 +649,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.7-plus",
@@ -608,7 +670,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.8-flash",
@@ -627,7 +691,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.8-max",
@@ -646,7 +712,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/opencode-go.json
+++ b/internal/providers/configs/opencode-go.json
@@ -10,10 +10,11 @@
     {
       "id": "deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 0.66,
-      "cost_per_1m_in_cached": 0.01,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.22,
+        "output": 0.66,
+        "cache_create": 0.01
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -28,10 +29,11 @@
     {
       "id": "deepseek-v4-flash-vision-exp",
       "name": "DeepSeek V4 Flash Vision Exp",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 0.66,
-      "cost_per_1m_in_cached": 0.01,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.22,
+        "output": 0.66,
+        "cache_create": 0.01
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -46,10 +48,11 @@
     {
       "id": "deepseek-v4-pro",
       "name": "DeepSeek V4 Pro (New)",
-      "cost_per_1m_in": 0.66,
-      "cost_per_1m_out": 1.98,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.66,
+        "output": 1.98,
+        "cache_create": 0.02
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -64,10 +67,11 @@
     {
       "id": "glm-5",
       "name": "GLM-5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0.2,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 3.2,
+        "cache_create": 0.2
+      },
       "context_window": 202752,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -82,10 +86,11 @@
     {
       "id": "glm-5.1",
       "name": "GLM-5.1",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0.26,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_create": 0.26
+      },
       "context_window": 202752,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -100,10 +105,11 @@
     {
       "id": "glm-5.2",
       "name": "GLM-5.2",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0.26,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_create": 0.26
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -118,10 +124,11 @@
     {
       "id": "glm-5.3",
       "name": "GLM-5.3",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0.26,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_create": 0.26
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -136,10 +143,11 @@
     {
       "id": "glm-5.3-flash",
       "name": "GLM-5.3-Flash (2x usage)",
-      "cost_per_1m_in": 0.08,
-      "cost_per_1m_out": 0.25,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.08,
+        "output": 0.25,
+        "cache_create": 0.02
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -154,10 +162,11 @@
     {
       "id": "gpt-5.6-luna",
       "name": "GPT-5.6 Luna",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.2,
+        "cache_create": 0.02
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -172,10 +181,11 @@
     {
       "id": "grok-4.5",
       "name": "Grok 4.5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_create": 0.3
+      },
       "context_window": 500000,
       "default_max_tokens": 500000,
       "can_reason": true,
@@ -190,10 +200,11 @@
     {
       "id": "grok-4.6",
       "name": "Grok 4.6",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_create": 0.5
+      },
       "context_window": 500000,
       "default_max_tokens": 500000,
       "can_reason": true,
@@ -208,10 +219,11 @@
     {
       "id": "hy3",
       "name": "Hy3",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.58,
-      "cost_per_1m_in_cached": 0.04,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.58,
+        "cache_create": 0.04
+      },
       "context_window": 256000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -226,10 +238,11 @@
     {
       "id": "hy4-preview",
       "name": "Hy4 preview",
-      "cost_per_1m_in": 0.83,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0.04,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.83,
+        "output": 2.5,
+        "cache_create": 0.04
+      },
       "context_window": 1024000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -244,10 +257,11 @@
     {
       "id": "kimi-k2.5",
       "name": "Kimi K2.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.1,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 3,
+        "cache_create": 0.1
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -262,10 +276,11 @@
     {
       "id": "kimi-k2.6",
       "name": "Kimi K2.6",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0.16,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_create": 0.16
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -280,10 +295,11 @@
     {
       "id": "kimi-k2.7-code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0.19,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_create": 0.19
+      },
       "context_window": 262144,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -298,10 +314,11 @@
     {
       "id": "kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.3
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -316,10 +333,11 @@
     {
       "id": "longcat-2.0",
       "name": "LongCat-2.0",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.01,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.01
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -334,10 +352,11 @@
     {
       "id": "mimo-v2-omni",
       "name": "MiMo V2 Omni",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0.08,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 2,
+        "cache_create": 0.08
+      },
       "context_window": 262144,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -352,10 +371,11 @@
     {
       "id": "mimo-v2-pro",
       "name": "MiMo V2 Pro",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.2,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 3,
+        "cache_create": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -370,10 +390,10 @@
     {
       "id": "mimo-v2.5",
       "name": "MiMo V2.5",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -388,10 +408,10 @@
     {
       "id": "mimo-v2.5-pro",
       "name": "MiMo V2.5 Pro",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 0.87,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.44,
+        "output": 0.87
+      },
       "context_window": 1048576,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -406,10 +426,11 @@
     {
       "id": "minimax-m2.5",
       "name": "MiniMax-M2.5",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.03
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -424,10 +445,11 @@
     {
       "id": "minimax-m2.7",
       "name": "MiniMax-M2.7",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.06,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.06
+      },
       "context_window": 204800,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -442,10 +464,11 @@
     {
       "id": "minimax-m3",
       "name": "MiniMax-M3",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.06,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.06
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -460,10 +483,10 @@
     {
       "id": "muse-spark-1.2-contributor",
       "name": "Muse Spark 1.2 Contributor",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -478,10 +501,10 @@
     {
       "id": "muse-spark-1.3-contributor",
       "name": "Muse Spark 1.3 Contributor",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -496,10 +519,10 @@
     {
       "id": "ox-alpha-free",
       "name": "Ox Alpha Free (Unlimited)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -514,10 +537,11 @@
     {
       "id": "qwen3.5-plus",
       "name": "Qwen3.5 Plus",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.2,
+        "cache_create": 0.02
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -532,10 +556,11 @@
     {
       "id": "qwen3.6-plus",
       "name": "Qwen3.6 Plus",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.05,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_create": 0.05
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -550,10 +575,11 @@
     {
       "id": "qwen3.7-max",
       "name": "Qwen3.7 Max",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 7.5,
+        "cache_create": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -568,10 +594,11 @@
     {
       "id": "qwen3.7-plus",
       "name": "Qwen3.7 Plus",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 1.6,
-      "cost_per_1m_in_cached": 0.04,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_create": 0.04
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -586,10 +613,11 @@
     {
       "id": "qwen3.8-flash",
       "name": "Qwen3.8 Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.47,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.47,
+        "cache_create": 0.02
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -604,10 +632,11 @@
     {
       "id": "qwen3.8-max",
       "name": "Qwen3.8 Max",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0.25,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_create": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,

--- a/internal/providers/configs/opencode-zen.json
+++ b/internal/providers/configs/opencode-zen.json
@@ -10,10 +10,10 @@
     {
       "id": "big-pickle",
       "name": "Big Pickle",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -28,10 +28,12 @@
     {
       "id": "claude-fable-5",
       "name": "Claude Fable 5",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 1,
-      "cost_per_1m_out_cached": 12.5,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 1,
+        "cache_hit": 12.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -46,10 +48,12 @@
     {
       "id": "claude-fable-5-1",
       "name": "Claude Fable 5.1",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 0.25,
-      "cost_per_1m_out_cached": 12.5,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 0.25,
+        "cache_hit": 12.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -64,10 +68,12 @@
     {
       "id": "claude-haiku-4-5",
       "name": "Claude Haiku 4.5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 0.1,
-      "cost_per_1m_out_cached": 1.25,
+      "pricing": {
+        "input": 1,
+        "output": 5,
+        "cache_create": 0.1,
+        "cache_hit": 1.25
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -82,10 +88,12 @@
     {
       "id": "claude-opus-4-5",
       "name": "Claude Opus 4.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 6.25,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 0.5,
+        "cache_hit": 6.25
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -100,10 +108,12 @@
     {
       "id": "claude-opus-4-6",
       "name": "Claude Opus 4.6",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 6.25,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 0.5,
+        "cache_hit": 6.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -118,10 +128,12 @@
     {
       "id": "claude-opus-4-7",
       "name": "Claude Opus 4.7",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 6.25,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 0.5,
+        "cache_hit": 6.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -136,10 +148,12 @@
     {
       "id": "claude-opus-4-8",
       "name": "Claude Opus 4.8",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 6.25,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 0.5,
+        "cache_hit": 6.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -154,10 +168,12 @@
     {
       "id": "claude-opus-5",
       "name": "Claude Opus 5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 6.25,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 0.5,
+        "cache_hit": 6.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -172,10 +188,12 @@
     {
       "id": "claude-sonnet-4",
       "name": "Claude Sonnet 4",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 3.75,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.3,
+        "cache_hit": 3.75
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -190,10 +208,12 @@
     {
       "id": "claude-sonnet-4-5",
       "name": "Claude Sonnet 4.5",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 3.75,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.3,
+        "cache_hit": 3.75
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -208,10 +228,12 @@
     {
       "id": "claude-sonnet-4-6",
       "name": "Claude Sonnet 4.6",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 3.75,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.3,
+        "cache_hit": 3.75
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -226,10 +248,12 @@
     {
       "id": "claude-sonnet-5",
       "name": "Claude Sonnet 5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0.2,
-      "cost_per_1m_out_cached": 2.5,
+      "pricing": {
+        "input": 2,
+        "output": 10,
+        "cache_create": 0.2,
+        "cache_hit": 2.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -244,10 +268,11 @@
     {
       "id": "deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_create": 0.03
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -262,10 +287,10 @@
     {
       "id": "deepseek-v4-flash-free",
       "name": "DeepSeek V4 Flash Free",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -280,10 +305,11 @@
     {
       "id": "deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
-      "cost_per_1m_in": 1.74,
-      "cost_per_1m_out": 3.84,
-      "cost_per_1m_in_cached": 0.14,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.74,
+        "output": 3.84,
+        "cache_create": 0.14
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -298,10 +324,11 @@
     {
       "id": "glm-5",
       "name": "GLM-5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0.2,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 3.2,
+        "cache_create": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -316,10 +343,11 @@
     {
       "id": "glm-5.1",
       "name": "GLM-5.1",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0.26,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_create": 0.26
+      },
       "context_window": 204800,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -334,10 +362,11 @@
     {
       "id": "glm-5.2",
       "name": "GLM-5.2",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0.26,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_create": 0.26
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -352,10 +381,11 @@
     {
       "id": "gpt-5",
       "name": "GPT-5",
-      "cost_per_1m_in": 1.07,
-      "cost_per_1m_out": 8.5,
-      "cost_per_1m_in_cached": 0.11,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.07,
+        "output": 8.5,
+        "cache_create": 0.11
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -370,10 +400,11 @@
     {
       "id": "gpt-5-codex",
       "name": "GPT-5 Codex",
-      "cost_per_1m_in": 1.07,
-      "cost_per_1m_out": 8.5,
-      "cost_per_1m_in_cached": 0.11,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.07,
+        "output": 8.5,
+        "cache_create": 0.11
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -388,10 +419,11 @@
     {
       "id": "gpt-5-nano",
       "name": "GPT-5 Nano",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.01,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.4,
+        "cache_create": 0.01
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -406,10 +438,11 @@
     {
       "id": "gpt-5.1",
       "name": "GPT-5.1",
-      "cost_per_1m_in": 1.07,
-      "cost_per_1m_out": 8.5,
-      "cost_per_1m_in_cached": 0.11,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.07,
+        "output": 8.5,
+        "cache_create": 0.11
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -424,10 +457,11 @@
     {
       "id": "gpt-5.1-codex",
       "name": "GPT-5.1 Codex",
-      "cost_per_1m_in": 1.07,
-      "cost_per_1m_out": 8.5,
-      "cost_per_1m_in_cached": 0.11,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.07,
+        "output": 8.5,
+        "cache_create": 0.11
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -442,10 +476,11 @@
     {
       "id": "gpt-5.1-codex-max",
       "name": "GPT-5.1 Codex Max",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0.13,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_create": 0.13
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -460,10 +495,11 @@
     {
       "id": "gpt-5.1-codex-mini",
       "name": "GPT-5.1 Codex Mini",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_create": 0.03
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -478,10 +514,11 @@
     {
       "id": "gpt-5.2",
       "name": "GPT-5.2",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0.18,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_create": 0.18
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -496,10 +533,11 @@
     {
       "id": "gpt-5.2-codex",
       "name": "GPT-5.2 Codex",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0.18,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_create": 0.18
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -514,10 +552,11 @@
     {
       "id": "gpt-5.3-codex",
       "name": "GPT-5.3 Codex",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0.18,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_create": 0.18
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -532,10 +571,11 @@
     {
       "id": "gpt-5.3-codex-spark",
       "name": "GPT-5.3 Codex Spark",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0.18,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_create": 0.18
+      },
       "context_window": 128000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -550,10 +590,11 @@
     {
       "id": "gpt-5.4",
       "name": "GPT-5.4",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.25,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 15,
+        "cache_create": 0.25
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -568,10 +609,11 @@
     {
       "id": "gpt-5.4-mini",
       "name": "GPT-5.4 Mini",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0.08,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.75,
+        "output": 4.5,
+        "cache_create": 0.08
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -586,10 +628,11 @@
     {
       "id": "gpt-5.4-nano",
       "name": "GPT-5.4 Nano",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.25,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.25,
+        "cache_create": 0.02
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -604,10 +647,11 @@
     {
       "id": "gpt-5.4-pro",
       "name": "GPT-5.4 Pro",
-      "cost_per_1m_in": 30,
-      "cost_per_1m_out": 180,
-      "cost_per_1m_in_cached": 30,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 30,
+        "output": 180,
+        "cache_create": 30
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -622,10 +666,11 @@
     {
       "id": "gpt-5.5",
       "name": "GPT-5.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 5,
+        "output": 30,
+        "cache_create": 0.5
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -640,10 +685,11 @@
     {
       "id": "gpt-5.5-pro",
       "name": "GPT-5.5 Pro",
-      "cost_per_1m_in": 30,
-      "cost_per_1m_out": 180,
-      "cost_per_1m_in_cached": 30,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 30,
+        "output": 180,
+        "cache_create": 30
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -658,10 +704,12 @@
     {
       "id": "gpt-5.6-luna",
       "name": "GPT-5.6 Luna",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.2,
+        "cache_create": 0.02,
+        "cache_hit": 0.25
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -676,10 +724,12 @@
     {
       "id": "gpt-5.6-sol",
       "name": "GPT-5.6 Sol (50% Off)",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0.2,
-      "cost_per_1m_out_cached": 2.5,
+      "pricing": {
+        "input": 2,
+        "output": 10,
+        "cache_create": 0.2,
+        "cache_hit": 2.5
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -694,10 +744,12 @@
     {
       "id": "gpt-5.6-terra",
       "name": "GPT-5.6 Terra",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.25,
-      "cost_per_1m_out_cached": 3.13,
+      "pricing": {
+        "input": 2.5,
+        "output": 15,
+        "cache_create": 0.25,
+        "cache_hit": 3.13
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -712,10 +764,11 @@
     {
       "id": "gemini-3-flash",
       "name": "Gemini 3 Flash",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.05,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_create": 0.05
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -730,10 +783,11 @@
     {
       "id": "gemini-3.1-pro",
       "name": "Gemini 3.1 Pro Preview",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0.2,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_create": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -748,10 +802,11 @@
     {
       "id": "gemini-3.5-flash",
       "name": "Gemini 3.5 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 9,
-      "cost_per_1m_in_cached": 0.15,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.5,
+        "output": 9,
+        "cache_create": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -766,10 +821,11 @@
     {
       "id": "gemini-3.5-flash-lite",
       "name": "Gemini 3.5 Flash Lite",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0.03,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_create": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -784,10 +840,11 @@
     {
       "id": "gemini-3.6-flash",
       "name": "Gemini 3.6 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0.15,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.5,
+        "output": 7.5,
+        "cache_create": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -802,10 +859,11 @@
     {
       "id": "gemini-3.7-flash",
       "name": "Gemini 3.7 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0.15,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.5,
+        "output": 7.5,
+        "cache_create": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -820,10 +878,11 @@
     {
       "id": "gemini-3.8-flash",
       "name": "Gemini 3.8 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0.15,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.5,
+        "output": 7.5,
+        "cache_create": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -838,10 +897,11 @@
     {
       "id": "grok-4.5",
       "name": "Grok 4.5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_create": 0.3
+      },
       "context_window": 500000,
       "default_max_tokens": 500000,
       "can_reason": true,
@@ -856,10 +916,11 @@
     {
       "id": "grok-4.6",
       "name": "Grok 4.6",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_create": 0.5
+      },
       "context_window": 500000,
       "default_max_tokens": 500000,
       "can_reason": true,
@@ -874,10 +935,11 @@
     {
       "id": "grok-build-0.1",
       "name": "Grok Build 0.1",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0.2,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 2,
+        "cache_create": 0.2
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": true,
@@ -892,10 +954,11 @@
     {
       "id": "kimi-k2.5",
       "name": "Kimi K2.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.08,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 3,
+        "cache_create": 0.08
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -910,10 +973,11 @@
     {
       "id": "kimi-k2.6",
       "name": "Kimi K2.6",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0.16,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_create": 0.16
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -928,10 +992,11 @@
     {
       "id": "kimi-k2.7-code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0.19,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_create": 0.19
+      },
       "context_window": 262144,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -946,10 +1011,11 @@
     {
       "id": "kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.3
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -964,10 +1030,10 @@
     {
       "id": "laguna-s-2.1-free",
       "name": "Laguna S 2.1 Free",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -982,10 +1048,10 @@
     {
       "id": "ling-3.0-flash-fin-free",
       "name": "Ling 3.0 Flash Fin Free",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1000,10 +1066,10 @@
     {
       "id": "mimo-v2.5-free",
       "name": "MiMo V2.5 Free",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -1018,10 +1084,11 @@
     {
       "id": "minimax-m2.5",
       "name": "MiniMax-M2.5",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.06,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.06
+      },
       "context_window": 204800,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1036,10 +1103,11 @@
     {
       "id": "minimax-m2.7",
       "name": "MiniMax-M2.7",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.06,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.06
+      },
       "context_window": 204800,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1054,10 +1122,11 @@
     {
       "id": "minimax-m3",
       "name": "MiniMax-M3",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.06,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.06
+      },
       "context_window": 512000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1072,10 +1141,11 @@
     {
       "id": "muse-spark-1.2",
       "name": "Muse Spark 1.2",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 4.25,
-      "cost_per_1m_in_cached": 0.15,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.25,
+        "output": 4.25,
+        "cache_create": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1090,10 +1160,10 @@
     {
       "id": "muse-spark-1.2-contributor-free",
       "name": "Muse Spark 1.2 Free",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1108,10 +1178,10 @@
     {
       "id": "muse-spark-1.3-contributor-free",
       "name": "Muse Spark 1.3 Free",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1126,10 +1196,10 @@
     {
       "id": "nemotron-3-ultra-free",
       "name": "Nemotron 3 Ultra Free",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1144,10 +1214,10 @@
     {
       "id": "nemotron-3.5-lightning-free",
       "name": "Nemotron 3.5 Lightning Free",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -1162,10 +1232,12 @@
     {
       "id": "qwen3.5-plus",
       "name": "Qwen3.5 Plus",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.2,
+        "cache_create": 0.02,
+        "cache_hit": 0.25
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1180,10 +1252,12 @@
     {
       "id": "qwen3.6-plus",
       "name": "Qwen3.6 Plus",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.05,
-      "cost_per_1m_out_cached": 0.63,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_create": 0.05,
+        "cache_hit": 0.63
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,

--- a/internal/providers/configs/opencode-zen.json
+++ b/internal/providers/configs/opencode-zen.json
@@ -23,7 +23,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-fable-5",
@@ -43,7 +45,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-fable-5-1",
@@ -63,7 +67,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-haiku-4-5",
@@ -83,7 +89,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-5",
@@ -103,7 +111,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-6",
@@ -123,7 +133,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-7",
@@ -143,7 +155,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-8",
@@ -163,7 +177,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-5",
@@ -183,7 +199,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4",
@@ -203,7 +221,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-5",
@@ -223,7 +243,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-6",
@@ -243,7 +265,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-5",
@@ -263,7 +287,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek-v4-flash",
@@ -282,7 +308,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash-free",
@@ -300,7 +328,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-pro",
@@ -319,7 +349,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5",
@@ -338,7 +370,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.1",
@@ -357,7 +391,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2",
@@ -376,7 +412,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-5",
@@ -395,7 +433,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-codex",
@@ -414,7 +454,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5-nano",
@@ -433,7 +475,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1",
@@ -452,7 +496,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1-codex",
@@ -471,7 +517,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1-codex-max",
@@ -490,7 +538,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.1-codex-mini",
@@ -509,7 +559,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.2",
@@ -528,7 +580,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.2-codex",
@@ -547,7 +601,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.3-codex",
@@ -566,7 +622,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.3-codex-spark",
@@ -585,7 +643,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-5.4",
@@ -604,7 +664,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-mini",
@@ -623,7 +685,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-nano",
@@ -642,7 +706,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.4-pro",
@@ -661,7 +727,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.5",
@@ -680,7 +748,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.5-pro",
@@ -699,7 +769,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-luna",
@@ -719,7 +791,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-sol",
@@ -739,7 +813,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-5.6-terra",
@@ -759,7 +835,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-flash",
@@ -778,7 +856,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.1-pro",
@@ -797,7 +877,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.5-flash",
@@ -816,7 +898,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.5-flash-lite",
@@ -835,7 +919,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.6-flash",
@@ -854,7 +940,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.7-flash",
@@ -873,7 +961,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.8-flash",
@@ -892,7 +982,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.5",
@@ -911,7 +1003,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.6",
@@ -930,7 +1024,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-build-0.1",
@@ -949,7 +1045,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.5",
@@ -968,7 +1066,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.6",
@@ -987,7 +1087,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2.7-code",
@@ -1006,7 +1108,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k3",
@@ -1025,7 +1129,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "laguna-s-2.1-free",
@@ -1043,7 +1149,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "ling-3.0-flash-fin-free",
@@ -1061,7 +1169,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mimo-v2.5-free",
@@ -1079,7 +1189,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax-m2.5",
@@ -1098,7 +1210,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m2.7",
@@ -1117,7 +1231,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m3",
@@ -1136,7 +1252,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "muse-spark-1.2",
@@ -1155,7 +1273,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "muse-spark-1.2-contributor-free",
@@ -1173,7 +1293,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "muse-spark-1.3-contributor-free",
@@ -1191,7 +1313,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nemotron-3-ultra-free",
@@ -1209,7 +1333,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nemotron-3.5-lightning-free",
@@ -1227,7 +1353,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3.5-plus",
@@ -1247,7 +1375,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-plus",
@@ -1267,7 +1397,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/openrouter.json
+++ b/internal/providers/configs/openrouter.json
@@ -10,10 +10,11 @@
     {
       "id": "aion-labs/aion-2.0",
       "name": "AionLabs: Aion-2.0",
-      "cost_per_1m_in": 0.8,
-      "cost_per_1m_out": 1.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 0.8,
+        "output": 1.6,
+        "cache_hit": 0.2
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -28,10 +29,11 @@
     {
       "id": "aion-labs/aion-3.0",
       "name": "AionLabs: Aion-3.0",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.75,
+      "pricing": {
+        "input": 3,
+        "output": 6,
+        "cache_hit": 0.75
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -46,10 +48,11 @@
     {
       "id": "aion-labs/aion-3.0-mini",
       "name": "AionLabs: Aion-3.0-Mini",
-      "cost_per_1m_in": 0.7,
-      "cost_per_1m_out": 1.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.18,
+      "pricing": {
+        "input": 0.7,
+        "output": 1.4,
+        "cache_hit": 0.18
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -64,10 +67,10 @@
     {
       "id": "amazon/nova-2-lite-v1",
       "name": "Amazon: Nova 2 Lite",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 32767,
       "can_reason": true,
@@ -82,10 +85,10 @@
     {
       "id": "amazon/nova-lite-v1",
       "name": "Amazon: Nova Lite 1.0",
-      "cost_per_1m_in": 0.06,
-      "cost_per_1m_out": 0.24,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.06,
+        "output": 0.24
+      },
       "context_window": 300000,
       "default_max_tokens": 2560,
       "can_reason": false,
@@ -94,10 +97,10 @@
     {
       "id": "amazon/nova-micro-v1",
       "name": "Amazon: Nova Micro 1.0",
-      "cost_per_1m_in": 0.035,
-      "cost_per_1m_out": 0.14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.035,
+        "output": 0.14
+      },
       "context_window": 128000,
       "default_max_tokens": 2560,
       "can_reason": false,
@@ -106,10 +109,11 @@
     {
       "id": "amazon/nova-premier-v1",
       "name": "Amazon: Nova Premier 1.0",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 12.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.625,
+      "pricing": {
+        "input": 2.5,
+        "output": 12.5,
+        "cache_hit": 0.625
+      },
       "context_window": 1000000,
       "default_max_tokens": 16000,
       "can_reason": false,
@@ -118,10 +122,10 @@
     {
       "id": "amazon/nova-pro-v1",
       "name": "Amazon: Nova Pro 1.0",
-      "cost_per_1m_in": 0.8,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.8,
+        "output": 3.2
+      },
       "context_window": 300000,
       "default_max_tokens": 2560,
       "can_reason": false,
@@ -130,10 +134,12 @@
     {
       "id": "anthropic/claude-3-haiku",
       "name": "Anthropic: Claude 3 Haiku",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1.25,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.25,
+        "output": 1.25,
+        "cache_create": 0.3,
+        "cache_hit": 0.03
+      },
       "context_window": 200000,
       "default_max_tokens": 2048,
       "can_reason": false,
@@ -142,10 +148,12 @@
     {
       "id": "anthropic/claude-fable-5",
       "name": "Anthropic: Claude Fable 5",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 1,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 1
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -160,10 +168,12 @@
     {
       "id": "anthropic/claude-fable-5.1",
       "name": "Anthropic: Claude Fable 5.1",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -178,10 +188,12 @@
     {
       "id": "anthropic/claude-haiku-4.5",
       "name": "Anthropic: Claude Haiku 4.5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 1.25,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 1,
+        "output": 5,
+        "cache_create": 1.25,
+        "cache_hit": 0.1
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -196,10 +208,12 @@
     {
       "id": "anthropic/claude-opus-4",
       "name": "Anthropic: Claude Opus 4",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 75,
-      "cost_per_1m_in_cached": 18.75,
-      "cost_per_1m_out_cached": 1.5,
+      "pricing": {
+        "input": 15,
+        "output": 75,
+        "cache_create": 18.75,
+        "cache_hit": 1.5
+      },
       "context_window": 200000,
       "default_max_tokens": 16000,
       "can_reason": true,
@@ -214,10 +228,12 @@
     {
       "id": "anthropic/claude-opus-4.1",
       "name": "Anthropic: Claude Opus 4.1",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 75,
-      "cost_per_1m_in_cached": 18.75,
-      "cost_per_1m_out_cached": 1.5,
+      "pricing": {
+        "input": 15,
+        "output": 75,
+        "cache_create": 18.75,
+        "cache_hit": 1.5
+      },
       "context_window": 200000,
       "default_max_tokens": 16000,
       "can_reason": true,
@@ -232,10 +248,12 @@
     {
       "id": "anthropic/claude-opus-4.5",
       "name": "Anthropic: Claude Opus 4.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -250,10 +268,12 @@
     {
       "id": "anthropic/claude-opus-4.6",
       "name": "Anthropic: Claude Opus 4.6",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -268,10 +288,12 @@
     {
       "id": "anthropic/claude-opus-4.7",
       "name": "Anthropic: Claude Opus 4.7",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -286,10 +308,12 @@
     {
       "id": "anthropic/claude-opus-4.8",
       "name": "Anthropic: Claude Opus 4.8",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -304,10 +328,12 @@
     {
       "id": "anthropic/claude-sonnet-4",
       "name": "Anthropic: Claude Sonnet 4",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -322,10 +348,12 @@
     {
       "id": "anthropic/claude-sonnet-4.5",
       "name": "Anthropic: Claude Sonnet 4.5",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -340,10 +368,12 @@
     {
       "id": "anthropic/claude-sonnet-4.6",
       "name": "Anthropic: Claude Sonnet 4.6",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -358,10 +388,12 @@
     {
       "id": "anthropic/claude-sonnet-5",
       "name": "Anthropic: Claude Sonnet 5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 10,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -376,10 +408,11 @@
     {
       "id": "arcee-ai/trinity-large-thinking",
       "name": "Arcee AI: Trinity Large Thinking",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.8,
+        "cache_hit": 0.06
+      },
       "context_window": 262144,
       "default_max_tokens": 40000,
       "can_reason": true,
@@ -394,10 +427,10 @@
     {
       "id": "bytedance-seed/seed-1.6",
       "name": "ByteDance Seed: Seed 1.6",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 2
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -412,10 +445,10 @@
     {
       "id": "bytedance-seed/seed-1.6-flash",
       "name": "ByteDance Seed: Seed 1.6 Flash",
-      "cost_per_1m_in": 0.075,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.075,
+        "output": 0.3
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -430,10 +463,10 @@
     {
       "id": "bytedance-seed/seed-2-1-turbo",
       "name": "ByteDance Seed: Seed 2.1 Turbo",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 2.5
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": true,
@@ -448,10 +481,10 @@
     {
       "id": "bytedance-seed/seed-2.0-code",
       "name": "ByteDance Seed: Seed-2.0-Code",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 3
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -466,10 +499,10 @@
     {
       "id": "bytedance-seed/seed-2.0-lite",
       "name": "ByteDance Seed: Seed-2.0-Lite",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 2
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -484,10 +517,10 @@
     {
       "id": "bytedance-seed/seed-2.0-mini",
       "name": "ByteDance Seed: Seed-2.0-Mini",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -502,10 +535,12 @@
     {
       "id": "anthropic/claude-opus-5",
       "name": "Claude Opus 5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -520,10 +555,10 @@
     {
       "id": "cohere/command-r-08-2024",
       "name": "Cohere: Command R (08-2024)",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6
+      },
       "context_window": 128000,
       "default_max_tokens": 2000,
       "can_reason": false,
@@ -532,10 +567,10 @@
     {
       "id": "cohere/command-r-plus-08-2024",
       "name": "Cohere: Command R+ (08-2024)",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 10
+      },
       "context_window": 128000,
       "default_max_tokens": 2000,
       "can_reason": false,
@@ -544,10 +579,10 @@
     {
       "id": "cohere/north-mini-code:free",
       "name": "Cohere: North Mini Code (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -562,10 +597,10 @@
     {
       "id": "deepseek/deepseek-chat",
       "name": "DeepSeek: DeepSeek V3",
-      "cost_per_1m_in": 0.32,
-      "cost_per_1m_out": 0.89,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.32,
+        "output": 0.89
+      },
       "context_window": 163840,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -574,10 +609,10 @@
     {
       "id": "deepseek/deepseek-chat-v3-0324",
       "name": "DeepSeek: DeepSeek V3 0324",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 1
+      },
       "context_window": 163840,
       "default_max_tokens": 73728,
       "can_reason": false,
@@ -586,10 +621,11 @@
     {
       "id": "deepseek/deepseek-chat-v3.1",
       "name": "DeepSeek: DeepSeek V3.1",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.95,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.95,
+        "cache_hit": 0.13
+      },
       "context_window": 163840,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -604,10 +640,10 @@
     {
       "id": "deepseek/deepseek-v3.1-terminus",
       "name": "DeepSeek: DeepSeek V3.1 Terminus",
-      "cost_per_1m_in": 0.27,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.27,
+        "output": 1
+      },
       "context_window": 163840,
       "default_max_tokens": 73728,
       "can_reason": true,
@@ -622,10 +658,11 @@
     {
       "id": "deepseek/deepseek-v3.2",
       "name": "DeepSeek: DeepSeek V3.2",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 1,
+        "output": 1,
+        "cache_hit": 0.5
+      },
       "context_window": 163840,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -640,10 +677,10 @@
     {
       "id": "deepseek/deepseek-v3.2-exp",
       "name": "DeepSeek: DeepSeek V3.2 Exp",
-      "cost_per_1m_in": 0.27,
-      "cost_per_1m_out": 0.41,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.27,
+        "output": 0.41
+      },
       "context_window": 163840,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -658,10 +695,11 @@
     {
       "id": "deepseek/deepseek-v4-flash",
       "name": "DeepSeek: DeepSeek V4 Flash 0423",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_hit": 0.028
+      },
       "context_window": 1048576,
       "default_max_tokens": 196608,
       "can_reason": true,
@@ -676,10 +714,11 @@
     {
       "id": "deepseek/deepseek-v4-flash-0731",
       "name": "DeepSeek: DeepSeek V4 Flash 0731",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 1.32,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.014,
+      "pricing": {
+        "input": 0.44,
+        "output": 1.32,
+        "cache_hit": 0.014
+      },
       "context_window": 1310720,
       "default_max_tokens": 589824,
       "can_reason": true,
@@ -694,10 +733,11 @@
     {
       "id": "deepseek/deepseek-v4-flash-vision-exp",
       "name": "DeepSeek: DeepSeek V4 Flash Vision Exp",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 0.66,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.007,
+      "pricing": {
+        "input": 0.22,
+        "output": 0.66,
+        "cache_hit": 0.007
+      },
       "context_window": 1048576,
       "default_max_tokens": 192000,
       "can_reason": true,
@@ -712,10 +752,11 @@
     {
       "id": "deepseek/deepseek-v4-pro",
       "name": "DeepSeek: DeepSeek V4 Pro 0423",
-      "cost_per_1m_in": 1.02921,
-      "cost_per_1m_out": 2.05842,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.08526,
+      "pricing": {
+        "input": 1.02921,
+        "output": 2.05842,
+        "cache_hit": 0.08526
+      },
       "context_window": 1048576,
       "default_max_tokens": 196608,
       "can_reason": true,
@@ -730,10 +771,11 @@
     {
       "id": "deepseek/deepseek-v4-pro-0813",
       "name": "DeepSeek: DeepSeek V4 Pro 0813",
-      "cost_per_1m_in": 0.66,
-      "cost_per_1m_out": 1.98,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.022,
+      "pricing": {
+        "input": 0.66,
+        "output": 1.98,
+        "cache_hit": 0.022
+      },
       "context_window": 1048576,
       "default_max_tokens": 192000,
       "can_reason": true,
@@ -748,10 +790,10 @@
     {
       "id": "deepseek/deepseek-r1",
       "name": "DeepSeek: R1",
-      "cost_per_1m_in": 0.7,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.7,
+        "output": 2.5
+      },
       "context_window": 64000,
       "default_max_tokens": 8000,
       "can_reason": true,
@@ -766,10 +808,10 @@
     {
       "id": "deepseek/deepseek-r1-0528",
       "name": "DeepSeek: R1 0528",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 2.18,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 2.18
+      },
       "context_window": 163840,
       "default_max_tokens": 73728,
       "can_reason": true,
@@ -784,10 +826,10 @@
     {
       "id": "dots-studio/dots-3-note-preview:free",
       "name": "Dots Studio: Dots3-Note Preview (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 512000,
       "default_max_tokens": 230400,
       "can_reason": true,
@@ -802,10 +844,12 @@
     {
       "id": "google/gemini-2.5-flash",
       "name": "Google: Gemini 2.5 Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 1.25,
-      "cost_per_1m_in_cached": 0.04167,
-      "cost_per_1m_out_cached": 0.015,
+      "pricing": {
+        "input": 0.15,
+        "output": 1.25,
+        "cache_create": 0.04167,
+        "cache_hit": 0.015
+      },
       "context_window": 1048576,
       "default_max_tokens": 32767,
       "can_reason": true,
@@ -820,10 +864,12 @@
     {
       "id": "google/gemini-2.5-flash-lite",
       "name": "Google: Gemini 2.5 Flash Lite",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0.04167,
-      "cost_per_1m_out_cached": 0.005,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.2,
+        "cache_create": 0.04167,
+        "cache_hit": 0.005
+      },
       "context_window": 1048576,
       "default_max_tokens": 32767,
       "can_reason": true,
@@ -838,10 +884,12 @@
     {
       "id": "google/gemini-2.5-pro",
       "name": "Google: Gemini 2.5 Pro",
-      "cost_per_1m_in": 2.25,
-      "cost_per_1m_out": 18,
-      "cost_per_1m_in_cached": 0.675,
-      "cost_per_1m_out_cached": 0.225,
+      "pricing": {
+        "input": 2.25,
+        "output": 18,
+        "cache_create": 0.675,
+        "cache_hit": 0.225
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -856,10 +904,12 @@
     {
       "id": "google/gemini-2.5-pro-preview-05-06",
       "name": "Google: Gemini 2.5 Pro Preview 05-06",
-      "cost_per_1m_in": 2.25,
-      "cost_per_1m_out": 18,
-      "cost_per_1m_in_cached": 0.675,
-      "cost_per_1m_out_cached": 0.225,
+      "pricing": {
+        "input": 2.25,
+        "output": 18,
+        "cache_create": 0.675,
+        "cache_hit": 0.225
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -874,10 +924,12 @@
     {
       "id": "google/gemini-2.5-pro-preview",
       "name": "Google: Gemini 2.5 Pro Preview 06-05",
-      "cost_per_1m_in": 2.25,
-      "cost_per_1m_out": 18,
-      "cost_per_1m_in_cached": 0.675,
-      "cost_per_1m_out_cached": 0.225,
+      "pricing": {
+        "input": 2.25,
+        "output": 18,
+        "cache_create": 0.675,
+        "cache_hit": 0.225
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -892,10 +944,12 @@
     {
       "id": "google/gemini-3-flash-preview",
       "name": "Google: Gemini 3 Flash Preview",
-      "cost_per_1m_in": 0.9,
-      "cost_per_1m_out": 5.4,
-      "cost_per_1m_in_cached": 0.15,
-      "cost_per_1m_out_cached": 0.09,
+      "pricing": {
+        "input": 0.9,
+        "output": 5.4,
+        "cache_create": 0.15,
+        "cache_hit": 0.09
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -910,10 +964,12 @@
     {
       "id": "google/gemini-3.1-flash-lite",
       "name": "Google: Gemini 3.1 Flash Lite",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 2.7,
-      "cost_per_1m_in_cached": 0.15,
-      "cost_per_1m_out_cached": 0.045,
+      "pricing": {
+        "input": 0.45,
+        "output": 2.7,
+        "cache_create": 0.15,
+        "cache_hit": 0.045
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -928,10 +984,12 @@
     {
       "id": "google/gemini-3.1-flash-lite-preview",
       "name": "Google: Gemini 3.1 Flash Lite Preview",
-      "cost_per_1m_in": 0.125,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0.04167,
-      "cost_per_1m_out_cached": 0.0125,
+      "pricing": {
+        "input": 0.125,
+        "output": 0.75,
+        "cache_create": 0.04167,
+        "cache_hit": 0.0125
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -946,10 +1004,12 @@
     {
       "id": "google/gemini-3.1-pro-preview",
       "name": "Google: Gemini 3.1 Pro Preview",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0.375,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_create": 0.375,
+        "cache_hit": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -964,10 +1024,12 @@
     {
       "id": "google/gemini-3.1-pro-preview-customtools",
       "name": "Google: Gemini 3.1 Pro Preview Custom Tools",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0.375,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_create": 0.375,
+        "cache_hit": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -982,10 +1044,12 @@
     {
       "id": "google/gemini-3.5-flash",
       "name": "Google: Gemini 3.5 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 9,
-      "cost_per_1m_in_cached": 0.08333,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.5,
+        "output": 9,
+        "cache_create": 0.08333,
+        "cache_hit": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1000,10 +1064,12 @@
     {
       "id": "google/gemini-3.5-flash-lite",
       "name": "Google: Gemini 3.5 Flash Lite",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 1.25,
-      "cost_per_1m_in_cached": 0.04167,
-      "cost_per_1m_out_cached": 0.015,
+      "pricing": {
+        "input": 0.15,
+        "output": 1.25,
+        "cache_create": 0.04167,
+        "cache_hit": 0.015
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1018,10 +1084,12 @@
     {
       "id": "google/gemini-3.6-flash",
       "name": "Google: Gemini 3.6 Flash",
-      "cost_per_1m_in": 0.375,
-      "cost_per_1m_out": 1.875,
-      "cost_per_1m_in_cached": 0.02083,
-      "cost_per_1m_out_cached": 0.0375,
+      "pricing": {
+        "input": 0.375,
+        "output": 1.875,
+        "cache_create": 0.02083,
+        "cache_hit": 0.0375
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1036,10 +1104,12 @@
     {
       "id": "google/gemini-3.7-flash",
       "name": "Google: Gemini 3.7 Flash",
-      "cost_per_1m_in": 0.375,
-      "cost_per_1m_out": 1.875,
-      "cost_per_1m_in_cached": 0.02083,
-      "cost_per_1m_out_cached": 0.0375,
+      "pricing": {
+        "input": 0.375,
+        "output": 1.875,
+        "cache_create": 0.02083,
+        "cache_hit": 0.0375
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1054,10 +1124,12 @@
     {
       "id": "google/gemini-3.8-flash",
       "name": "Google: Gemini 3.8 Flash",
-      "cost_per_1m_in": 0.375,
-      "cost_per_1m_out": 1.875,
-      "cost_per_1m_in_cached": 0.02083,
-      "cost_per_1m_out_cached": 0.0375,
+      "pricing": {
+        "input": 0.375,
+        "output": 1.875,
+        "cache_create": 0.02083,
+        "cache_hit": 0.0375
+      },
       "context_window": 1048576,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1072,10 +1144,10 @@
     {
       "id": "google/gemma-3-12b-it",
       "name": "Google: Gemma 3 12B",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.15
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -1084,10 +1156,10 @@
     {
       "id": "google/gemma-3-27b-it",
       "name": "Google: Gemma 3 27B",
-      "cost_per_1m_in": 0.08,
-      "cost_per_1m_out": 0.16,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.08,
+        "output": 0.16
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -1096,10 +1168,10 @@
     {
       "id": "google/gemma-4-26b-a4b-it",
       "name": "Google: Gemma 4 26B A4B ",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.34,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.07,
+        "output": 0.34
+      },
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -1114,10 +1186,10 @@
     {
       "id": "google/gemma-4-26b-a4b-it:free",
       "name": "Google: Gemma 4 26B A4B  (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -1132,10 +1204,10 @@
     {
       "id": "google/gemma-4-31b-it",
       "name": "Google: Gemma 4 31B",
-      "cost_per_1m_in": 0.39,
-      "cost_per_1m_out": 0.97,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.39,
+        "output": 0.97
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": true,
@@ -1150,10 +1222,10 @@
     {
       "id": "google/gemma-4-31b-it:free",
       "name": "Google: Gemma 4 31B (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -1168,10 +1240,11 @@
     {
       "id": "ibm-granite/granite-4.1-8b",
       "name": "IBM: Granite 4.1 8B",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.1,
+        "cache_hit": 0.05
+      },
       "context_window": 131072,
       "default_max_tokens": 58982,
       "can_reason": false,
@@ -1180,10 +1253,11 @@
     {
       "id": "ibm-granite/granite-4.2-8b",
       "name": "IBM: Granite 4.2 8B",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.15,
+        "cache_hit": 0.05
+      },
       "context_window": 131072,
       "default_max_tokens": 58982,
       "can_reason": true,
@@ -1198,10 +1272,11 @@
     {
       "id": "inception/mercury-2",
       "name": "Inception: Mercury 2",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.75,
+        "cache_hit": 0.025
+      },
       "context_window": 128000,
       "default_max_tokens": 25000,
       "can_reason": true,
@@ -1216,10 +1291,11 @@
     {
       "id": "inception/mercury-2.5-preview",
       "name": "Inception: Mercury 2.5 Preview",
-      "cost_per_1m_in": 0.04,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.004,
+      "pricing": {
+        "input": 0.04,
+        "output": 0.15,
+        "cache_hit": 0.004
+      },
       "context_window": 260000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1234,10 +1310,11 @@
     {
       "id": "kwaipilot/kat-coder-pro-v2",
       "name": "Kwaipilot: KAT-Coder-Pro V2",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.06
+      },
       "context_window": 262144,
       "default_max_tokens": 72000,
       "can_reason": false,
@@ -1246,10 +1323,11 @@
     {
       "id": "kwaipilot/kat-coder-pro-v2.5",
       "name": "Kwaipilot: KAT-Coder-Pro V2.5",
-      "cost_per_1m_in": 0.74,
-      "cost_per_1m_out": 2.96,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 0.74,
+        "output": 2.96,
+        "cache_hit": 0.15
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
@@ -1258,10 +1336,10 @@
     {
       "id": "inclusionai/ling-3.0-flash-fin:free",
       "name": "Ling 3.0 Flash Fin (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -1276,10 +1354,11 @@
     {
       "id": "inclusionai/ling-3.0-flash",
       "name": "Ling-3.0-flash",
-      "cost_per_1m_in": 0.021,
-      "cost_per_1m_out": 0.063,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0042,
+      "pricing": {
+        "input": 0.021,
+        "output": 0.063,
+        "cache_hit": 0.0042
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -1294,10 +1373,10 @@
     {
       "id": "liquid/lfm-2.5-2.6b:free",
       "name": "LiquidAI: LFM2.5-2.6B (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 65536,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -1312,10 +1391,11 @@
     {
       "id": "meituan/longcat-2.0",
       "name": "Meituan: LongCat 2.0",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.006,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.006
+      },
       "context_window": 1048756,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1330,10 +1410,10 @@
     {
       "id": "meta-llama/llama-3.1-70b-instruct",
       "name": "Meta: Llama 3.1 70B Instruct",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 0.4
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -1342,10 +1422,11 @@
     {
       "id": "meta-llama/llama-3.1-8b-instruct",
       "name": "Meta: Llama 3.1 8B Instruct",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 0.22,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.22,
+      "pricing": {
+        "input": 0.22,
+        "output": 0.22,
+        "cache_hit": 0.22
+      },
       "context_window": 131072,
       "default_max_tokens": 58982,
       "can_reason": false,
@@ -1354,10 +1435,11 @@
     {
       "id": "meta-llama/llama-3.3-70b-instruct",
       "name": "Meta: Llama 3.3 70B Instruct",
-      "cost_per_1m_in": 0.59,
-      "cost_per_1m_out": 0.79,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.295,
+      "pricing": {
+        "input": 0.59,
+        "output": 0.79,
+        "cache_hit": 0.295
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1366,10 +1448,10 @@
     {
       "id": "meta-llama/llama-4-maverick",
       "name": "Meta: Llama 4 Maverick",
-      "cost_per_1m_in": 0.35,
-      "cost_per_1m_out": 1.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.35,
+        "output": 1.15
+      },
       "context_window": 524288,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -1378,10 +1460,10 @@
     {
       "id": "meta-llama/llama-4-scout",
       "name": "Meta: Llama 4 Scout",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.7,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.7
+      },
       "context_window": 1310720,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -1390,10 +1472,11 @@
     {
       "id": "meta/muse-glimmer-30b",
       "name": "Meta: Muse Glimmer 30B",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.04
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -1408,10 +1491,11 @@
     {
       "id": "meta/muse-spark-1.1",
       "name": "Meta: Muse Spark 1.1",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 4.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.25,
+        "output": 4.25,
+        "cache_hit": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 471859,
       "can_reason": true,
@@ -1426,10 +1510,11 @@
     {
       "id": "meta/muse-spark-1.2",
       "name": "Meta: Muse Spark 1.2",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 4.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.25,
+        "output": 4.25,
+        "cache_hit": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 471859,
       "can_reason": true,
@@ -1444,10 +1529,11 @@
     {
       "id": "meta/muse-spark-1.2-contributor",
       "name": "Meta: Muse Spark 1.2 Contributor",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.002,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.2,
+        "cache_hit": 0.002
+      },
       "context_window": 1048576,
       "default_max_tokens": 471859,
       "can_reason": true,
@@ -1462,10 +1548,11 @@
     {
       "id": "meta/muse-spark-1.3",
       "name": "Meta: Muse Spark 1.3",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 4.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.25,
+        "output": 4.25,
+        "cache_hit": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 471859,
       "can_reason": true,
@@ -1480,10 +1567,11 @@
     {
       "id": "meta/muse-spark-1.3-contributor",
       "name": "Meta: Muse Spark 1.3 Contributor",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.002,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.2,
+        "cache_hit": 0.002
+      },
       "context_window": 1048576,
       "default_max_tokens": 471859,
       "can_reason": true,
@@ -1498,10 +1586,10 @@
     {
       "id": "minimax/minimax-m2",
       "name": "MiniMax: MiniMax M2",
-      "cost_per_1m_in": 0.255,
-      "cost_per_1m_out": 1.02,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.255,
+        "output": 1.02
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1516,10 +1604,11 @@
     {
       "id": "minimax/minimax-m2.1",
       "name": "MiniMax: MiniMax M2.1",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.03
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1534,10 +1623,11 @@
     {
       "id": "minimax/minimax-m2.5",
       "name": "MiniMax: MiniMax M2.5",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.03
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1552,10 +1642,11 @@
     {
       "id": "minimax/minimax-m2.7",
       "name": "MiniMax: MiniMax M2.7",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.06
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1570,10 +1661,10 @@
     {
       "id": "minimax/minimax-m2.7:free",
       "name": "MiniMax: MiniMax M2.7 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 196608,
       "default_max_tokens": 88473,
       "can_reason": true,
@@ -1588,10 +1679,11 @@
     {
       "id": "minimax/minimax-m3",
       "name": "MiniMax: MiniMax M3",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 0.75,
+        "output": 3,
+        "cache_hit": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 471859,
       "can_reason": true,
@@ -1606,10 +1698,10 @@
     {
       "id": "minimax/minimax-m3:free",
       "name": "MiniMax: MiniMax M3 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 471859,
       "can_reason": true,
@@ -1624,10 +1716,11 @@
     {
       "id": "mistralai/mistral-large",
       "name": "Mistral Large",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.2
+      },
       "context_window": 128000,
       "default_max_tokens": 51200,
       "can_reason": false,
@@ -1636,10 +1729,11 @@
     {
       "id": "mistralai/mistral-large-2407",
       "name": "Mistral Large 2407",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.2
+      },
       "context_window": 131072,
       "default_max_tokens": 52428,
       "can_reason": false,
@@ -1648,10 +1742,11 @@
     {
       "id": "mistralai/codestral-2508",
       "name": "Mistral: Codestral 2508",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.9,
+        "cache_hit": 0.03
+      },
       "context_window": 256000,
       "default_max_tokens": 102400,
       "can_reason": false,
@@ -1660,10 +1755,11 @@
     {
       "id": "mistralai/devstral-2512",
       "name": "Mistral: Devstral 2 2512",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.4,
+        "output": 2,
+        "cache_hit": 0.04
+      },
       "context_window": 262144,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -1672,10 +1768,11 @@
     {
       "id": "mistralai/ministral-14b-2512",
       "name": "Mistral: Ministral 3 14B 2512",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2,
+        "cache_hit": 0.02
+      },
       "context_window": 262144,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -1684,10 +1781,11 @@
     {
       "id": "mistralai/ministral-3b-2512",
       "name": "Mistral: Ministral 3 3B 2512",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.1,
+        "cache_hit": 0.01
+      },
       "context_window": 131072,
       "default_max_tokens": 52428,
       "can_reason": false,
@@ -1696,10 +1794,11 @@
     {
       "id": "mistralai/ministral-8b-2512",
       "name": "Mistral: Ministral 3 8B 2512",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.015,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.15,
+        "cache_hit": 0.015
+      },
       "context_window": 262144,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -1708,10 +1807,11 @@
     {
       "id": "mistralai/mistral-large-2512",
       "name": "Mistral: Mistral Large 3 2512",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.5,
+        "output": 1.5,
+        "cache_hit": 0.05
+      },
       "context_window": 262144,
       "default_max_tokens": 104857,
       "can_reason": false,
@@ -1720,10 +1820,11 @@
     {
       "id": "mistralai/mistral-medium-3",
       "name": "Mistral: Mistral Medium 3",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.4,
+        "output": 2,
+        "cache_hit": 0.04
+      },
       "context_window": 131072,
       "default_max_tokens": 52428,
       "can_reason": false,
@@ -1732,10 +1833,11 @@
     {
       "id": "mistralai/mistral-medium-3.1",
       "name": "Mistral: Mistral Medium 3.1",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.4,
+        "output": 2,
+        "cache_hit": 0.04
+      },
       "context_window": 131072,
       "default_max_tokens": 52428,
       "can_reason": false,
@@ -1744,10 +1846,10 @@
     {
       "id": "mistralai/mistral-medium-3-5",
       "name": "Mistral: Mistral Medium 3.5",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.5,
+        "output": 7.5
+      },
       "context_window": 262144,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -1762,10 +1864,11 @@
     {
       "id": "mistralai/mistral-nemo",
       "name": "Mistral: Mistral Nemo",
-      "cost_per_1m_in": 0.044,
-      "cost_per_1m_out": 0.16,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.029,
+      "pricing": {
+        "input": 0.044,
+        "output": 0.16,
+        "cache_hit": 0.029
+      },
       "context_window": 128000,
       "default_max_tokens": 51200,
       "can_reason": false,
@@ -1774,10 +1877,10 @@
     {
       "id": "mistralai/mistral-small-3.2-24b-instruct",
       "name": "Mistral: Mistral Small 3.2 24B",
-      "cost_per_1m_in": 0.075,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.075,
+        "output": 0.2
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -1786,10 +1889,11 @@
     {
       "id": "mistralai/mistral-small-2603",
       "name": "Mistral: Mistral Small 4",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.015,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.015
+      },
       "context_window": 262144,
       "default_max_tokens": 104857,
       "can_reason": true,
@@ -1804,10 +1908,11 @@
     {
       "id": "mistralai/mixtral-8x22b-instruct",
       "name": "Mistral: Mixtral 8x22B Instruct",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.2
+      },
       "context_window": 65536,
       "default_max_tokens": 26214,
       "can_reason": false,
@@ -1816,10 +1921,11 @@
     {
       "id": "mistralai/mistral-saba",
       "name": "Mistral: Saba",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.6,
+        "cache_hit": 0.02
+      },
       "context_window": 32768,
       "default_max_tokens": 13107,
       "can_reason": false,
@@ -1828,10 +1934,11 @@
     {
       "id": "mistralai/voxtral-small-24b-2507",
       "name": "Mistral: Voxtral Small 24B 2507",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.3,
+        "cache_hit": 0.01
+      },
       "context_window": 32768,
       "default_max_tokens": 13107,
       "can_reason": false,
@@ -1840,10 +1947,10 @@
     {
       "id": "moonshotai/kimi-k2",
       "name": "MoonshotAI: Kimi K2 0711",
-      "cost_per_1m_in": 0.57,
-      "cost_per_1m_out": 2.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.57,
+        "output": 2.3
+      },
       "context_window": 131072,
       "default_max_tokens": 50176,
       "can_reason": false,
@@ -1852,10 +1959,10 @@
     {
       "id": "moonshotai/kimi-k2-0905",
       "name": "MoonshotAI: Kimi K2 0905",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.5
+      },
       "context_window": 262144,
       "default_max_tokens": 50176,
       "can_reason": false,
@@ -1864,10 +1971,10 @@
     {
       "id": "moonshotai/kimi-k2-thinking",
       "name": "MoonshotAI: Kimi K2 Thinking",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.5
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": true,
@@ -1882,10 +1989,10 @@
     {
       "id": "moonshotai/kimi-k2.5",
       "name": "MoonshotAI: Kimi K2.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 3
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1900,10 +2007,11 @@
     {
       "id": "moonshotai/kimi-k2.6",
       "name": "MoonshotAI: Kimi K2.6",
-      "cost_per_1m_in": 0.5372,
-      "cost_per_1m_out": 2.2618,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0905,
+      "pricing": {
+        "input": 0.5372,
+        "output": 2.2618,
+        "cache_hit": 0.0905
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": true,
@@ -1918,10 +2026,11 @@
     {
       "id": "moonshotai/kimi-k2.7-code",
       "name": "MoonshotAI: Kimi K2.7 Code",
-      "cost_per_1m_in": 0.68,
-      "cost_per_1m_out": 3.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.136,
+      "pricing": {
+        "input": 0.68,
+        "output": 3.4,
+        "cache_hit": 0.136
+      },
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -1936,10 +2045,11 @@
     {
       "id": "moonshotai/kimi-k3",
       "name": "MoonshotAI: Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_hit": 0.3
+      },
       "context_window": 1048576,
       "default_max_tokens": 471859,
       "can_reason": true,
@@ -1954,10 +2064,11 @@
     {
       "id": "nvidia/nemotron-3-nano-30b-a3b",
       "name": "NVIDIA: Nemotron 3 Nano 30B A3B",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.2,
+        "cache_hit": 0.025
+      },
       "context_window": 262144,
       "default_max_tokens": 114000,
       "can_reason": true,
@@ -1972,10 +2083,10 @@
     {
       "id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
       "name": "NVIDIA: Nemotron 3 Nano Omni (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1990,10 +2101,11 @@
     {
       "id": "nvidia/nemotron-3-super-120b-a12b",
       "name": "NVIDIA: Nemotron 3 Super",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.65,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.65,
+        "cache_hit": 0.06
+      },
       "context_window": 1000000,
       "default_max_tokens": 450000,
       "can_reason": true,
@@ -2008,10 +2120,10 @@
     {
       "id": "nvidia/nemotron-3-super-120b-a12b:free",
       "name": "NVIDIA: Nemotron 3 Super (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": true,
@@ -2026,10 +2138,11 @@
     {
       "id": "nvidia/nemotron-3-ultra-550b-a55b",
       "name": "NVIDIA: Nemotron 3 Ultra",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.12,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_hit": 0.12
+      },
       "context_window": 202800,
       "default_max_tokens": 91260,
       "can_reason": true,
@@ -2044,10 +2157,10 @@
     {
       "id": "nvidia/nemotron-3-ultra-550b-a55b:free",
       "name": "NVIDIA: Nemotron 3 Ultra (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -2062,10 +2175,11 @@
     {
       "id": "nvidia/nemotron-3.5-lightning",
       "name": "NVIDIA: Nemotron 3.5 Lightning",
-      "cost_per_1m_in": 0.08,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.08,
+        "output": 0.2,
+        "cache_hit": 0.04
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -2080,10 +2194,10 @@
     {
       "id": "nvidia/nemotron-3.5-lightning:free",
       "name": "NVIDIA: Nemotron 3.5 Lightning (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -2098,10 +2212,11 @@
     {
       "id": "nex-agi/nex-n2-mini",
       "name": "Nex AGI: Nex-N2-Mini",
-      "cost_per_1m_in": 0.025,
-      "cost_per_1m_out": 0.1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0025,
+      "pricing": {
+        "input": 0.025,
+        "output": 0.1,
+        "cache_hit": 0.0025
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": true,
@@ -2116,10 +2231,11 @@
     {
       "id": "nex-agi/nex-n2-pro",
       "name": "Nex AGI: Nex-N2-Pro",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.25,
+        "output": 1,
+        "cache_hit": 0.025
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": true,
@@ -2134,10 +2250,10 @@
     {
       "id": "openai/gpt-audio",
       "name": "OpenAI: GPT Audio",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 10
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2146,10 +2262,10 @@
     {
       "id": "openai/gpt-audio-mini",
       "name": "OpenAI: GPT Audio Mini",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2158,10 +2274,11 @@
     {
       "id": "openai/gpt-chat-latest",
       "name": "OpenAI: GPT Chat Latest",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 30,
+        "cache_hit": 0.5
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -2170,10 +2287,10 @@
     {
       "id": "openai/gpt-4-turbo",
       "name": "OpenAI: GPT-4 Turbo",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 10,
+        "output": 30
+      },
       "context_window": 128000,
       "default_max_tokens": 2048,
       "can_reason": false,
@@ -2182,10 +2299,10 @@
     {
       "id": "openai/gpt-4-turbo-preview",
       "name": "OpenAI: GPT-4 Turbo Preview",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 10,
+        "output": 30
+      },
       "context_window": 128000,
       "default_max_tokens": 2048,
       "can_reason": false,
@@ -2194,10 +2311,11 @@
     {
       "id": "openai/gpt-4.1",
       "name": "OpenAI: GPT-4.1",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 1047576,
       "default_max_tokens": 471409,
       "can_reason": false,
@@ -2206,10 +2324,11 @@
     {
       "id": "openai/gpt-4.1-mini",
       "name": "OpenAI: GPT-4.1 Mini",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 1.76,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.11,
+      "pricing": {
+        "input": 0.44,
+        "output": 1.76,
+        "cache_hit": 0.11
+      },
       "context_window": 1047576,
       "default_max_tokens": 471409,
       "can_reason": false,
@@ -2218,10 +2337,11 @@
     {
       "id": "openai/gpt-4.1-nano",
       "name": "OpenAI: GPT-4.1 Nano",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_hit": 0.03
+      },
       "context_window": 1047576,
       "default_max_tokens": 471409,
       "can_reason": false,
@@ -2230,10 +2350,10 @@
     {
       "id": "openai/gpt-4o",
       "name": "OpenAI: GPT-4o",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 10
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2242,10 +2362,10 @@
     {
       "id": "openai/gpt-4o-2024-05-13",
       "name": "OpenAI: GPT-4o (2024-05-13)",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 5,
+        "output": 15
+      },
       "context_window": 128000,
       "default_max_tokens": 2048,
       "can_reason": false,
@@ -2254,10 +2374,11 @@
     {
       "id": "openai/gpt-4o-2024-08-06",
       "name": "OpenAI: GPT-4o (2024-08-06)",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 10,
+        "cache_hit": 1.25
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2266,10 +2387,11 @@
     {
       "id": "openai/gpt-4o-2024-11-20",
       "name": "OpenAI: GPT-4o (2024-11-20)",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 10,
+        "cache_hit": 1.25
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2278,10 +2400,11 @@
     {
       "id": "openai/gpt-4o-mini",
       "name": "OpenAI: GPT-4o-mini",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.075
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2290,10 +2413,11 @@
     {
       "id": "openai/gpt-4o-mini-2024-07-18",
       "name": "OpenAI: GPT-4o-mini (2024-07-18)",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.075
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2302,10 +2426,11 @@
     {
       "id": "openai/gpt-5",
       "name": "OpenAI: GPT-5",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2320,10 +2445,11 @@
     {
       "id": "openai/gpt-5-mini",
       "name": "OpenAI: GPT-5 Mini",
-      "cost_per_1m_in": 0.125,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0125,
+      "pricing": {
+        "input": 0.125,
+        "output": 1,
+        "cache_hit": 0.0125
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2338,10 +2464,11 @@
     {
       "id": "openai/gpt-5-nano",
       "name": "OpenAI: GPT-5 Nano",
-      "cost_per_1m_in": 0.025,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0025,
+      "pricing": {
+        "input": 0.025,
+        "output": 0.2,
+        "cache_hit": 0.0025
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2356,10 +2483,10 @@
     {
       "id": "openai/gpt-5-pro",
       "name": "OpenAI: GPT-5 Pro",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 120,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 15,
+        "output": 120
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2374,10 +2501,11 @@
     {
       "id": "openai/gpt-5.1",
       "name": "OpenAI: GPT-5.1",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.13
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2392,10 +2520,11 @@
     {
       "id": "openai/gpt-5.1-codex",
       "name": "OpenAI: GPT-5.1-Codex",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.13
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2410,10 +2539,11 @@
     {
       "id": "openai/gpt-5.1-codex-max",
       "name": "OpenAI: GPT-5.1-Codex-Max",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2428,10 +2558,11 @@
     {
       "id": "openai/gpt-5.1-codex-mini",
       "name": "OpenAI: GPT-5.1-Codex-Mini",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_hit": 0.03
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2446,10 +2577,11 @@
     {
       "id": "openai/gpt-5.2",
       "name": "OpenAI: GPT-5.2",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2464,10 +2596,11 @@
     {
       "id": "openai/gpt-5.2-chat",
       "name": "OpenAI: GPT-5.2 Chat",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 128000,
       "default_max_tokens": 16000,
       "can_reason": false,
@@ -2476,10 +2609,10 @@
     {
       "id": "openai/gpt-5.2-pro",
       "name": "OpenAI: GPT-5.2 Pro",
-      "cost_per_1m_in": 21,
-      "cost_per_1m_out": 168,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 21,
+        "output": 168
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2494,10 +2627,11 @@
     {
       "id": "openai/gpt-5.2-codex",
       "name": "OpenAI: GPT-5.2-Codex",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2512,10 +2646,11 @@
     {
       "id": "openai/gpt-5.3-codex",
       "name": "OpenAI: GPT-5.3-Codex",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2530,10 +2665,11 @@
     {
       "id": "openai/gpt-5.4",
       "name": "OpenAI: GPT-5.4",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 15,
+        "cache_hit": 0.25
+      },
       "context_window": 1050000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2548,10 +2684,11 @@
     {
       "id": "openai/gpt-5.4-mini",
       "name": "OpenAI: GPT-5.4 Mini",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.75,
+        "output": 4.5,
+        "cache_hit": 0.075
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2566,10 +2703,11 @@
     {
       "id": "openai/gpt-5.4-nano",
       "name": "OpenAI: GPT-5.4 Nano",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.625,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.625,
+        "cache_hit": 0.01
+      },
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2584,10 +2722,10 @@
     {
       "id": "openai/gpt-5.4-pro",
       "name": "OpenAI: GPT-5.4 Pro",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 90,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 15,
+        "output": 90
+      },
       "context_window": 1050000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2602,10 +2740,11 @@
     {
       "id": "openai/gpt-5.5",
       "name": "OpenAI: GPT-5.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 30,
+        "cache_hit": 0.5
+      },
       "context_window": 1050000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2620,10 +2759,10 @@
     {
       "id": "openai/gpt-5.5-pro",
       "name": "OpenAI: GPT-5.5 Pro",
-      "cost_per_1m_in": 30,
-      "cost_per_1m_out": 180,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 30,
+        "output": 180
+      },
       "context_window": 1050000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2638,10 +2777,12 @@
     {
       "id": "openai/gpt-5.6-luna",
       "name": "OpenAI: GPT-5.6 Luna",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 1.32,
-      "cost_per_1m_in_cached": 0.275,
-      "cost_per_1m_out_cached": 0.022,
+      "pricing": {
+        "input": 0.22,
+        "output": 1.32,
+        "cache_create": 0.275,
+        "cache_hit": 0.022
+      },
       "context_window": 1050000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2656,10 +2797,12 @@
     {
       "id": "openai/gpt-5.6-luna-pro",
       "name": "OpenAI: GPT-5.6 Luna Pro",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0.125,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.6,
+        "cache_create": 0.125,
+        "cache_hit": 0.01
+      },
       "context_window": 1050000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2674,10 +2817,12 @@
     {
       "id": "openai/gpt-5.6-sol",
       "name": "OpenAI: GPT-5.6 Sol",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 1.25,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 1,
+        "output": 5,
+        "cache_create": 1.25,
+        "cache_hit": 0.1
+      },
       "context_window": 1050000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2692,10 +2837,12 @@
     {
       "id": "openai/gpt-5.6-sol-pro",
       "name": "OpenAI: GPT-5.6 Sol Pro",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 1.25,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 1,
+        "output": 5,
+        "cache_create": 1.25,
+        "cache_hit": 0.1
+      },
       "context_window": 1050000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2710,10 +2857,12 @@
     {
       "id": "openai/gpt-5.6-terra",
       "name": "OpenAI: GPT-5.6 Terra",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 1.25,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 1,
+        "output": 6,
+        "cache_create": 1.25,
+        "cache_hit": 0.1
+      },
       "context_window": 1050000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2728,10 +2877,12 @@
     {
       "id": "openai/gpt-5.6-terra-pro",
       "name": "OpenAI: GPT-5.6 Terra Pro",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1050000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -2746,10 +2897,10 @@
     {
       "id": "openai/gpt-oss-120b",
       "name": "OpenAI: gpt-oss-120b",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -2764,10 +2915,11 @@
     {
       "id": "openai/gpt-oss-20b",
       "name": "OpenAI: gpt-oss-20b",
-      "cost_per_1m_in": 0.03,
-      "cost_per_1m_out": 0.13,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.03,
+        "output": 0.13,
+        "cache_hit": 0.03
+      },
       "context_window": 131072,
       "default_max_tokens": 58982,
       "can_reason": true,
@@ -2782,10 +2934,11 @@
     {
       "id": "openai/gpt-oss-safeguard-20b",
       "name": "OpenAI: gpt-oss-safeguard-20b",
-      "cost_per_1m_in": 0.075,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0375,
+      "pricing": {
+        "input": 0.075,
+        "output": 0.3,
+        "cache_hit": 0.0375
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -2800,10 +2953,11 @@
     {
       "id": "openai/o1",
       "name": "OpenAI: o1",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 60,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 7.5,
+      "pricing": {
+        "input": 15,
+        "output": 60,
+        "cache_hit": 7.5
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -2818,10 +2972,11 @@
     {
       "id": "openai/o3",
       "name": "OpenAI: o3",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -2836,10 +2991,11 @@
     {
       "id": "openai/o3-mini",
       "name": "OpenAI: o3 Mini",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.55
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -2854,10 +3010,11 @@
     {
       "id": "openai/o3-mini-high",
       "name": "OpenAI: o3 Mini High",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.55
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -2872,10 +3029,10 @@
     {
       "id": "openai/o3-pro",
       "name": "OpenAI: o3 Pro",
-      "cost_per_1m_in": 20,
-      "cost_per_1m_out": 80,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 20,
+        "output": 80
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -2890,10 +3047,11 @@
     {
       "id": "openai/o4-mini",
       "name": "OpenAI: o4 Mini",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.275,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.275
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -2908,10 +3066,11 @@
     {
       "id": "openai/o4-mini-high",
       "name": "OpenAI: o4 Mini High",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.275,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.275
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -2926,10 +3085,11 @@
     {
       "id": "poolside/laguna-s-2.1",
       "name": "Poolside: Laguna S 2.1",
-      "cost_per_1m_in": 0.09,
-      "cost_per_1m_out": 0.18,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.009,
+      "pricing": {
+        "input": 0.09,
+        "output": 0.18,
+        "cache_hit": 0.009
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -2944,10 +3104,10 @@
     {
       "id": "poolside/laguna-s-2.1:free",
       "name": "Poolside: Laguna S 2.1 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -2962,10 +3122,11 @@
     {
       "id": "poolside/laguna-xs-2.1",
       "name": "Poolside: Laguna XS 2.1",
-      "cost_per_1m_in": 0.06,
-      "cost_per_1m_out": 0.12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.06,
+        "output": 0.12,
+        "cache_hit": 0.03
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -2980,10 +3141,10 @@
     {
       "id": "poolside/laguna-xs-2.1:free",
       "name": "Poolside: Laguna XS 2.1 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -2998,10 +3159,10 @@
     {
       "id": "qwen/qwen-2.5-72b-instruct",
       "name": "Qwen2.5 72B Instruct",
-      "cost_per_1m_in": 0.36,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.36,
+        "output": 0.4
+      },
       "context_window": 32768,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -3010,10 +3171,10 @@
     {
       "id": "qwen/qwen-plus-2025-07-28",
       "name": "Qwen: Qwen Plus 0728",
-      "cost_per_1m_in": 0.26,
-      "cost_per_1m_out": 0.78,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.26,
+        "output": 0.78
+      },
       "context_window": 1000000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -3022,10 +3183,12 @@
     {
       "id": "qwen/qwen-plus",
       "name": "Qwen: Qwen-Plus",
-      "cost_per_1m_in": 0.26,
-      "cost_per_1m_out": 0.78,
-      "cost_per_1m_in_cached": 0.325,
-      "cost_per_1m_out_cached": 0.052,
+      "pricing": {
+        "input": 0.26,
+        "output": 0.78,
+        "cache_create": 0.325,
+        "cache_hit": 0.052
+      },
       "context_window": 1000000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -3034,10 +3197,10 @@
     {
       "id": "qwen/qwen-2.5-7b-instruct",
       "name": "Qwen: Qwen2.5 7B Instruct",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.2
+      },
       "context_window": 32768,
       "default_max_tokens": 14745,
       "can_reason": false,
@@ -3046,10 +3209,10 @@
     {
       "id": "qwen/qwen3-14b",
       "name": "Qwen: Qwen3 14B",
-      "cost_per_1m_in": 0.2275,
-      "cost_per_1m_out": 0.91,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2275,
+        "output": 0.91
+      },
       "context_window": 131072,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -3064,10 +3227,10 @@
     {
       "id": "qwen/qwen3-235b-a22b",
       "name": "Qwen: Qwen3 235B A22B",
-      "cost_per_1m_in": 0.455,
-      "cost_per_1m_out": 1.82,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.455,
+        "output": 1.82
+      },
       "context_window": 131072,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -3082,10 +3245,10 @@
     {
       "id": "qwen/qwen3-235b-a22b-2507",
       "name": "Qwen: Qwen3 235B A22B Instruct 2507",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 0.88,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.22,
+        "output": 0.88
+      },
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -3094,10 +3257,10 @@
     {
       "id": "qwen/qwen3-235b-a22b-thinking-2507",
       "name": "Qwen: Qwen3 235B A22B Thinking 2507",
-      "cost_per_1m_in": 0.23,
-      "cost_per_1m_out": 2.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.23,
+        "output": 2.3
+      },
       "context_window": 131072,
       "default_max_tokens": 58982,
       "can_reason": true,
@@ -3112,10 +3275,10 @@
     {
       "id": "qwen/qwen3-30b-a3b",
       "name": "Qwen: Qwen3 30B A3B",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.52,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.13,
+        "output": 0.52
+      },
       "context_window": 131072,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -3130,10 +3293,11 @@
     {
       "id": "qwen/qwen3-30b-a3b-instruct-2507",
       "name": "Qwen: Qwen3 30B A3B Instruct 2507",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.3,
+        "cache_hit": 0.1
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
@@ -3142,10 +3306,10 @@
     {
       "id": "qwen/qwen3-30b-a3b-thinking-2507",
       "name": "Qwen: Qwen3 30B A3B Thinking 2507",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 2.4
+      },
       "context_window": 81920,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -3160,10 +3324,10 @@
     {
       "id": "qwen/qwen3-32b",
       "name": "Qwen: Qwen3 32B",
-      "cost_per_1m_in": 0.08,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.08,
+        "output": 0.28
+      },
       "context_window": 40960,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -3178,10 +3342,10 @@
     {
       "id": "qwen/qwen3-8b",
       "name": "Qwen: Qwen3 8B",
-      "cost_per_1m_in": 0.117,
-      "cost_per_1m_out": 0.455,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.117,
+        "output": 0.455
+      },
       "context_window": 131072,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -3196,10 +3360,10 @@
     {
       "id": "qwen/qwen3-coder-30b-a3b-instruct",
       "name": "Qwen: Qwen3 Coder 30B A3B Instruct",
-      "cost_per_1m_in": 0.2925,
-      "cost_per_1m_out": 1.4625,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2925,
+        "output": 1.4625
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -3208,10 +3372,10 @@
     {
       "id": "qwen/qwen3-coder",
       "name": "Qwen: Qwen3 Coder 480B A35B",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.22,
+        "output": 1.8
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -3220,10 +3384,12 @@
     {
       "id": "qwen/qwen3-coder-flash",
       "name": "Qwen: Qwen3 Coder Flash",
-      "cost_per_1m_in": 0.195,
-      "cost_per_1m_out": 0.975,
-      "cost_per_1m_in_cached": 0.24375,
-      "cost_per_1m_out_cached": 0.039,
+      "pricing": {
+        "input": 0.195,
+        "output": 0.975,
+        "cache_create": 0.24375,
+        "cache_hit": 0.039
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -3232,10 +3398,11 @@
     {
       "id": "qwen/qwen3-coder-next",
       "name": "Qwen: Qwen3 Coder Next",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.07,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.8,
+        "cache_hit": 0.07
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
@@ -3244,10 +3411,12 @@
     {
       "id": "qwen/qwen3-coder-plus",
       "name": "Qwen: Qwen3 Coder Plus",
-      "cost_per_1m_in": 0.65,
-      "cost_per_1m_out": 3.25,
-      "cost_per_1m_in_cached": 0.8125,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 0.65,
+        "output": 3.25,
+        "cache_create": 0.8125,
+        "cache_hit": 0.13
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -3256,10 +3425,12 @@
     {
       "id": "qwen/qwen3-max",
       "name": "Qwen: Qwen3 Max",
-      "cost_per_1m_in": 0.78,
-      "cost_per_1m_out": 3.9,
-      "cost_per_1m_in_cached": 0.975,
-      "cost_per_1m_out_cached": 0.156,
+      "pricing": {
+        "input": 0.78,
+        "output": 3.9,
+        "cache_create": 0.975,
+        "cache_hit": 0.156
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -3268,10 +3439,10 @@
     {
       "id": "qwen/qwen3-max-thinking",
       "name": "Qwen: Qwen3 Max Thinking",
-      "cost_per_1m_in": 0.78,
-      "cost_per_1m_out": 3.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.78,
+        "output": 3.9
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3286,10 +3457,11 @@
     {
       "id": "qwen/qwen3-next-80b-a3b-instruct",
       "name": "Qwen: Qwen3 Next 80B A3B Instruct",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 1.1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.07,
+      "pricing": {
+        "input": 0.1,
+        "output": 1.1,
+        "cache_hit": 0.07
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
@@ -3298,10 +3470,10 @@
     {
       "id": "qwen/qwen3-next-80b-a3b-thinking",
       "name": "Qwen: Qwen3 Next 80B A3B Thinking",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 1.2
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -3316,10 +3488,10 @@
     {
       "id": "qwen/qwen3-vl-235b-a22b-instruct",
       "name": "Qwen: Qwen3 VL 235B A22B Instruct",
-      "cost_per_1m_in": 0.26,
-      "cost_per_1m_out": 1.04,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.26,
+        "output": 1.04
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -3328,10 +3500,10 @@
     {
       "id": "qwen/qwen3-vl-235b-a22b-thinking",
       "name": "Qwen: Qwen3 VL 235B A22B Thinking",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 4
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -3346,10 +3518,10 @@
     {
       "id": "qwen/qwen3-vl-30b-a3b-instruct",
       "name": "Qwen: Qwen3 VL 30B A3B Instruct",
-      "cost_per_1m_in": 0.29,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.29,
+        "output": 1
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
@@ -3358,10 +3530,10 @@
     {
       "id": "qwen/qwen3-vl-30b-a3b-thinking",
       "name": "Qwen: Qwen3 VL 30B A3B Thinking",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 2.4
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -3376,10 +3548,10 @@
     {
       "id": "qwen/qwen3-vl-32b-instruct",
       "name": "Qwen: Qwen3 VL 32B Instruct",
-      "cost_per_1m_in": 0.104,
-      "cost_per_1m_out": 0.416,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.104,
+        "output": 0.416
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -3388,10 +3560,11 @@
     {
       "id": "qwen/qwen3-vl-8b-instruct",
       "name": "Qwen: Qwen3 VL 8B Instruct",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.12,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.75,
+        "cache_hit": 0.12
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
@@ -3400,10 +3573,10 @@
     {
       "id": "qwen/qwen3-vl-8b-thinking",
       "name": "Qwen: Qwen3 VL 8B Thinking",
-      "cost_per_1m_in": 0.18,
-      "cost_per_1m_out": 2.1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.18,
+        "output": 2.1
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -3418,10 +3591,10 @@
     {
       "id": "qwen/qwen3.5-397b-a17b",
       "name": "Qwen: Qwen3.5 397B A17B",
-      "cost_per_1m_in": 0.39,
-      "cost_per_1m_out": 2.34,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.39,
+        "output": 2.34
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3436,10 +3609,10 @@
     {
       "id": "qwen/qwen3.5-plus-02-15",
       "name": "Qwen: Qwen3.5 Plus 2026-02-15",
-      "cost_per_1m_in": 0.26,
-      "cost_per_1m_out": 1.56,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.26,
+        "output": 1.56
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3454,10 +3627,11 @@
     {
       "id": "qwen/qwen3.5-plus-20260420",
       "name": "Qwen: Qwen3.5 Plus 2026-04-20",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0.375,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.8,
+        "cache_create": 0.375
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3472,10 +3646,10 @@
     {
       "id": "qwen/qwen3.5-122b-a10b",
       "name": "Qwen: Qwen3.5-122B-A10B",
-      "cost_per_1m_in": 0.26,
-      "cost_per_1m_out": 2.08,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.26,
+        "output": 2.08
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3490,10 +3664,10 @@
     {
       "id": "qwen/qwen3.5-27b",
       "name": "Qwen: Qwen3.5-27B",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.4
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3508,10 +3682,10 @@
     {
       "id": "qwen/qwen3.5-35b-a3b",
       "name": "Qwen: Qwen3.5-35B-A3B",
-      "cost_per_1m_in": 0.08,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.08,
+        "output": 0.75
+      },
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -3526,10 +3700,10 @@
     {
       "id": "qwen/qwen3.5-9b",
       "name": "Qwen: Qwen3.5-9B",
-      "cost_per_1m_in": 0.17,
-      "cost_per_1m_out": 0.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.17,
+        "output": 0.25
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": true,
@@ -3544,10 +3718,10 @@
     {
       "id": "qwen/qwen3.5-flash-02-23",
       "name": "Qwen: Qwen3.5-Flash",
-      "cost_per_1m_in": 0.065,
-      "cost_per_1m_out": 0.26,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.065,
+        "output": 0.26
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3562,10 +3736,10 @@
     {
       "id": "qwen/qwen3.6-27b",
       "name": "Qwen: Qwen3.6 27B",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 2.7,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.45,
+        "output": 2.7
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3580,10 +3754,11 @@
     {
       "id": "qwen/qwen3.6-35b-a3b",
       "name": "Qwen: Qwen3.6 35B A3B",
-      "cost_per_1m_in": 0.186,
-      "cost_per_1m_out": 1.11375,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.186,
+      "pricing": {
+        "input": 0.186,
+        "output": 1.11375,
+        "cache_hit": 0.186
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3598,10 +3773,11 @@
     {
       "id": "qwen/qwen3.6-flash",
       "name": "Qwen: Qwen3.6 Flash",
-      "cost_per_1m_in": 0.1875,
-      "cost_per_1m_out": 1.125,
-      "cost_per_1m_in_cached": 0.23438,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1875,
+        "output": 1.125,
+        "cache_create": 0.23438
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3616,10 +3792,11 @@
     {
       "id": "qwen/qwen3.6-max-preview",
       "name": "Qwen: Qwen3.6 Max Preview",
-      "cost_per_1m_in": 1.027,
-      "cost_per_1m_out": 6.162,
-      "cost_per_1m_in_cached": 1.28375,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.027,
+        "output": 6.162,
+        "cache_create": 1.28375
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3634,10 +3811,11 @@
     {
       "id": "qwen/qwen3.6-plus",
       "name": "Qwen: Qwen3.6 Plus",
-      "cost_per_1m_in": 0.325,
-      "cost_per_1m_out": 1.95,
-      "cost_per_1m_in_cached": 0.40625,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.325,
+        "output": 1.95,
+        "cache_create": 0.40625
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3652,10 +3830,12 @@
     {
       "id": "qwen/qwen3.7-flash",
       "name": "Qwen: Qwen3.7 Flash",
-      "cost_per_1m_in": 0.03,
-      "cost_per_1m_out": 0.13,
-      "cost_per_1m_in_cached": 0.038,
-      "cost_per_1m_out_cached": 0.006,
+      "pricing": {
+        "input": 0.03,
+        "output": 0.13,
+        "cache_create": 0.038,
+        "cache_hit": 0.006
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3670,10 +3850,12 @@
     {
       "id": "qwen/qwen3.7-max",
       "name": "Qwen: Qwen3.7 Max",
-      "cost_per_1m_in": 1.475,
-      "cost_per_1m_out": 4.425,
-      "cost_per_1m_in_cached": 1.84375,
-      "cost_per_1m_out_cached": 0.295,
+      "pricing": {
+        "input": 1.475,
+        "output": 4.425,
+        "cache_create": 1.84375,
+        "cache_hit": 0.295
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -3688,10 +3870,12 @@
     {
       "id": "qwen/qwen3.7-plus",
       "name": "Qwen: Qwen3.7 Plus",
-      "cost_per_1m_in": 0.32,
-      "cost_per_1m_out": 1.28,
-      "cost_per_1m_in_cached": 0.4,
-      "cost_per_1m_out_cached": 0.064,
+      "pricing": {
+        "input": 0.32,
+        "output": 1.28,
+        "cache_create": 0.4,
+        "cache_hit": 0.064
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -3706,10 +3890,11 @@
     {
       "id": "qwen/qwen3.8-2.4t-a95b",
       "name": "Qwen: Qwen3.8 2.4T A95B",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -3724,10 +3909,12 @@
     {
       "id": "qwen/qwen3.8-27b",
       "name": "Qwen: Qwen3.8 27B",
-      "cost_per_1m_in": 0.425,
-      "cost_per_1m_out": 2.55,
-      "cost_per_1m_in_cached": 0.53125,
-      "cost_per_1m_out_cached": 0.085,
+      "pricing": {
+        "input": 0.425,
+        "output": 2.55,
+        "cache_create": 0.53125,
+        "cache_hit": 0.085
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -3742,10 +3929,12 @@
     {
       "id": "qwen/qwen3.8-flash",
       "name": "Qwen: Qwen3.8 Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.47,
-      "cost_per_1m_in_cached": 0.2,
-      "cost_per_1m_out_cached": 0.016,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.47,
+        "cache_create": 0.2,
+        "cache_hit": 0.016
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -3760,10 +3949,12 @@
     {
       "id": "qwen/qwen3.8-max",
       "name": "Qwen: Qwen3.8 Max",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_create": 2.5,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -3778,10 +3969,10 @@
     {
       "id": "relace/relace-search",
       "name": "Relace: Relace Search",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 3
+      },
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -3790,10 +3981,11 @@
     {
       "id": "sakana/fugu-ultra",
       "name": "Sakana: Fugu Ultra",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 30,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -3808,10 +4000,11 @@
     {
       "id": "sakana/sakana-namazu",
       "name": "Sakana: Sakana Namazu",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_hit": 0.15
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3826,10 +4019,11 @@
     {
       "id": "x-ai/grok-4.20",
       "name": "SpaceXAI: Grok 4.20",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 900000,
       "can_reason": true,
@@ -3844,10 +4038,11 @@
     {
       "id": "x-ai/grok-4.3",
       "name": "SpaceXAI: Grok 4.3",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 450000,
       "can_reason": true,
@@ -3862,10 +4057,11 @@
     {
       "id": "x-ai/grok-4.5",
       "name": "SpaceXAI: Grok 4.5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.3
+      },
       "context_window": 500000,
       "default_max_tokens": 225000,
       "can_reason": true,
@@ -3880,10 +4076,11 @@
     {
       "id": "x-ai/grok-4.6",
       "name": "SpaceXAI: Grok 4.6",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.5
+      },
       "context_window": 500000,
       "default_max_tokens": 225000,
       "can_reason": true,
@@ -3898,10 +4095,11 @@
     {
       "id": "x-ai/grok-build-0.1",
       "name": "SpaceXAI: Grok Build 0.1",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1,
+        "output": 2,
+        "cache_hit": 0.2
+      },
       "context_window": 256000,
       "default_max_tokens": 115200,
       "can_reason": true,
@@ -3916,10 +4114,10 @@
     {
       "id": "stepfun/step-3.5-flash",
       "name": "StepFun: Step 3.5 Flash",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.3
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3934,10 +4132,11 @@
     {
       "id": "stepfun/step-3.7-flash",
       "name": "StepFun: Step 3.7 Flash",
-      "cost_per_1m_in": 0.16,
-      "cost_per_1m_out": 0.92,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.032,
+      "pricing": {
+        "input": 0.16,
+        "output": 0.92,
+        "cache_hit": 0.032
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -3952,10 +4151,11 @@
     {
       "id": "tencent/hy3",
       "name": "Tencent: Hy3",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.58,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.035,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.58,
+        "cache_hit": 0.035
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": true,
@@ -3970,10 +4170,11 @@
     {
       "id": "tencent/hy3-preview",
       "name": "Tencent: Hy3 preview",
-      "cost_per_1m_in": 0.18,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.18,
+        "output": 0.6,
+        "cache_hit": 0.06
+      },
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": true,
@@ -3988,10 +4189,11 @@
     {
       "id": "tencent/hy4-preview",
       "name": "Tencent: Hy4 preview",
-      "cost_per_1m_in": 0.834,
-      "cost_per_1m_out": 2.501,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.042,
+      "pricing": {
+        "input": 0.834,
+        "output": 2.501,
+        "cache_hit": 0.042
+      },
       "context_window": 1048576,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -4006,10 +4208,10 @@
     {
       "id": "thedrummer/unslopnemo-12b",
       "name": "TheDrummer: UnslopNemo 12B",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 0.4
+      },
       "context_window": 32768,
       "default_max_tokens": 13107,
       "can_reason": false,
@@ -4018,10 +4220,11 @@
     {
       "id": "thinkingmachines/inkling",
       "name": "Thinking Machines: Inkling",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 4.05,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.17,
+      "pricing": {
+        "input": 1,
+        "output": 4.05,
+        "cache_hit": 0.17
+      },
       "context_window": 524288,
       "default_max_tokens": 235929,
       "can_reason": true,
@@ -4036,10 +4239,10 @@
     {
       "id": "thinkingmachines/inkling:free",
       "name": "Thinking Machines: Inkling (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -4054,10 +4257,11 @@
     {
       "id": "thinkingmachines/inkling-small",
       "name": "Thinking Machines: Inkling Small",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.5,
+        "output": 1.2,
+        "cache_hit": 0.1
+      },
       "context_window": 1048576,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -4072,10 +4276,10 @@
     {
       "id": "thinkingmachines/inkling-small:free",
       "name": "Thinking Machines: Inkling Small (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -4090,10 +4294,11 @@
     {
       "id": "upstage/solar-pro-3",
       "name": "Upstage: Solar Pro 3",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.015,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.015
+      },
       "context_window": 131072,
       "default_max_tokens": 58982,
       "can_reason": true,
@@ -4108,10 +4313,11 @@
     {
       "id": "upstage/solar-pro4",
       "name": "Upstage: Solar Pro 4",
-      "cost_per_1m_in": 0.03,
-      "cost_per_1m_out": 0.12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.006,
+      "pricing": {
+        "input": 0.03,
+        "output": 0.12,
+        "cache_hit": 0.006
+      },
       "context_window": 524288,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -4126,10 +4332,11 @@
     {
       "id": "xiaomi/mimo-v2.5",
       "name": "Xiaomi: MiMo-V2.5",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0028,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_hit": 0.0028
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -4144,10 +4351,11 @@
     {
       "id": "xiaomi/mimo-v2.5-pro",
       "name": "Xiaomi: MiMo-V2.5-Pro",
-      "cost_per_1m_in": 0.39,
-      "cost_per_1m_out": 1.17,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.078,
+      "pricing": {
+        "input": 0.39,
+        "output": 1.17,
+        "cache_hit": 0.078
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -4162,10 +4370,11 @@
     {
       "id": "z-ai/glm-4.5",
       "name": "Z.ai: GLM 4.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_hit": 0.11
+      },
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
@@ -4180,10 +4389,11 @@
     {
       "id": "z-ai/glm-4.5-air",
       "name": "Z.ai: GLM 4.5 Air",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.85,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.13,
+        "output": 0.85,
+        "cache_hit": 0.025
+      },
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
@@ -4198,10 +4408,11 @@
     {
       "id": "z-ai/glm-4.5v",
       "name": "Z.ai: GLM 4.5V",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 1.8,
+        "cache_hit": 0.11
+      },
       "context_window": 65536,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -4216,10 +4427,11 @@
     {
       "id": "z-ai/glm-4.6",
       "name": "Z.ai: GLM 4.6",
-      "cost_per_1m_in": 0.55,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.11,
+      "pricing": {
+        "input": 0.55,
+        "output": 2.2,
+        "cache_hit": 0.11
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -4234,10 +4446,11 @@
     {
       "id": "z-ai/glm-4.6v",
       "name": "Z.ai: GLM 4.6V",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.055,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.9,
+        "cache_hit": 0.055
+      },
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -4252,10 +4465,11 @@
     {
       "id": "z-ai/glm-4.7",
       "name": "Z.ai: GLM 4.7",
-      "cost_per_1m_in": 0.54,
-      "cost_per_1m_out": 1.98,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.099,
+      "pricing": {
+        "input": 0.54,
+        "output": 1.98,
+        "cache_hit": 0.099
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -4270,10 +4484,11 @@
     {
       "id": "z-ai/glm-4.7-flash",
       "name": "Z.ai: GLM 4.7 Flash",
-      "cost_per_1m_in": 0.06,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.06,
+        "output": 0.4,
+        "cache_hit": 0.01
+      },
       "context_window": 202752,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -4288,10 +4503,11 @@
     {
       "id": "z-ai/glm-5",
       "name": "Z.ai: GLM 5",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 2.55,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 0.95,
+        "output": 2.55,
+        "cache_hit": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -4306,10 +4522,11 @@
     {
       "id": "z-ai/glm-5-turbo",
       "name": "Z.ai: GLM 5 Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 4,
+        "cache_hit": 0.24
+      },
       "context_window": 202752,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -4324,10 +4541,11 @@
     {
       "id": "z-ai/glm-5.1",
       "name": "Z.ai: GLM 5.1",
-      "cost_per_1m_in": 1.19,
-      "cost_per_1m_out": 3.74,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.6,
+      "pricing": {
+        "input": 1.19,
+        "output": 3.74,
+        "cache_hit": 0.6
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -4342,10 +4560,11 @@
     {
       "id": "z-ai/glm-5.2",
       "name": "Z.ai: GLM 5.2",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.115,
+      "pricing": {
+        "input": 0.5,
+        "output": 3.15,
+        "cache_hit": 0.115
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -4360,10 +4579,10 @@
     {
       "id": "z-ai/glm-5.2:free",
       "name": "Z.ai: GLM 5.2 (free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 115200,
       "can_reason": true,
@@ -4378,10 +4597,11 @@
     {
       "id": "z-ai/glm-5.3",
       "name": "Z.ai: GLM 5.3",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.26,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.26
+      },
       "context_window": 1310720,
       "default_max_tokens": 589824,
       "can_reason": true,
@@ -4396,10 +4616,11 @@
     {
       "id": "z-ai/glm-5.3-flash",
       "name": "Z.ai: GLM 5.3 Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.5,
+        "cache_hit": 0.03
+      },
       "context_window": 1310720,
       "default_max_tokens": 589824,
       "can_reason": true,
@@ -4414,10 +4635,11 @@
     {
       "id": "z-ai/glm-5v-turbo",
       "name": "Z.ai: GLM 5V Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 4,
+        "cache_hit": 0.24
+      },
       "context_window": 202752,
       "default_max_tokens": 65536,
       "can_reason": true,

--- a/internal/providers/configs/openrouter.json
+++ b/internal/providers/configs/openrouter.json
@@ -24,7 +24,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "aion-labs/aion-3.0",
@@ -43,7 +45,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "aion-labs/aion-3.0-mini",
@@ -62,7 +66,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "amazon/nova-2-lite-v1",
@@ -80,7 +86,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "amazon/nova-lite-v1",
@@ -92,7 +100,9 @@
       "context_window": 300000,
       "default_max_tokens": 2560,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "amazon/nova-micro-v1",
@@ -104,7 +114,9 @@
       "context_window": 128000,
       "default_max_tokens": 2560,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "amazon/nova-premier-v1",
@@ -117,7 +129,9 @@
       "context_window": 1000000,
       "default_max_tokens": 16000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "amazon/nova-pro-v1",
@@ -129,7 +143,9 @@
       "context_window": 300000,
       "default_max_tokens": 2560,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-3-haiku",
@@ -143,7 +159,9 @@
       "context_window": 200000,
       "default_max_tokens": 2048,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-fable-5",
@@ -163,7 +181,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-fable-5.1",
@@ -183,7 +203,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-haiku-4.5",
@@ -203,7 +225,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4",
@@ -223,7 +247,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4.1",
@@ -243,7 +269,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4.5",
@@ -263,7 +291,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4.6",
@@ -283,7 +313,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4.7",
@@ -303,7 +335,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4.8",
@@ -323,7 +357,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-sonnet-4",
@@ -343,7 +379,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-sonnet-4.5",
@@ -363,7 +401,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-sonnet-4.6",
@@ -383,7 +423,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-sonnet-5",
@@ -403,7 +445,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "arcee-ai/trinity-large-thinking",
@@ -422,7 +466,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "bytedance-seed/seed-1.6",
@@ -440,7 +486,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "bytedance-seed/seed-1.6-flash",
@@ -458,7 +506,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "bytedance-seed/seed-2-1-turbo",
@@ -476,7 +526,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "bytedance-seed/seed-2.0-code",
@@ -494,7 +546,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "bytedance-seed/seed-2.0-lite",
@@ -512,7 +566,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "bytedance-seed/seed-2.0-mini",
@@ -530,7 +586,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-5",
@@ -550,7 +608,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "cohere/command-r-08-2024",
@@ -562,7 +622,9 @@
       "context_window": 128000,
       "default_max_tokens": 2000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "cohere/command-r-plus-08-2024",
@@ -574,7 +636,9 @@
       "context_window": 128000,
       "default_max_tokens": 2000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "cohere/north-mini-code:free",
@@ -592,7 +656,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-chat",
@@ -604,7 +670,9 @@
       "context_window": 163840,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-chat-v3-0324",
@@ -616,7 +684,9 @@
       "context_window": 163840,
       "default_max_tokens": 73728,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-chat-v3.1",
@@ -635,7 +705,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v3.1-terminus",
@@ -653,7 +725,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v3.2",
@@ -672,7 +746,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v3.2-exp",
@@ -690,7 +766,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-flash",
@@ -709,7 +787,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-flash-0731",
@@ -728,7 +808,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-flash-vision-exp",
@@ -747,7 +829,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek/deepseek-v4-pro",
@@ -766,7 +850,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-pro-0813",
@@ -785,7 +871,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-r1",
@@ -803,7 +891,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-r1-0528",
@@ -821,7 +911,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "dots-studio/dots-3-note-preview:free",
@@ -839,7 +931,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-2.5-flash",
@@ -859,7 +953,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-2.5-flash-lite",
@@ -879,7 +975,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-2.5-pro",
@@ -899,7 +997,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-2.5-pro-preview-05-06",
@@ -919,7 +1019,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-2.5-pro-preview",
@@ -939,7 +1041,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3-flash-preview",
@@ -959,7 +1063,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.1-flash-lite",
@@ -979,7 +1085,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.1-flash-lite-preview",
@@ -999,7 +1107,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.1-pro-preview",
@@ -1019,7 +1129,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.1-pro-preview-customtools",
@@ -1039,7 +1151,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.5-flash",
@@ -1059,7 +1173,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.5-flash-lite",
@@ -1079,7 +1195,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.6-flash",
@@ -1099,7 +1217,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.7-flash",
@@ -1119,7 +1239,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.8-flash",
@@ -1139,7 +1261,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemma-3-12b-it",
@@ -1151,7 +1275,9 @@
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemma-3-27b-it",
@@ -1163,7 +1289,9 @@
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemma-4-26b-a4b-it",
@@ -1181,7 +1309,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemma-4-26b-a4b-it:free",
@@ -1199,7 +1329,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemma-4-31b-it",
@@ -1217,7 +1349,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemma-4-31b-it:free",
@@ -1235,7 +1369,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "ibm-granite/granite-4.1-8b",
@@ -1248,7 +1384,9 @@
       "context_window": 131072,
       "default_max_tokens": 58982,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "ibm-granite/granite-4.2-8b",
@@ -1267,7 +1405,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "inception/mercury-2",
@@ -1286,7 +1426,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "inception/mercury-2.5-preview",
@@ -1305,7 +1447,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kwaipilot/kat-coder-pro-v2",
@@ -1318,7 +1462,9 @@
       "context_window": 262144,
       "default_max_tokens": 72000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kwaipilot/kat-coder-pro-v2.5",
@@ -1331,7 +1477,9 @@
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "inclusionai/ling-3.0-flash-fin:free",
@@ -1349,7 +1497,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "inclusionai/ling-3.0-flash",
@@ -1368,7 +1518,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "liquid/lfm-2.5-2.6b:free",
@@ -1386,7 +1538,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meituan/longcat-2.0",
@@ -1405,7 +1559,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta-llama/llama-3.1-70b-instruct",
@@ -1417,7 +1573,9 @@
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta-llama/llama-3.1-8b-instruct",
@@ -1430,7 +1588,9 @@
       "context_window": 131072,
       "default_max_tokens": 58982,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta-llama/llama-3.3-70b-instruct",
@@ -1443,7 +1603,9 @@
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta-llama/llama-4-maverick",
@@ -1455,7 +1617,9 @@
       "context_window": 524288,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta-llama/llama-4-scout",
@@ -1467,7 +1631,9 @@
       "context_window": 1310720,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-glimmer-30b",
@@ -1486,7 +1652,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-spark-1.1",
@@ -1505,7 +1673,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-spark-1.2",
@@ -1524,7 +1694,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-spark-1.2-contributor",
@@ -1543,7 +1715,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-spark-1.3",
@@ -1562,7 +1736,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-spark-1.3-contributor",
@@ -1581,7 +1757,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax/minimax-m2",
@@ -1599,7 +1777,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.1",
@@ -1618,7 +1798,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.5",
@@ -1637,7 +1819,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.7",
@@ -1656,7 +1840,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.7:free",
@@ -1674,7 +1860,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m3",
@@ -1693,7 +1881,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax/minimax-m3:free",
@@ -1711,7 +1901,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistralai/mistral-large",
@@ -1724,7 +1916,9 @@
       "context_window": 128000,
       "default_max_tokens": 51200,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistralai/mistral-large-2407",
@@ -1737,7 +1931,9 @@
       "context_window": 131072,
       "default_max_tokens": 52428,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistralai/codestral-2508",
@@ -1750,7 +1946,9 @@
       "context_window": 256000,
       "default_max_tokens": 102400,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistralai/devstral-2512",
@@ -1763,7 +1961,9 @@
       "context_window": 262144,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistralai/ministral-14b-2512",
@@ -1776,7 +1976,9 @@
       "context_window": 262144,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistralai/ministral-3b-2512",
@@ -1789,7 +1991,9 @@
       "context_window": 131072,
       "default_max_tokens": 52428,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistralai/ministral-8b-2512",
@@ -1802,7 +2006,9 @@
       "context_window": 262144,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistralai/mistral-large-2512",
@@ -1815,7 +2021,9 @@
       "context_window": 262144,
       "default_max_tokens": 104857,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistralai/mistral-medium-3",
@@ -1828,7 +2036,9 @@
       "context_window": 131072,
       "default_max_tokens": 52428,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistralai/mistral-medium-3.1",
@@ -1841,7 +2051,9 @@
       "context_window": 131072,
       "default_max_tokens": 52428,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistralai/mistral-medium-3-5",
@@ -1859,7 +2071,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistralai/mistral-nemo",
@@ -1872,7 +2086,9 @@
       "context_window": 128000,
       "default_max_tokens": 51200,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistralai/mistral-small-3.2-24b-instruct",
@@ -1884,7 +2100,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistralai/mistral-small-2603",
@@ -1903,7 +2121,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistralai/mixtral-8x22b-instruct",
@@ -1916,7 +2136,9 @@
       "context_window": 65536,
       "default_max_tokens": 26214,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistralai/mistral-saba",
@@ -1929,7 +2151,9 @@
       "context_window": 32768,
       "default_max_tokens": 13107,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistralai/voxtral-small-24b-2507",
@@ -1942,7 +2166,9 @@
       "context_window": 32768,
       "default_max_tokens": 13107,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/kimi-k2",
@@ -1954,7 +2180,9 @@
       "context_window": 131072,
       "default_max_tokens": 50176,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/kimi-k2-0905",
@@ -1966,7 +2194,9 @@
       "context_window": 262144,
       "default_max_tokens": 50176,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/kimi-k2-thinking",
@@ -1984,7 +2214,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/kimi-k2.5",
@@ -2002,7 +2234,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k2.6",
@@ -2021,7 +2255,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k2.7-code",
@@ -2040,7 +2276,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k3",
@@ -2059,7 +2297,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nvidia/nemotron-3-nano-30b-a3b",
@@ -2078,7 +2318,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
@@ -2096,7 +2338,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nvidia/nemotron-3-super-120b-a12b",
@@ -2115,7 +2359,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/nemotron-3-super-120b-a12b:free",
@@ -2133,7 +2379,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/nemotron-3-ultra-550b-a55b",
@@ -2152,7 +2400,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/nemotron-3-ultra-550b-a55b:free",
@@ -2170,7 +2420,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/nemotron-3.5-lightning",
@@ -2189,7 +2441,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/nemotron-3.5-lightning:free",
@@ -2207,7 +2461,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nex-agi/nex-n2-mini",
@@ -2226,7 +2482,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nex-agi/nex-n2-pro",
@@ -2245,7 +2503,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-audio",
@@ -2257,7 +2517,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-audio-mini",
@@ -2269,7 +2531,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-chat-latest",
@@ -2282,7 +2546,9 @@
       "context_window": 400000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4-turbo",
@@ -2294,7 +2560,9 @@
       "context_window": 128000,
       "default_max_tokens": 2048,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4-turbo-preview",
@@ -2306,7 +2574,9 @@
       "context_window": 128000,
       "default_max_tokens": 2048,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-4.1",
@@ -2319,7 +2589,9 @@
       "context_window": 1047576,
       "default_max_tokens": 471409,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4.1-mini",
@@ -2332,7 +2604,9 @@
       "context_window": 1047576,
       "default_max_tokens": 471409,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4.1-nano",
@@ -2345,7 +2619,9 @@
       "context_window": 1047576,
       "default_max_tokens": 471409,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4o",
@@ -2357,7 +2633,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4o-2024-05-13",
@@ -2369,7 +2647,9 @@
       "context_window": 128000,
       "default_max_tokens": 2048,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4o-2024-08-06",
@@ -2382,7 +2662,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4o-2024-11-20",
@@ -2395,7 +2677,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4o-mini",
@@ -2408,7 +2692,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4o-mini-2024-07-18",
@@ -2421,7 +2707,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5",
@@ -2440,7 +2728,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5-mini",
@@ -2459,7 +2749,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5-nano",
@@ -2478,7 +2770,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5-pro",
@@ -2496,7 +2790,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.1",
@@ -2515,7 +2811,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.1-codex",
@@ -2534,7 +2832,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.1-codex-max",
@@ -2553,7 +2853,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.1-codex-mini",
@@ -2572,7 +2874,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.2",
@@ -2591,7 +2895,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.2-chat",
@@ -2604,7 +2910,9 @@
       "context_window": 128000,
       "default_max_tokens": 16000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.2-pro",
@@ -2622,7 +2930,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.2-codex",
@@ -2641,7 +2951,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.3-codex",
@@ -2660,7 +2972,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.4",
@@ -2679,7 +2993,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.4-mini",
@@ -2698,7 +3014,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.4-nano",
@@ -2717,7 +3035,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.4-pro",
@@ -2735,7 +3055,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.5",
@@ -2754,7 +3076,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.5-pro",
@@ -2772,7 +3096,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-luna",
@@ -2792,7 +3118,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-luna-pro",
@@ -2812,7 +3140,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-sol",
@@ -2832,7 +3162,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-sol-pro",
@@ -2852,7 +3184,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-terra",
@@ -2872,7 +3206,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-terra-pro",
@@ -2892,7 +3228,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -2910,7 +3248,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-20b",
@@ -2929,7 +3269,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-safeguard-20b",
@@ -2948,7 +3290,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/o1",
@@ -2967,7 +3311,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/o3",
@@ -2986,7 +3332,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/o3-mini",
@@ -3005,7 +3353,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/o3-mini-high",
@@ -3024,7 +3374,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/o3-pro",
@@ -3042,7 +3394,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/o4-mini",
@@ -3061,7 +3415,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/o4-mini-high",
@@ -3080,7 +3436,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "poolside/laguna-s-2.1",
@@ -3099,7 +3457,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "poolside/laguna-s-2.1:free",
@@ -3117,7 +3477,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "poolside/laguna-xs-2.1",
@@ -3136,7 +3498,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "poolside/laguna-xs-2.1:free",
@@ -3154,7 +3518,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen-2.5-72b-instruct",
@@ -3166,7 +3532,9 @@
       "context_window": 32768,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen-plus-2025-07-28",
@@ -3178,7 +3546,9 @@
       "context_window": 1000000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen-plus",
@@ -3192,7 +3562,9 @@
       "context_window": 1000000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen-2.5-7b-instruct",
@@ -3204,7 +3576,9 @@
       "context_window": 32768,
       "default_max_tokens": 14745,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-14b",
@@ -3222,7 +3596,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-235b-a22b",
@@ -3240,7 +3616,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-235b-a22b-2507",
@@ -3252,7 +3630,9 @@
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-235b-a22b-thinking-2507",
@@ -3270,7 +3650,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-30b-a3b",
@@ -3288,7 +3670,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-30b-a3b-instruct-2507",
@@ -3301,7 +3685,9 @@
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-30b-a3b-thinking-2507",
@@ -3319,7 +3705,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-32b",
@@ -3337,7 +3725,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-8b",
@@ -3355,7 +3745,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-coder-30b-a3b-instruct",
@@ -3367,7 +3759,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-coder",
@@ -3379,7 +3773,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-coder-flash",
@@ -3393,7 +3789,9 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-coder-next",
@@ -3406,7 +3804,9 @@
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-coder-plus",
@@ -3420,7 +3820,9 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-max",
@@ -3434,7 +3836,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-max-thinking",
@@ -3452,7 +3856,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-next-80b-a3b-instruct",
@@ -3465,7 +3871,9 @@
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-next-80b-a3b-thinking",
@@ -3483,7 +3891,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3-vl-235b-a22b-instruct",
@@ -3495,7 +3905,9 @@
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3-vl-235b-a22b-thinking",
@@ -3513,7 +3925,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3-vl-30b-a3b-instruct",
@@ -3525,7 +3939,9 @@
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3-vl-30b-a3b-thinking",
@@ -3543,7 +3959,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3-vl-32b-instruct",
@@ -3555,7 +3973,9 @@
       "context_window": 131072,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3-vl-8b-instruct",
@@ -3568,7 +3988,9 @@
       "context_window": 262144,
       "default_max_tokens": 117964,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3-vl-8b-thinking",
@@ -3586,7 +4008,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-397b-a17b",
@@ -3604,7 +4028,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-plus-02-15",
@@ -3622,7 +4048,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-plus-20260420",
@@ -3641,7 +4069,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-122b-a10b",
@@ -3659,7 +4089,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-27b",
@@ -3677,7 +4109,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-35b-a3b",
@@ -3695,7 +4129,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-9b",
@@ -3713,7 +4149,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.5-flash-02-23",
@@ -3731,7 +4169,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.6-27b",
@@ -3749,7 +4189,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.6-35b-a3b",
@@ -3768,7 +4210,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.6-flash",
@@ -3787,7 +4231,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.6-max-preview",
@@ -3806,7 +4252,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3.6-plus",
@@ -3825,7 +4273,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.7-flash",
@@ -3845,7 +4295,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.7-max",
@@ -3865,7 +4317,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3.7-plus",
@@ -3885,7 +4339,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.8-2.4t-a95b",
@@ -3904,7 +4360,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen/qwen3.8-27b",
@@ -3924,7 +4382,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.8-flash",
@@ -3944,7 +4404,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen/qwen3.8-max",
@@ -3964,7 +4426,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "relace/relace-search",
@@ -3976,7 +4440,9 @@
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "sakana/fugu-ultra",
@@ -3995,7 +4461,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "sakana/sakana-namazu",
@@ -4014,7 +4482,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "x-ai/grok-4.20",
@@ -4033,7 +4503,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "x-ai/grok-4.3",
@@ -4052,7 +4524,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "x-ai/grok-4.5",
@@ -4071,7 +4545,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "x-ai/grok-4.6",
@@ -4090,7 +4566,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "x-ai/grok-build-0.1",
@@ -4109,7 +4587,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "stepfun/step-3.5-flash",
@@ -4127,7 +4607,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "stepfun/step-3.7-flash",
@@ -4146,7 +4628,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "tencent/hy3",
@@ -4165,7 +4649,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "tencent/hy3-preview",
@@ -4184,7 +4670,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "tencent/hy4-preview",
@@ -4203,7 +4691,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "thedrummer/unslopnemo-12b",
@@ -4215,7 +4705,9 @@
       "context_window": 32768,
       "default_max_tokens": 13107,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "thinkingmachines/inkling",
@@ -4234,7 +4726,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "thinkingmachines/inkling:free",
@@ -4252,7 +4746,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "thinkingmachines/inkling-small",
@@ -4271,7 +4767,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "thinkingmachines/inkling-small:free",
@@ -4289,7 +4787,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "upstage/solar-pro-3",
@@ -4308,7 +4808,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "upstage/solar-pro4",
@@ -4327,7 +4829,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "xiaomi/mimo-v2.5",
@@ -4346,7 +4850,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "xiaomi/mimo-v2.5-pro",
@@ -4365,7 +4871,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-4.5",
@@ -4384,7 +4892,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-4.5-air",
@@ -4403,7 +4913,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-4.5v",
@@ -4422,7 +4934,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "z-ai/glm-4.6",
@@ -4441,7 +4955,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-4.6v",
@@ -4460,7 +4976,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "z-ai/glm-4.7",
@@ -4479,7 +4997,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-4.7-flash",
@@ -4498,7 +5018,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5",
@@ -4517,7 +5039,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5-turbo",
@@ -4536,7 +5060,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5.1",
@@ -4555,7 +5081,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5.2",
@@ -4574,7 +5102,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5.2:free",
@@ -4592,7 +5122,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5.3",
@@ -4611,7 +5143,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5.3-flash",
@@ -4630,7 +5164,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "z-ai/glm-5v-turbo",
@@ -4649,7 +5185,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ],
   "default_headers": {

--- a/internal/providers/configs/pioneer.json
+++ b/internal/providers/configs/pioneer.json
@@ -10,10 +10,10 @@
     {
       "id": "claude-fable-5",
       "name": "Claude Fable 5",
-      "cost_per_1m_in": 11,
-      "cost_per_1m_out": 55,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 11,
+        "output": 55
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -22,10 +22,10 @@
     {
       "id": "claude-haiku-4-5",
       "name": "Claude Haiku 4.5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 5
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": false,
@@ -34,10 +34,10 @@
     {
       "id": "claude-opus-5",
       "name": "Claude Opus 5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 5,
+        "output": 25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -46,10 +46,10 @@
     {
       "id": "claude-opus-5-fast",
       "name": "Claude Opus 5 (Fast)",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 10,
+        "output": 50
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -58,10 +58,10 @@
     {
       "id": "claude-sonnet-5",
       "name": "Claude Sonnet 5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2,
+        "output": 10
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -70,10 +70,10 @@
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -88,10 +88,10 @@
     {
       "id": "fastino/Fastino-Nemotron-3.5-Lightning-Finance",
       "name": "Fastino Nemotron 3.5 Lightning Finance",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 0.5
+      },
       "context_window": 8192,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -100,10 +100,10 @@
     {
       "id": "fastino/Fastino-Nemotron-3.5-Lightning-Healthcare",
       "name": "Fastino Nemotron 3.5 Lightning Healthcare",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 0.5
+      },
       "context_window": 8192,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -112,10 +112,10 @@
     {
       "id": "zai-org/GLM-5.2",
       "name": "GLM 5.2",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -124,10 +124,10 @@
     {
       "id": "gpt-5.5",
       "name": "GPT-5.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 5,
+        "output": 30
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -136,10 +136,10 @@
     {
       "id": "gpt-5.6-luna",
       "name": "GPT-5.6 Luna",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 6
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -148,10 +148,10 @@
     {
       "id": "gpt-5.6-sol",
       "name": "GPT-5.6 Sol",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 5,
+        "output": 30
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -160,10 +160,10 @@
     {
       "id": "gpt-5.6-terra",
       "name": "GPT-5.6 Terra",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 15
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -172,10 +172,10 @@
     {
       "id": "moonshotai/Kimi-K3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -184,10 +184,10 @@
     {
       "id": "moonshotai/Kimi-K3-Fast",
       "name": "Kimi K3 Fast",
-      "cost_per_1m_in": 4.5,
-      "cost_per_1m_out": 22.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 4.5,
+        "output": 22.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -196,10 +196,10 @@
     {
       "id": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16",
       "name": "Nemotron 3.5 Lightning 30B-A3B",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 0.5
+      },
       "context_window": 8192,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -208,10 +208,10 @@
     {
       "id": "HuggingFaceTB/SmolLM2-360M-Instruct",
       "name": "SmolLM2 360M Instruct",
-      "cost_per_1m_in": 0.01,
-      "cost_per_1m_out": 0.01,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.01,
+        "output": 0.01
+      },
       "context_window": 2048,
       "default_max_tokens": 4096,
       "can_reason": false,

--- a/internal/providers/configs/pioneer.json
+++ b/internal/providers/configs/pioneer.json
@@ -17,7 +17,9 @@
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-haiku-4-5",
@@ -29,7 +31,9 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-opus-5",
@@ -41,7 +45,9 @@
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-opus-5-fast",
@@ -53,7 +59,9 @@
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-sonnet-5",
@@ -65,7 +73,9 @@
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-ai/DeepSeek-V4-Flash",
@@ -83,7 +93,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "fastino/Fastino-Nemotron-3.5-Lightning-Finance",
@@ -95,7 +107,9 @@
       "context_window": 8192,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "fastino/Fastino-Nemotron-3.5-Lightning-Healthcare",
@@ -107,7 +121,9 @@
       "context_window": 8192,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org/GLM-5.2",
@@ -119,7 +135,9 @@
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-5.5",
@@ -131,7 +149,9 @@
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-5.6-luna",
@@ -143,7 +163,9 @@
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-5.6-sol",
@@ -155,7 +177,9 @@
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gpt-5.6-terra",
@@ -167,7 +191,9 @@
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K3",
@@ -179,7 +205,9 @@
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/Kimi-K3-Fast",
@@ -191,7 +219,9 @@
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16",
@@ -203,7 +233,9 @@
       "context_window": 8192,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "HuggingFaceTB/SmolLM2-360M-Instruct",
@@ -215,7 +247,9 @@
       "context_window": 2048,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/qiniucloud.json
+++ b/internal/providers/configs/qiniucloud.json
@@ -19,7 +19,9 @@
       "context_window": 204800,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-5",
@@ -33,7 +35,9 @@
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.1",
@@ -47,7 +51,9 @@
       "context_window": 204800,
       "default_max_tokens": 4096,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/kimi-k2-thinking",
@@ -61,7 +67,9 @@
       "context_window": 256000,
       "default_max_tokens": 100000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-4.7",
@@ -75,7 +83,9 @@
       "context_window": 200000,
       "default_max_tokens": 4096,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2",
@@ -89,7 +99,9 @@
       "context_window": 200000,
       "default_max_tokens": 4096,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai/glm-4.6",
@@ -103,7 +115,9 @@
       "context_window": 200000,
       "default_max_tokens": 4096,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v3.1-terminus",
@@ -117,7 +131,9 @@
       "context_window": 128000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v3.1",
@@ -131,7 +147,9 @@
       "context_window": 128000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "doubao-seed-2.0-pro",
@@ -145,7 +163,9 @@
       "context_window": 256000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "doubao-seed-2.0-code",
@@ -159,7 +179,9 @@
       "context_window": 256000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-coder-480b-a35b-instruct",
@@ -173,7 +195,9 @@
       "context_window": 262000,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.5",
@@ -187,7 +211,9 @@
       "context_window": 131072,
       "default_max_tokens": 98304,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/kimi-k2-0905",
@@ -201,7 +227,9 @@
       "context_window": 256000,
       "default_max_tokens": 100000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     }
   ]
 }

--- a/internal/providers/configs/qiniucloud.json
+++ b/internal/providers/configs/qiniucloud.json
@@ -10,10 +10,12 @@
     {
       "id": "minimax/minimax-m2.5",
       "name": "Minimax/Minimax-M2.5",
-      "cost_per_1m_in": 0.29,
-      "cost_per_1m_out": 1.17,
-      "cost_per_1m_in_cached": 0.29,
-      "cost_per_1m_out_cached": 1.17,
+      "pricing": {
+        "input": 0.29,
+        "output": 1.17,
+        "cache_create": 0.29,
+        "cache_hit": 1.17
+      },
       "context_window": 204800,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -22,10 +24,12 @@
     {
       "id": "z-ai/glm-5",
       "name": "Z-Ai/GLM 5",
-      "cost_per_1m_in": 0.56,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0.56,
-      "cost_per_1m_out_cached": 2.5,
+      "pricing": {
+        "input": 0.56,
+        "output": 2.5,
+        "cache_create": 0.56,
+        "cache_hit": 2.5
+      },
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -34,10 +38,12 @@
     {
       "id": "minimax/minimax-m2.1",
       "name": "Minimax/Minimax-M2.1",
-      "cost_per_1m_in": 0.29,
-      "cost_per_1m_out": 1.17,
-      "cost_per_1m_in_cached": 0.29,
-      "cost_per_1m_out_cached": 1.17,
+      "pricing": {
+        "input": 0.29,
+        "output": 1.17,
+        "cache_create": 0.29,
+        "cache_hit": 1.17
+      },
       "context_window": 204800,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -46,10 +52,12 @@
     {
       "id": "moonshotai/kimi-k2-thinking",
       "name": "Kimi K2 Thinking",
-      "cost_per_1m_in": 0.56,
-      "cost_per_1m_out": 2.22,
-      "cost_per_1m_in_cached": 0.56,
-      "cost_per_1m_out_cached": 2.22,
+      "pricing": {
+        "input": 0.56,
+        "output": 2.22,
+        "cache_create": 0.56,
+        "cache_hit": 2.22
+      },
       "context_window": 256000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -58,10 +66,12 @@
     {
       "id": "z-ai/glm-4.7",
       "name": "Z-Ai/GLM 4.7",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 1.74,
-      "cost_per_1m_in_cached": 0.44,
-      "cost_per_1m_out_cached": 1.74,
+      "pricing": {
+        "input": 0.44,
+        "output": 1.74,
+        "cache_create": 0.44,
+        "cache_hit": 1.74
+      },
       "context_window": 200000,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -70,10 +80,12 @@
     {
       "id": "minimax/minimax-m2",
       "name": "Minimax/Minimax-M2",
-      "cost_per_1m_in": 0.29,
-      "cost_per_1m_out": 1.17,
-      "cost_per_1m_in_cached": 0.29,
-      "cost_per_1m_out_cached": 1.17,
+      "pricing": {
+        "input": 0.29,
+        "output": 1.17,
+        "cache_create": 0.29,
+        "cache_hit": 1.17
+      },
       "context_window": 200000,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -82,10 +94,12 @@
     {
       "id": "z-ai/glm-4.6",
       "name": "Z-AI/GLM 4.6",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 1.75,
-      "cost_per_1m_in_cached": 1,
-      "cost_per_1m_out_cached": 1.75,
+      "pricing": {
+        "input": 1,
+        "output": 1.75,
+        "cache_create": 1,
+        "cache_hit": 1.75
+      },
       "context_window": 200000,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -94,10 +108,12 @@
     {
       "id": "deepseek/deepseek-v3.1-terminus",
       "name": "DeepSeek/DeepSeek-V3.1-Terminus",
-      "cost_per_1m_in": 0.56,
-      "cost_per_1m_out": 1.67,
-      "cost_per_1m_in_cached": 0.56,
-      "cost_per_1m_out_cached": 1.67,
+      "pricing": {
+        "input": 0.56,
+        "output": 1.67,
+        "cache_create": 0.56,
+        "cache_hit": 1.67
+      },
       "context_window": 128000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -106,10 +122,12 @@
     {
       "id": "deepseek-v3.1",
       "name": "DeepSeek-V3.1",
-      "cost_per_1m_in": 0.56,
-      "cost_per_1m_out": 1.67,
-      "cost_per_1m_in_cached": 0.56,
-      "cost_per_1m_out_cached": 1.67,
+      "pricing": {
+        "input": 0.56,
+        "output": 1.67,
+        "cache_create": 0.56,
+        "cache_hit": 1.67
+      },
       "context_window": 128000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -118,10 +136,12 @@
     {
       "id": "doubao-seed-2.0-pro",
       "name": "Doubao Seed 2.0 Pro",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 2.22,
-      "cost_per_1m_in_cached": 0.44,
-      "cost_per_1m_out_cached": 2.22,
+      "pricing": {
+        "input": 0.44,
+        "output": 2.22,
+        "cache_create": 0.44,
+        "cache_hit": 2.22
+      },
       "context_window": 256000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -130,10 +150,12 @@
     {
       "id": "doubao-seed-2.0-code",
       "name": "Doubao Seed 2.0 Code",
-      "cost_per_1m_in": 0.44,
-      "cost_per_1m_out": 2.22,
-      "cost_per_1m_in_cached": 0.44,
-      "cost_per_1m_out_cached": 2.22,
+      "pricing": {
+        "input": 0.44,
+        "output": 2.22,
+        "cache_create": 0.44,
+        "cache_hit": 2.22
+      },
       "context_window": 256000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -142,10 +164,12 @@
     {
       "id": "qwen3-coder-480b-a35b-instruct",
       "name": "Qwen3 Coder 480B A35B Instruct",
-      "cost_per_1m_in": 0.83,
-      "cost_per_1m_out": 3.33,
-      "cost_per_1m_in_cached": 0.83,
-      "cost_per_1m_out_cached": 3.33,
+      "pricing": {
+        "input": 0.83,
+        "output": 3.33,
+        "cache_create": 0.83,
+        "cache_hit": 3.33
+      },
       "context_window": 262000,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -154,10 +178,12 @@
     {
       "id": "glm-4.5",
       "name": "GLM 4.5",
-      "cost_per_1m_in": 0.56,
-      "cost_per_1m_out": 2.22,
-      "cost_per_1m_in_cached": 0.56,
-      "cost_per_1m_out_cached": 2.22,
+      "pricing": {
+        "input": 0.56,
+        "output": 2.22,
+        "cache_create": 0.56,
+        "cache_hit": 2.22
+      },
       "context_window": 131072,
       "default_max_tokens": 98304,
       "can_reason": false,
@@ -166,10 +192,12 @@
     {
       "id": "moonshotai/kimi-k2-0905",
       "name": "Kimi K2 0905",
-      "cost_per_1m_in": 0.56,
-      "cost_per_1m_out": 2.22,
-      "cost_per_1m_in_cached": 0.56,
-      "cost_per_1m_out_cached": 2.22,
+      "pricing": {
+        "input": 0.56,
+        "output": 2.22,
+        "cache_create": 0.56,
+        "cache_hit": 2.22
+      },
       "context_window": 256000,
       "default_max_tokens": 100000,
       "can_reason": true,

--- a/internal/providers/configs/scaleway.json
+++ b/internal/providers/configs/scaleway.json
@@ -17,7 +17,9 @@
       "context_window": 256000,
       "default_max_tokens": 16384,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3.6-35b-a3b",
@@ -29,7 +31,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemma-4-26b-a4b-it",
@@ -41,7 +45,9 @@
       "context_window": 256000,
       "default_max_tokens": 16384,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gpt-oss-120b",
@@ -52,7 +58,10 @@
       },
       "context_window": 128000,
       "default_max_tokens": 32768,
-      "can_reason": true
+      "can_reason": true,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral-medium-3.5-128b",
@@ -63,7 +72,10 @@
       },
       "context_window": 256000,
       "default_max_tokens": 16384,
-      "can_reason": true
+      "can_reason": true,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "llama-3.3-70b-instruct",
@@ -73,7 +85,10 @@
         "output": 0.9
       },
       "context_window": 100000,
-      "default_max_tokens": 16384
+      "default_max_tokens": 16384,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-235b-a22b-instruct-2507",
@@ -83,7 +98,10 @@
         "output": 2.25
       },
       "context_window": 256000,
-      "default_max_tokens": 16384
+      "default_max_tokens": 16384,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-coder-30b-a3b-instruct",
@@ -93,7 +111,10 @@
         "output": 0.8
       },
       "context_window": 128000,
-      "default_max_tokens": 32768
+      "default_max_tokens": 32768,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "voxtral-small-24b-2507",
@@ -103,7 +124,10 @@
         "output": 0.35
       },
       "context_window": 32000,
-      "default_max_tokens": 16384
+      "default_max_tokens": 16384,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral-small-3.2-24b-instruct-2506",
@@ -114,7 +138,9 @@
       },
       "context_window": 128000,
       "default_max_tokens": 32768,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "devstral-2-123b-instruct-2512",
@@ -124,7 +150,10 @@
         "output": 2
       },
       "context_window": 256000,
-      "default_max_tokens": 16384
+      "default_max_tokens": 16384,
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "gemma-3-27b-it",
@@ -135,7 +164,9 @@
       },
       "context_window": 40000,
       "default_max_tokens": 8192,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/scaleway.json
+++ b/internal/providers/configs/scaleway.json
@@ -10,10 +10,10 @@
     {
       "id": "qwen3.5-397b-a17b",
       "name": "Qwen 3.5 397B A17B",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 3.6
+      },
       "context_window": 256000,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -22,10 +22,10 @@
     {
       "id": "qwen3.6-35b-a3b",
       "name": "Qwen 3.6 35B A3B",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 1.5
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -34,10 +34,10 @@
     {
       "id": "gemma-4-26b-a4b-it",
       "name": "Gemma 4 26B A4B IT",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.5
+      },
       "context_window": 256000,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -46,10 +46,10 @@
     {
       "id": "gpt-oss-120b",
       "name": "GPT OSS 120B",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6
+      },
       "context_window": 128000,
       "default_max_tokens": 32768,
       "can_reason": true
@@ -57,10 +57,10 @@
     {
       "id": "mistral-medium-3.5-128b",
       "name": "Mistral Medium 3.5 128B",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.5,
+        "output": 7.5
+      },
       "context_window": 256000,
       "default_max_tokens": 16384,
       "can_reason": true
@@ -68,50 +68,50 @@
     {
       "id": "llama-3.3-70b-instruct",
       "name": "Llama 3.3 70B Instruct",
-      "cost_per_1m_in": 0.9,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.9,
+        "output": 0.9
+      },
       "context_window": 100000,
       "default_max_tokens": 16384
     },
     {
       "id": "qwen3-235b-a22b-instruct-2507",
       "name": "Qwen 3 235B A22B Instruct 2507",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 2.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.75,
+        "output": 2.25
+      },
       "context_window": 256000,
       "default_max_tokens": 16384
     },
     {
       "id": "qwen3-coder-30b-a3b-instruct",
       "name": "Qwen 3 Coder 30B A3B Instruct",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.8
+      },
       "context_window": 128000,
       "default_max_tokens": 32768
     },
     {
       "id": "voxtral-small-24b-2507",
       "name": "Voxtral Small 24B 2507",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.35,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.35
+      },
       "context_window": 32000,
       "default_max_tokens": 16384
     },
     {
       "id": "mistral-small-3.2-24b-instruct-2506",
       "name": "Mistral Small 3.2 24B Instruct 2506",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.35,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.35
+      },
       "context_window": 128000,
       "default_max_tokens": 32768,
       "supports_attachments": true
@@ -119,20 +119,20 @@
     {
       "id": "devstral-2-123b-instruct-2512",
       "name": "Devstral 2 123B Instruct 2512",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 2
+      },
       "context_window": 256000,
       "default_max_tokens": 16384
     },
     {
       "id": "gemma-3-27b-it",
       "name": "Gemma 3 27B IT",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.5
+      },
       "context_window": 40000,
       "default_max_tokens": 8192,
       "supports_attachments": true

--- a/internal/providers/configs/synthetic.json
+++ b/internal/providers/configs/synthetic.json
@@ -10,10 +10,12 @@
     {
       "id": "hf:zai-org/GLM-4.7-Flash",
       "name": "GLM 4.7 Flash",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.5,
+        "cache_create": 0.02,
+        "cache_hit": 0.02
+      },
       "context_window": 196608,
       "default_max_tokens": 19660,
       "can_reason": true,
@@ -28,10 +30,12 @@
     {
       "id": "hf:zai-org/GLM-5.2",
       "name": "GLM 5.2",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.16,
-      "cost_per_1m_out_cached": 0.16,
+      "pricing": {
+        "input": 1,
+        "output": 3,
+        "cache_create": 0.16,
+        "cache_hit": 0.16
+      },
       "context_window": 524288,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -46,10 +50,12 @@
     {
       "id": "hf:zai-org/GLM-5.3-Flash",
       "name": "GLM 5.3 Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0.04,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.5,
+        "cache_create": 0.04,
+        "cache_hit": 0.04
+      },
       "context_window": 524288,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -64,10 +70,12 @@
     {
       "id": "hf:moonshotai/Kimi-K3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.45,
-      "cost_per_1m_out_cached": 0.45,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.45,
+        "cache_hit": 0.45
+      },
       "context_window": 524288,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -82,10 +90,12 @@
     {
       "id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
       "name": "NVIDIA Nemotron 3 Super 120B A12B NVFP4",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0.06,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.3,
+        "output": 1,
+        "cache_create": 0.06,
+        "cache_hit": 0.06
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -100,10 +110,12 @@
     {
       "id": "hf:Qwen/Qwen3.8-27B",
       "name": "Qwen3.8 27B",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.09,
-      "cost_per_1m_out_cached": 0.09,
+      "pricing": {
+        "input": 0.45,
+        "output": 2.2,
+        "cache_create": 0.09,
+        "cache_hit": 0.09
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -112,10 +124,12 @@
     {
       "id": "hf:openai/gpt-oss-120b",
       "name": "gpt oss 120b",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.1,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.1,
+        "cache_create": 0.02,
+        "cache_hit": 0.02
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": true,
@@ -130,10 +144,12 @@
     {
       "id": "syn:large:text",
       "name": "syn:large:text",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0.04,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.5,
+        "cache_create": 0.04,
+        "cache_hit": 0.04
+      },
       "context_window": 524288,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -148,10 +164,12 @@
     {
       "id": "syn:large:vision",
       "name": "syn:large:vision",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0.45,
-      "cost_per_1m_out_cached": 0.45,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 0.45,
+        "cache_hit": 0.45
+      },
       "context_window": 524288,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -166,10 +184,12 @@
     {
       "id": "syn:small:text",
       "name": "syn:small:text",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0.02,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.5,
+        "cache_create": 0.02,
+        "cache_hit": 0.02
+      },
       "context_window": 196608,
       "default_max_tokens": 19660,
       "can_reason": true,
@@ -184,10 +204,12 @@
     {
       "id": "syn:small:vision",
       "name": "syn:small:vision",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.09,
-      "cost_per_1m_out_cached": 0.09,
+      "pricing": {
+        "input": 0.45,
+        "output": 2.2,
+        "cache_create": 0.09,
+        "cache_hit": 0.09
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,

--- a/internal/providers/configs/synthetic.json
+++ b/internal/providers/configs/synthetic.json
@@ -25,7 +25,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "hf:zai-org/GLM-5.2",
@@ -45,7 +47,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "hf:zai-org/GLM-5.3-Flash",
@@ -65,7 +69,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "hf:moonshotai/Kimi-K3",
@@ -85,7 +91,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -105,7 +113,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "hf:Qwen/Qwen3.8-27B",
@@ -119,7 +129,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "hf:openai/gpt-oss-120b",
@@ -139,7 +151,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "syn:large:text",
@@ -159,7 +173,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "syn:large:vision",
@@ -179,7 +195,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "syn:small:text",
@@ -199,7 +217,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "syn:small:vision",
@@ -219,7 +239,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/venice.json
+++ b/internal/providers/configs/venice.json
@@ -23,7 +23,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "aion-labs-aion-3-0-mini",
@@ -41,7 +43,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "claude-fable-5",
@@ -59,7 +63,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-fable-5-1",
@@ -77,7 +83,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-5",
@@ -89,7 +97,9 @@
       "context_window": 198000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-6",
@@ -107,7 +117,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-7",
@@ -125,7 +137,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-8",
@@ -143,7 +157,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-8-fast",
@@ -161,7 +177,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-5",
@@ -179,7 +197,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-5-fast",
@@ -197,7 +217,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-5",
@@ -209,7 +231,9 @@
       "context_window": 198000,
       "default_max_tokens": 64000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-6",
@@ -227,7 +251,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-5",
@@ -245,7 +271,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek-v3.2",
@@ -263,7 +291,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "e2ee-deepseek-v4-flash",
@@ -275,7 +305,9 @@
       "context_window": 1000000,
       "default_max_tokens": 8192,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash",
@@ -293,7 +325,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash-0731",
@@ -311,7 +345,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-flash-0731-fast",
@@ -329,7 +365,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-pro",
@@ -341,7 +379,9 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek-v4-pro-0813",
@@ -353,7 +393,9 @@
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org-glm-4.6",
@@ -371,7 +413,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org-glm-4.7",
@@ -389,7 +433,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org-glm-4.7-flash",
@@ -407,7 +453,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "olafangensan-glm-4.7-flash-heretic",
@@ -425,7 +473,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org-glm-5",
@@ -443,7 +493,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai-glm-5-turbo",
@@ -461,7 +513,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org-glm-5-1",
@@ -479,7 +533,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "e2ee-glm-5-2-p",
@@ -497,7 +553,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai-org-glm-5-2",
@@ -515,7 +573,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai-glm-5-3",
@@ -527,7 +587,9 @@
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "z-ai-glm-5-3-flash",
@@ -545,7 +607,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "z-ai-glm-5v-turbo",
@@ -563,7 +627,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-4o-2024-11-20",
@@ -575,7 +641,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-4o-mini-2024-07-18",
@@ -587,7 +655,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-52",
@@ -605,7 +675,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai-gpt-52-codex",
@@ -623,7 +695,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-53-codex",
@@ -641,7 +715,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-54",
@@ -659,7 +735,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-54-mini",
@@ -677,7 +755,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-54-pro",
@@ -695,7 +775,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-55",
@@ -713,7 +795,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-55-pro",
@@ -731,7 +815,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-56-luna",
@@ -749,7 +835,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-56-luna-pro",
@@ -767,7 +855,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-56-sol",
@@ -785,7 +875,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-56-sol-pro",
@@ -803,7 +895,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-56-terra",
@@ -821,7 +915,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai-gpt-56-terra-pro",
@@ -839,7 +935,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-flash-preview",
@@ -857,7 +955,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-1-pro-preview",
@@ -875,7 +975,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-5-flash",
@@ -893,7 +995,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-5-flash-lite",
@@ -905,7 +1009,9 @@
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-6-flash",
@@ -917,7 +1023,9 @@
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-7-flash",
@@ -929,7 +1037,9 @@
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-8-flash",
@@ -941,7 +1051,9 @@
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemma-4-uncensored",
@@ -953,7 +1065,9 @@
       "context_window": 256000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google-gemma-3-27b-it",
@@ -965,7 +1079,9 @@
       "context_window": 198000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google-gemma-4-26b-a4b-it",
@@ -983,7 +1099,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google-gemma-4-31b-it",
@@ -1001,7 +1119,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4-20",
@@ -1013,7 +1133,9 @@
       "context_window": 2000000,
       "default_max_tokens": 128000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4-3",
@@ -1031,7 +1153,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4-5",
@@ -1049,7 +1173,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4-6",
@@ -1067,7 +1193,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-build-0-1",
@@ -1079,7 +1207,9 @@
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "inkling",
@@ -1097,7 +1227,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2-5",
@@ -1109,7 +1241,9 @@
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2-6",
@@ -1127,7 +1261,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k2-7-code",
@@ -1145,7 +1281,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k3",
@@ -1163,7 +1301,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kimi-k3-fast-api",
@@ -1181,7 +1321,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "llama-3.2-3b",
@@ -1193,7 +1335,9 @@
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "llama-3.3-70b",
@@ -1205,7 +1349,9 @@
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mercury-2",
@@ -1223,7 +1369,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "xiaomi-mimo-v2-5",
@@ -1241,7 +1389,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax-m25",
@@ -1259,7 +1409,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m27",
@@ -1277,7 +1429,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax-m3-preview",
@@ -1289,7 +1443,9 @@
       "context_window": 524288,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral-small-3-2-24b-instruct",
@@ -1301,7 +1457,9 @@
       "context_window": 256000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral-small-2603",
@@ -1319,7 +1477,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nvidia-nemotron-3-nano-30b-a3b",
@@ -1331,7 +1491,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia-nemotron-3-ultra-550b-a55b",
@@ -1349,7 +1511,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai-gpt-oss-120b",
@@ -1367,7 +1531,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-235b-a22b-instruct-2507",
@@ -1379,7 +1545,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-235b-a22b-thinking-2507",
@@ -1397,7 +1565,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-coder-480b-a35b-instruct-turbo",
@@ -1409,7 +1579,9 @@
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-next-80b",
@@ -1421,7 +1593,9 @@
       "context_window": 256000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen3-5-35b-a3b",
@@ -1439,7 +1613,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true,
+      "capabilities": {
+        "vision": true
+      },
       "options": {
         "temperature": 1,
         "top_p": 0.95
@@ -1461,7 +1637,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-5-9b",
@@ -1479,7 +1657,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-6-27b",
@@ -1497,7 +1677,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true,
+      "capabilities": {
+        "vision": true
+      },
       "options": {
         "temperature": 1,
         "top_p": 0.95
@@ -1513,7 +1695,9 @@
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true,
+      "capabilities": {
+        "vision": true
+      },
       "options": {
         "temperature": 1,
         "top_p": 0.95
@@ -1529,7 +1713,9 @@
       "context_window": 32000,
       "default_max_tokens": 4096,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen-3-6-plus",
@@ -1541,7 +1727,9 @@
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true,
+      "capabilities": {
+        "vision": true
+      },
       "options": {
         "temperature": 0.7,
         "top_p": 0.8
@@ -1557,7 +1745,9 @@
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen-3-7-plus",
@@ -1569,7 +1759,9 @@
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true,
+      "capabilities": {
+        "vision": true
+      },
       "options": {
         "temperature": 0.7,
         "top_p": 0.8
@@ -1585,7 +1777,9 @@
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "qwen-3-8-27b",
@@ -1603,7 +1797,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen-3-8-max",
@@ -1615,7 +1811,9 @@
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "qwen3-vl-235b-a22b",
@@ -1627,7 +1825,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "e2ee-qwen3-vl-30b-a3b-p",
@@ -1639,7 +1839,9 @@
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "seed-2-1-turbo",
@@ -1651,7 +1853,9 @@
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "venice-uncensored-role-play",
@@ -1663,7 +1867,9 @@
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "venice-uncensored-1-2",
@@ -1675,7 +1881,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/venice.json
+++ b/internal/providers/configs/venice.json
@@ -10,10 +10,10 @@
     {
       "id": "aion-labs-aion-3-0",
       "name": "Aion 3.0",
-      "cost_per_1m_in": 3.75,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.75,
+        "output": 7.5
+      },
       "context_window": 128000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -28,10 +28,10 @@
     {
       "id": "aion-labs-aion-3-0-mini",
       "name": "Aion 3.0 Mini",
-      "cost_per_1m_in": 0.875,
-      "cost_per_1m_out": 1.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.875,
+        "output": 1.75
+      },
       "context_window": 128000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -46,10 +46,10 @@
     {
       "id": "claude-fable-5",
       "name": "Claude Fable 5",
-      "cost_per_1m_in": 12,
-      "cost_per_1m_out": 60,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 12,
+        "output": 60
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -64,10 +64,10 @@
     {
       "id": "claude-fable-5-1",
       "name": "Claude Fable 5.1",
-      "cost_per_1m_in": 12,
-      "cost_per_1m_out": 60,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 12,
+        "output": 60
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -82,10 +82,10 @@
     {
       "id": "claude-opus-4-5",
       "name": "Claude Opus 4.5",
-      "cost_per_1m_in": 6,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 6,
+        "output": 30
+      },
       "context_window": 198000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -94,10 +94,10 @@
     {
       "id": "claude-opus-4-6",
       "name": "Claude Opus 4.6",
-      "cost_per_1m_in": 6,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 6,
+        "output": 30
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -112,10 +112,10 @@
     {
       "id": "claude-opus-4-7",
       "name": "Claude Opus 4.7",
-      "cost_per_1m_in": 6,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 6,
+        "output": 30
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -130,10 +130,10 @@
     {
       "id": "claude-opus-4-8",
       "name": "Claude Opus 4.8",
-      "cost_per_1m_in": 6,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 6,
+        "output": 30
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -148,10 +148,10 @@
     {
       "id": "claude-opus-4-8-fast",
       "name": "Claude Opus 4.8 Fast",
-      "cost_per_1m_in": 12,
-      "cost_per_1m_out": 60,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 12,
+        "output": 60
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -166,10 +166,10 @@
     {
       "id": "claude-opus-5",
       "name": "Claude Opus 5",
-      "cost_per_1m_in": 6,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 6,
+        "output": 30
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -184,10 +184,10 @@
     {
       "id": "claude-opus-5-fast",
       "name": "Claude Opus 5 Fast",
-      "cost_per_1m_in": 12,
-      "cost_per_1m_out": 60,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 12,
+        "output": 60
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -202,10 +202,10 @@
     {
       "id": "claude-sonnet-4-5",
       "name": "Claude Sonnet 4.5",
-      "cost_per_1m_in": 3.75,
-      "cost_per_1m_out": 18.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.75,
+        "output": 18.75
+      },
       "context_window": 198000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -214,10 +214,10 @@
     {
       "id": "claude-sonnet-4-6",
       "name": "Claude Sonnet 4.6",
-      "cost_per_1m_in": 3.6,
-      "cost_per_1m_out": 18,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.6,
+        "output": 18
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -232,10 +232,10 @@
     {
       "id": "claude-sonnet-5",
       "name": "Claude Sonnet 5",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3,
+        "output": 15
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -250,10 +250,10 @@
     {
       "id": "deepseek-v3.2",
       "name": "DeepSeek V3.2",
-      "cost_per_1m_in": 0.33,
-      "cost_per_1m_out": 0.48,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.33,
+        "output": 0.48
+      },
       "context_window": 160000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -268,10 +268,10 @@
     {
       "id": "e2ee-deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.182,
-      "cost_per_1m_out": 0.373,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.182,
+        "output": 0.373
+      },
       "context_window": 1000000,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -280,10 +280,10 @@
     {
       "id": "deepseek-v4-flash",
       "name": "DeepSeek V4 Flash 0423",
-      "cost_per_1m_in": 0.138,
-      "cost_per_1m_out": 0.275,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.138,
+        "output": 0.275
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -298,10 +298,10 @@
     {
       "id": "deepseek-v4-flash-0731",
       "name": "DeepSeek V4 Flash 0731",
-      "cost_per_1m_in": 0.175,
-      "cost_per_1m_out": 0.35,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.175,
+        "output": 0.35
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -316,10 +316,10 @@
     {
       "id": "deepseek-v4-flash-0731-fast",
       "name": "DeepSeek V4 Flash 0731 Fast",
-      "cost_per_1m_in": 0.35,
-      "cost_per_1m_out": 0.7,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.35,
+        "output": 0.7
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -334,10 +334,10 @@
     {
       "id": "deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
-      "cost_per_1m_in": 1.65,
-      "cost_per_1m_out": 3.301,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.65,
+        "output": 3.301
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -346,10 +346,10 @@
     {
       "id": "deepseek-v4-pro-0813",
       "name": "DeepSeek V4 Pro 0813",
-      "cost_per_1m_in": 1.65,
-      "cost_per_1m_out": 4.95,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.65,
+        "output": 4.95
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -358,10 +358,10 @@
     {
       "id": "zai-org-glm-4.6",
       "name": "GLM 4.6",
-      "cost_per_1m_in": 0.43,
-      "cost_per_1m_out": 1.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.43,
+        "output": 1.75
+      },
       "context_window": 198000,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -376,10 +376,10 @@
     {
       "id": "zai-org-glm-4.7",
       "name": "GLM 4.7",
-      "cost_per_1m_in": 0.55,
-      "cost_per_1m_out": 2.65,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.55,
+        "output": 2.65
+      },
       "context_window": 198000,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -394,10 +394,10 @@
     {
       "id": "zai-org-glm-4.7-flash",
       "name": "GLM 4.7 Flash",
-      "cost_per_1m_in": 0.06,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.06,
+        "output": 0.4
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -412,10 +412,10 @@
     {
       "id": "olafangensan-glm-4.7-flash-heretic",
       "name": "GLM 4.7 Flash Heretic",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.07,
+        "output": 0.4
+      },
       "context_window": 200000,
       "default_max_tokens": 24000,
       "can_reason": true,
@@ -430,10 +430,10 @@
     {
       "id": "zai-org-glm-5",
       "name": "GLM 5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 3.2
+      },
       "context_window": 198000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -448,10 +448,10 @@
     {
       "id": "z-ai-glm-5-turbo",
       "name": "GLM 5 Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.2,
+        "output": 4
+      },
       "context_window": 200000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -466,10 +466,10 @@
     {
       "id": "zai-org-glm-5-1",
       "name": "GLM 5.1",
-      "cost_per_1m_in": 1.54,
-      "cost_per_1m_out": 4.84,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.54,
+        "output": 4.84
+      },
       "context_window": 200000,
       "default_max_tokens": 80000,
       "can_reason": true,
@@ -484,10 +484,10 @@
     {
       "id": "e2ee-glm-5-2-p",
       "name": "GLM 5.2",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 5.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.75,
+        "output": 5.75
+      },
       "context_window": 524288,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -502,10 +502,10 @@
     {
       "id": "zai-org-glm-5-2",
       "name": "GLM 5.2",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -520,10 +520,10 @@
     {
       "id": "z-ai-glm-5-3",
       "name": "GLM 5.3",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 5.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.75,
+        "output": 5.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -532,10 +532,10 @@
     {
       "id": "z-ai-glm-5-3-flash",
       "name": "GLM 5.3 Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.5
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -550,10 +550,10 @@
     {
       "id": "z-ai-glm-5v-turbo",
       "name": "GLM 5V Turbo",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.5,
+        "output": 5
+      },
       "context_window": 200000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -568,10 +568,10 @@
     {
       "id": "openai-gpt-4o-2024-11-20",
       "name": "GPT-4o",
-      "cost_per_1m_in": 3.125,
-      "cost_per_1m_out": 12.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.125,
+        "output": 12.5
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -580,10 +580,10 @@
     {
       "id": "openai-gpt-4o-mini-2024-07-18",
       "name": "GPT-4o Mini",
-      "cost_per_1m_in": 0.1875,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1875,
+        "output": 0.75
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -592,10 +592,10 @@
     {
       "id": "openai-gpt-52",
       "name": "GPT-5.2",
-      "cost_per_1m_in": 2.19,
-      "cost_per_1m_out": 17.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.19,
+        "output": 17.5
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -610,10 +610,10 @@
     {
       "id": "openai-gpt-52-codex",
       "name": "GPT-5.2 Codex",
-      "cost_per_1m_in": 2.19,
-      "cost_per_1m_out": 17.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.19,
+        "output": 17.5
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -628,10 +628,10 @@
     {
       "id": "openai-gpt-53-codex",
       "name": "GPT-5.3 Codex",
-      "cost_per_1m_in": 2.19,
-      "cost_per_1m_out": 17.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.19,
+        "output": 17.5
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -646,10 +646,10 @@
     {
       "id": "openai-gpt-54",
       "name": "GPT-5.4",
-      "cost_per_1m_in": 3.13,
-      "cost_per_1m_out": 18.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.13,
+        "output": 18.8
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -664,10 +664,10 @@
     {
       "id": "openai-gpt-54-mini",
       "name": "GPT-5.4 Mini",
-      "cost_per_1m_in": 0.9375,
-      "cost_per_1m_out": 5.625,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.9375,
+        "output": 5.625
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -682,10 +682,10 @@
     {
       "id": "openai-gpt-54-pro",
       "name": "GPT-5.4 Pro",
-      "cost_per_1m_in": 37.5,
-      "cost_per_1m_out": 225,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 37.5,
+        "output": 225
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -700,10 +700,10 @@
     {
       "id": "openai-gpt-55",
       "name": "GPT-5.5",
-      "cost_per_1m_in": 6.25,
-      "cost_per_1m_out": 37.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 6.25,
+        "output": 37.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -718,10 +718,10 @@
     {
       "id": "openai-gpt-55-pro",
       "name": "GPT-5.5 Pro",
-      "cost_per_1m_in": 37.5,
-      "cost_per_1m_out": 225,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 37.5,
+        "output": 225
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -736,10 +736,10 @@
     {
       "id": "openai-gpt-56-luna",
       "name": "GPT-5.6 Luna",
-      "cost_per_1m_in": 0.26667,
-      "cost_per_1m_out": 1.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.26667,
+        "output": 1.6
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -754,10 +754,10 @@
     {
       "id": "openai-gpt-56-luna-pro",
       "name": "GPT-5.6 Luna Pro",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.25,
+        "output": 7.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -772,10 +772,10 @@
     {
       "id": "openai-gpt-56-sol",
       "name": "GPT-5.6 Sol",
-      "cost_per_1m_in": 6.25,
-      "cost_per_1m_out": 37.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 6.25,
+        "output": 37.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -790,10 +790,10 @@
     {
       "id": "openai-gpt-56-sol-pro",
       "name": "GPT-5.6 Sol Pro",
-      "cost_per_1m_in": 6.25,
-      "cost_per_1m_out": 37.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 6.25,
+        "output": 37.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -808,10 +808,10 @@
     {
       "id": "openai-gpt-56-terra",
       "name": "GPT-5.6 Terra",
-      "cost_per_1m_in": 3.125,
-      "cost_per_1m_out": 18.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.125,
+        "output": 18.75
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -826,10 +826,10 @@
     {
       "id": "openai-gpt-56-terra-pro",
       "name": "GPT-5.6 Terra Pro",
-      "cost_per_1m_in": 3.125,
-      "cost_per_1m_out": 18.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.125,
+        "output": 18.75
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -844,10 +844,10 @@
     {
       "id": "gemini-3-flash-preview",
       "name": "Gemini 3 Flash Preview",
-      "cost_per_1m_in": 0.7,
-      "cost_per_1m_out": 3.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.7,
+        "output": 3.75
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -862,10 +862,10 @@
     {
       "id": "gemini-3-1-pro-preview",
       "name": "Gemini 3.1 Pro Preview",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 15
+      },
       "context_window": 1000000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -880,10 +880,10 @@
     {
       "id": "gemini-3-5-flash",
       "name": "Gemini 3.5 Flash",
-      "cost_per_1m_in": 1.55,
-      "cost_per_1m_out": 9.45,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.55,
+        "output": 9.45
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -898,10 +898,10 @@
     {
       "id": "gemini-3-5-flash-lite",
       "name": "Gemini 3.5 Flash-Lite",
-      "cost_per_1m_in": 0.375,
-      "cost_per_1m_out": 3.125,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.375,
+        "output": 3.125
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -910,10 +910,10 @@
     {
       "id": "gemini-3-6-flash",
       "name": "Gemini 3.6 Flash",
-      "cost_per_1m_in": 0.9375,
-      "cost_per_1m_out": 4.6875,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.9375,
+        "output": 4.6875
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -922,10 +922,10 @@
     {
       "id": "gemini-3-7-flash",
       "name": "Gemini 3.7 Flash",
-      "cost_per_1m_in": 0.9375,
-      "cost_per_1m_out": 4.6875,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.9375,
+        "output": 4.6875
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -934,10 +934,10 @@
     {
       "id": "gemini-3-8-flash",
       "name": "Gemini 3.8 Flash",
-      "cost_per_1m_in": 0.9375,
-      "cost_per_1m_out": 4.6875,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.9375,
+        "output": 4.6875
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -946,10 +946,10 @@
     {
       "id": "gemma-4-uncensored",
       "name": "Gemma 4 Uncensored",
-      "cost_per_1m_in": 0.1625,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1625,
+        "output": 0.5
+      },
       "context_window": 256000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -958,10 +958,10 @@
     {
       "id": "google-gemma-3-27b-it",
       "name": "Google Gemma 3 27B Instruct",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.2
+      },
       "context_window": 198000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -970,10 +970,10 @@
     {
       "id": "google-gemma-4-26b-a4b-it",
       "name": "Google Gemma 4 26B A4B Instruct",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.13,
+        "output": 0.4
+      },
       "context_window": 256000,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -988,10 +988,10 @@
     {
       "id": "google-gemma-4-31b-it",
       "name": "Google Gemma 4 31B Instruct",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.36,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.36
+      },
       "context_window": 256000,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -1006,10 +1006,10 @@
     {
       "id": "grok-4-20",
       "name": "Grok 4.20",
-      "cost_per_1m_in": 1.42,
-      "cost_per_1m_out": 2.83,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.42,
+        "output": 2.83
+      },
       "context_window": 2000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1018,10 +1018,10 @@
     {
       "id": "grok-4-3",
       "name": "Grok 4.3",
-      "cost_per_1m_in": 1.42,
-      "cost_per_1m_out": 2.83,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.42,
+        "output": 2.83
+      },
       "context_window": 1000000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -1036,10 +1036,10 @@
     {
       "id": "grok-4-5",
       "name": "Grok 4.5",
-      "cost_per_1m_in": 2.27,
-      "cost_per_1m_out": 6.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.27,
+        "output": 6.8
+      },
       "context_window": 500000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -1054,10 +1054,10 @@
     {
       "id": "grok-4-6",
       "name": "Grok 4.6",
-      "cost_per_1m_in": 2.27,
-      "cost_per_1m_out": 6.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.27,
+        "output": 6.8
+      },
       "context_window": 500000,
       "default_max_tokens": 200000,
       "can_reason": true,
@@ -1072,10 +1072,10 @@
     {
       "id": "grok-build-0-1",
       "name": "Grok Build 0.1",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 2
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1084,10 +1084,10 @@
     {
       "id": "inkling",
       "name": "Inkling",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 5.0625,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.25,
+        "output": 5.0625
+      },
       "context_window": 524288,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1102,10 +1102,10 @@
     {
       "id": "kimi-k2-5",
       "name": "Kimi K2.5",
-      "cost_per_1m_in": 0.56,
-      "cost_per_1m_out": 3.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.56,
+        "output": 3.5
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1114,10 +1114,10 @@
     {
       "id": "kimi-k2-6",
       "name": "Kimi K2.6",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 3.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.75,
+        "output": 3.5
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1132,10 +1132,10 @@
     {
       "id": "kimi-k2-7-code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 3.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.75,
+        "output": 3.5
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1150,10 +1150,10 @@
     {
       "id": "kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3.75,
-      "cost_per_1m_out": 18.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 3.75,
+        "output": 18.75
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1168,10 +1168,10 @@
     {
       "id": "kimi-k3-fast-api",
       "name": "Kimi K3 Fast",
-      "cost_per_1m_in": 4.5,
-      "cost_per_1m_out": 22.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 4.5,
+        "output": 22.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1186,10 +1186,10 @@
     {
       "id": "llama-3.2-3b",
       "name": "Llama 3.2 3B",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6
+      },
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -1198,10 +1198,10 @@
     {
       "id": "llama-3.3-70b",
       "name": "Llama 3.3 70B",
-      "cost_per_1m_in": 0.7,
-      "cost_per_1m_out": 2.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.7,
+        "output": 2.8
+      },
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -1210,10 +1210,10 @@
     {
       "id": "mercury-2",
       "name": "Mercury 2",
-      "cost_per_1m_in": 0.3125,
-      "cost_per_1m_out": 0.9375,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3125,
+        "output": 0.9375
+      },
       "context_window": 128000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -1228,10 +1228,10 @@
     {
       "id": "xiaomi-mimo-v2-5",
       "name": "MiMo-V2.5",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 2
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1246,10 +1246,10 @@
     {
       "id": "minimax-m25",
       "name": "MiniMax M2.5",
-      "cost_per_1m_in": 0.27,
-      "cost_per_1m_out": 0.95,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.27,
+        "output": 0.95
+      },
       "context_window": 198000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1264,10 +1264,10 @@
     {
       "id": "minimax-m27",
       "name": "MiniMax M2.7",
-      "cost_per_1m_in": 0.375,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.375,
+        "output": 1.5
+      },
       "context_window": 198000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1282,10 +1282,10 @@
     {
       "id": "minimax-m3-preview",
       "name": "MiniMax M3 Preview",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2
+      },
       "context_window": 524288,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1294,10 +1294,10 @@
     {
       "id": "mistral-small-3-2-24b-instruct",
       "name": "Mistral Small 3.2 24B Instruct",
-      "cost_per_1m_in": 0.09375,
-      "cost_per_1m_out": 0.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.09375,
+        "output": 0.25
+      },
       "context_window": 256000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1306,10 +1306,10 @@
     {
       "id": "mistral-small-2603",
       "name": "Mistral Small 4",
-      "cost_per_1m_in": 0.1875,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1875,
+        "output": 0.75
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1324,10 +1324,10 @@
     {
       "id": "nvidia-nemotron-3-nano-30b-a3b",
       "name": "NVIDIA Nemotron 3 Nano 30B",
-      "cost_per_1m_in": 0.075,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.075,
+        "output": 0.3
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1336,10 +1336,10 @@
     {
       "id": "nvidia-nemotron-3-ultra-550b-a55b",
       "name": "NVIDIA Nemotron 3 Ultra",
-      "cost_per_1m_in": 0.625,
-      "cost_per_1m_out": 3.125,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.625,
+        "output": 3.125
+      },
       "context_window": 256000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1354,10 +1354,10 @@
     {
       "id": "openai-gpt-oss-120b",
       "name": "OpenAI GPT OSS 120B",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.07,
+        "output": 0.3
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -1372,10 +1372,10 @@
     {
       "id": "qwen3-235b-a22b-instruct-2507",
       "name": "Qwen 3 235B A22B Instruct 2507",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.75
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1384,10 +1384,10 @@
     {
       "id": "qwen3-235b-a22b-thinking-2507",
       "name": "Qwen 3 235B A22B Thinking 2507",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 3.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.45,
+        "output": 3.5
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -1402,10 +1402,10 @@
     {
       "id": "qwen3-coder-480b-a35b-instruct-turbo",
       "name": "Qwen 3 Coder 480B Turbo",
-      "cost_per_1m_in": 0.35,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.35,
+        "output": 1.5
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -1414,10 +1414,10 @@
     {
       "id": "qwen3-next-80b",
       "name": "Qwen 3 Next 80b",
-      "cost_per_1m_in": 0.35,
-      "cost_per_1m_out": 1.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.35,
+        "output": 1.9
+      },
       "context_window": 256000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1426,10 +1426,10 @@
     {
       "id": "qwen3-5-35b-a3b",
       "name": "Qwen 3.5 35B A3B",
-      "cost_per_1m_in": 0.3125,
-      "cost_per_1m_out": 1.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3125,
+        "output": 1.25
+      },
       "context_window": 256000,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -1448,10 +1448,10 @@
     {
       "id": "qwen3-5-397b-a17b",
       "name": "Qwen 3.5 397B",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.75,
+        "output": 4.5
+      },
       "context_window": 128000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1466,10 +1466,10 @@
     {
       "id": "qwen3-5-9b",
       "name": "Qwen 3.5 9B",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.15
+      },
       "context_window": 256000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -1484,10 +1484,10 @@
     {
       "id": "qwen3-6-27b",
       "name": "Qwen 3.6 27B",
-      "cost_per_1m_in": 0.325,
-      "cost_per_1m_out": 3.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.325,
+        "output": 3.25
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1506,10 +1506,10 @@
     {
       "id": "qwen3-6-35b-a3b",
       "name": "Qwen 3.6 35B A3B",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 1
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1522,10 +1522,10 @@
     {
       "id": "e2ee-qwen3-6-35b-a3b",
       "name": "Qwen 3.6 35B A3B FP8",
-      "cost_per_1m_in": 0.182,
-      "cost_per_1m_out": 1.18,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.182,
+        "output": 1.18
+      },
       "context_window": 32000,
       "default_max_tokens": 4096,
       "can_reason": true,
@@ -1534,10 +1534,10 @@
     {
       "id": "qwen-3-6-plus",
       "name": "Qwen 3.6 Plus Uncensored",
-      "cost_per_1m_in": 0.625,
-      "cost_per_1m_out": 3.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.625,
+        "output": 3.75
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1550,10 +1550,10 @@
     {
       "id": "qwen-3-7-max",
       "name": "Qwen 3.7 Max",
-      "cost_per_1m_in": 2.7,
-      "cost_per_1m_out": 8.05,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.7,
+        "output": 8.05
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1562,10 +1562,10 @@
     {
       "id": "qwen-3-7-plus",
       "name": "Qwen 3.7 Plus",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 2
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1578,10 +1578,10 @@
     {
       "id": "qwen-3-8-2-4t-a95b",
       "name": "Qwen 3.8 2.4T",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 7.5
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1590,10 +1590,10 @@
     {
       "id": "qwen-3-8-27b",
       "name": "Qwen 3.8 27B",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.45,
+        "output": 3.2
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1608,10 +1608,10 @@
     {
       "id": "qwen-3-8-max",
       "name": "Qwen 3.8 Max",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 7.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1620,10 +1620,10 @@
     {
       "id": "qwen3-vl-235b-a22b",
       "name": "Qwen3 VL 235B",
-      "cost_per_1m_in": 0.21,
-      "cost_per_1m_out": 1.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.21,
+        "output": 1.9
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1632,10 +1632,10 @@
     {
       "id": "e2ee-qwen3-vl-30b-a3b-p",
       "name": "Qwen3 VL 30B A3B",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.9
+      },
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -1644,10 +1644,10 @@
     {
       "id": "seed-2-1-turbo",
       "name": "Seed 2.1 Turbo",
-      "cost_per_1m_in": 0.625,
-      "cost_per_1m_out": 3.125,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.625,
+        "output": 3.125
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1656,10 +1656,10 @@
     {
       "id": "venice-uncensored-role-play",
       "name": "Venice Role Play Uncensored",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 2
+      },
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -1668,10 +1668,10 @@
     {
       "id": "venice-uncensored-1-2",
       "name": "Venice Uncensored 1.2",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.9
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,

--- a/internal/providers/configs/vercel.json
+++ b/internal/providers/configs/vercel.json
@@ -10,10 +10,11 @@
     {
       "id": "bytedance/seed-1.8",
       "name": "Bytedance Seed 1.8",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_hit": 0.05
+      },
       "context_window": 256000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -28,10 +29,12 @@
     {
       "id": "anthropic/claude-3-haiku",
       "name": "Claude 3 Haiku",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1.25,
-      "cost_per_1m_in_cached": 0.3,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.25,
+        "output": 1.25,
+        "cache_create": 0.3,
+        "cache_hit": 0.03
+      },
       "context_window": 200000,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -40,10 +43,12 @@
     {
       "id": "anthropic/claude-fable-5",
       "name": "Claude Fable 5",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 1,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 1
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -61,10 +66,12 @@
     {
       "id": "anthropic/claude-fable-5.1",
       "name": "Claude Fable 5.1",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -82,10 +89,12 @@
     {
       "id": "anthropic/claude-haiku-4.5",
       "name": "Claude Haiku 4.5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 1.25,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 1,
+        "output": 5,
+        "cache_create": 1.25,
+        "cache_hit": 0.1
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -103,10 +112,12 @@
     {
       "id": "anthropic/claude-opus-4",
       "name": "Claude Opus 4",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 75,
-      "cost_per_1m_in_cached": 18.75,
-      "cost_per_1m_out_cached": 1.5,
+      "pricing": {
+        "input": 15,
+        "output": 75,
+        "cache_create": 18.75,
+        "cache_hit": 1.5
+      },
       "context_window": 200000,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -124,10 +135,12 @@
     {
       "id": "anthropic/claude-opus-4.5",
       "name": "Claude Opus 4.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -145,10 +158,12 @@
     {
       "id": "anthropic/claude-opus-4.6",
       "name": "Claude Opus 4.6",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -166,10 +181,12 @@
     {
       "id": "anthropic/claude-opus-4.7",
       "name": "Claude Opus 4.7",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -187,10 +204,12 @@
     {
       "id": "anthropic/claude-opus-4.8",
       "name": "Claude Opus 4.8",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -208,10 +227,12 @@
     {
       "id": "anthropic/claude-opus-4.8-fast",
       "name": "Claude Opus 4.8 (Fast)",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 1,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 1
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -229,10 +250,12 @@
     {
       "id": "anthropic/claude-opus-5",
       "name": "Claude Opus 5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -250,10 +273,12 @@
     {
       "id": "anthropic/claude-opus-5-fast",
       "name": "Claude Opus 5 (Fast)",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 50,
-      "cost_per_1m_in_cached": 12.5,
-      "cost_per_1m_out_cached": 1,
+      "pricing": {
+        "input": 10,
+        "output": 50,
+        "cache_create": 12.5,
+        "cache_hit": 1
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -271,10 +296,12 @@
     {
       "id": "anthropic/claude-sonnet-4",
       "name": "Claude Sonnet 4",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -292,10 +319,12 @@
     {
       "id": "anthropic/claude-sonnet-4.5",
       "name": "Claude Sonnet 4.5",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -313,10 +342,12 @@
     {
       "id": "anthropic/claude-sonnet-4.6",
       "name": "Claude Sonnet 4.6",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -334,10 +365,12 @@
     {
       "id": "anthropic/claude-sonnet-5",
       "name": "Claude Sonnet 5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 10,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -355,10 +388,10 @@
     {
       "id": "cohere/command-a",
       "name": "Command A",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 2.5,
+        "output": 10
+      },
       "context_window": 256000,
       "default_max_tokens": 8000,
       "can_reason": false,
@@ -367,10 +400,11 @@
     {
       "id": "deepseek/deepseek-v3.1",
       "name": "DeepSeek V3.1",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.95,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.95,
+        "cache_hit": 0.13
+      },
       "context_window": 163840,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -385,10 +419,11 @@
     {
       "id": "deepseek/deepseek-v3.1-terminus",
       "name": "DeepSeek V3.1 Terminus",
-      "cost_per_1m_in": 0.27,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.135,
+      "pricing": {
+        "input": 0.27,
+        "output": 1,
+        "cache_hit": 0.135
+      },
       "context_window": 131072,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -403,10 +438,11 @@
     {
       "id": "deepseek/deepseek-v3.2",
       "name": "DeepSeek V3.2",
-      "cost_per_1m_in": 0.28,
-      "cost_per_1m_out": 0.42,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
+      "pricing": {
+        "input": 0.28,
+        "output": 0.42,
+        "cache_hit": 0.028
+      },
       "context_window": 128000,
       "default_max_tokens": 8000,
       "can_reason": false,
@@ -415,10 +451,10 @@
     {
       "id": "deepseek/deepseek-v3.2-thinking",
       "name": "DeepSeek V3.2 Thinking",
-      "cost_per_1m_in": 0.62,
-      "cost_per_1m_out": 1.85,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.62,
+        "output": 1.85
+      },
       "context_window": 128000,
       "default_max_tokens": 8000,
       "can_reason": false,
@@ -427,10 +463,11 @@
     {
       "id": "deepseek/deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "cost_per_1m_in": 0.13,
-      "cost_per_1m_out": 0.26,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.028,
+      "pricing": {
+        "input": 0.13,
+        "output": 0.26,
+        "cache_hit": 0.028
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -445,10 +482,11 @@
     {
       "id": "deepseek/deepseek-v4-flash-0731",
       "name": "DeepSeek V4 Flash 0731",
-      "cost_per_1m_in": 0.076,
-      "cost_per_1m_out": 0.153,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.014,
+      "pricing": {
+        "input": 0.076,
+        "output": 0.153,
+        "cache_hit": 0.014
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -463,10 +501,11 @@
     {
       "id": "deepseek/deepseek-v4-flash-vision-exp",
       "name": "DeepSeek V4 Flash Vision Exp",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 0.66,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.007,
+      "pricing": {
+        "input": 0.22,
+        "output": 0.66,
+        "cache_hit": 0.007
+      },
       "context_window": 1048576,
       "default_max_tokens": 1048576,
       "can_reason": true,
@@ -481,10 +520,11 @@
     {
       "id": "deepseek/deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
-      "cost_per_1m_in": 0.66,
-      "cost_per_1m_out": 1.98,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.022,
+      "pricing": {
+        "input": 0.66,
+        "output": 1.98,
+        "cache_hit": 0.022
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -499,10 +539,11 @@
     {
       "id": "deepseek/deepseek-v4-pro-0813",
       "name": "DeepSeek V4 Pro 0813",
-      "cost_per_1m_in": 0.66,
-      "cost_per_1m_out": 1.98,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.066,
+      "pricing": {
+        "input": 0.66,
+        "output": 1.98,
+        "cache_hit": 0.066
+      },
       "context_window": 1000000,
       "default_max_tokens": 384000,
       "can_reason": true,
@@ -517,10 +558,10 @@
     {
       "id": "deepseek/deepseek-r1",
       "name": "DeepSeek-R1",
-      "cost_per_1m_in": 1.35,
-      "cost_per_1m_out": 5.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.35,
+        "output": 5.4
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -535,10 +576,10 @@
     {
       "id": "mistral/devstral-2",
       "name": "Devstral 2",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 2
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": false,
@@ -547,10 +588,10 @@
     {
       "id": "mistral/devstral-small-2",
       "name": "Devstral Small 2",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.3
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": false,
@@ -559,10 +600,11 @@
     {
       "id": "sakana/fugu-ultra",
       "name": "Fugu Ultra",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 30,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 1000000,
       "can_reason": true,
@@ -577,10 +619,11 @@
     {
       "id": "zai/glm-4.5",
       "name": "GLM 4.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_hit": 0.11
+      },
       "context_window": 128000,
       "default_max_tokens": 96000,
       "can_reason": true,
@@ -595,10 +638,11 @@
     {
       "id": "zai/glm-4.5-air",
       "name": "GLM 4.5 Air",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.1,
+        "cache_hit": 0.03
+      },
       "context_window": 128000,
       "default_max_tokens": 96000,
       "can_reason": true,
@@ -613,10 +657,11 @@
     {
       "id": "zai/glm-4.5v",
       "name": "GLM 4.5V",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 1.8,
+        "cache_hit": 0.11
+      },
       "context_window": 66000,
       "default_max_tokens": 16000,
       "can_reason": true,
@@ -631,10 +676,11 @@
     {
       "id": "zai/glm-4.6",
       "name": "GLM 4.6",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_hit": 0.11
+      },
       "context_window": 200000,
       "default_max_tokens": 96000,
       "can_reason": true,
@@ -649,10 +695,11 @@
     {
       "id": "zai/glm-4.7",
       "name": "GLM 4.7",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.12,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_hit": 0.12
+      },
       "context_window": 200000,
       "default_max_tokens": 120000,
       "can_reason": true,
@@ -667,10 +714,10 @@
     {
       "id": "zai/glm-4.7-flash",
       "name": "GLM 4.7 Flash",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.07,
+        "output": 0.4
+      },
       "context_window": 200000,
       "default_max_tokens": 131000,
       "can_reason": true,
@@ -685,10 +732,11 @@
     {
       "id": "zai/glm-4.7-flashx",
       "name": "GLM 4.7 FlashX",
-      "cost_per_1m_in": 0.06,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.06,
+        "output": 0.4,
+        "cache_hit": 0.01
+      },
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -703,10 +751,10 @@
     {
       "id": "zai/glm-5",
       "name": "GLM 5",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1,
+        "output": 3.2
+      },
       "context_window": 202800,
       "default_max_tokens": 131100,
       "can_reason": true,
@@ -721,10 +769,11 @@
     {
       "id": "zai/glm-5-turbo",
       "name": "GLM 5 Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 4,
+        "cache_hit": 0.24
+      },
       "context_window": 202800,
       "default_max_tokens": 131100,
       "can_reason": true,
@@ -739,10 +788,11 @@
     {
       "id": "zai/glm-5.1",
       "name": "GLM 5.1",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.26,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.26
+      },
       "context_window": 202800,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -757,10 +807,11 @@
     {
       "id": "zai/glm-5.2",
       "name": "GLM 5.2",
-      "cost_per_1m_in": 0.8,
-      "cost_per_1m_out": 2.55,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.16,
+      "pricing": {
+        "input": 0.8,
+        "output": 2.55,
+        "cache_hit": 0.16
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -774,10 +825,11 @@
     {
       "id": "zai/glm-5.2-fast",
       "name": "GLM 5.2 Fast",
-      "cost_per_1m_in": 2.1,
-      "cost_per_1m_out": 6.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.21,
+      "pricing": {
+        "input": 2.1,
+        "output": 6.6,
+        "cache_hit": 0.21
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -792,10 +844,11 @@
     {
       "id": "zai/glm-5.3",
       "name": "GLM 5.3",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.14,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.14
+      },
       "context_window": 1000000,
       "default_max_tokens": 1000000,
       "can_reason": true,
@@ -810,10 +863,11 @@
     {
       "id": "zai/glm-5.3-promo-50",
       "name": "GLM 5.3 (50% off)",
-      "cost_per_1m_in": 0.7,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 0.7,
+        "output": 2.2,
+        "cache_hit": 0.13
+      },
       "context_window": 1048576,
       "default_max_tokens": 1048576,
       "can_reason": true,
@@ -828,10 +882,11 @@
     {
       "id": "zai/glm-5.3-flash",
       "name": "GLM 5.3 Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.5,
+        "cache_hit": 0.03
+      },
       "context_window": 1000000,
       "default_max_tokens": 131000,
       "can_reason": true,
@@ -846,10 +901,11 @@
     {
       "id": "zai/glm-5v-turbo",
       "name": "GLM 5V Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 4,
+        "cache_hit": 0.24
+      },
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -864,10 +920,11 @@
     {
       "id": "openai/gpt-5.1-codex-max",
       "name": "GPT 5.1 Codex Max",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -882,10 +939,11 @@
     {
       "id": "openai/gpt-5.1-codex-mini",
       "name": "GPT 5.1 Codex Mini",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_hit": 0.03
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -900,10 +958,11 @@
     {
       "id": "openai/gpt-5.1-thinking",
       "name": "GPT 5.1 Thinking",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -918,10 +977,11 @@
     {
       "id": "openai/gpt-5.1-thinking-fast",
       "name": "GPT 5.1 Thinking (Fast)",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 20,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 20,
+        "cache_hit": 0.25
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -936,10 +996,11 @@
     {
       "id": "openai/gpt-5.2",
       "name": "GPT 5.2",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -954,10 +1015,10 @@
     {
       "id": "openai/gpt-5.2-pro",
       "name": "GPT 5.2 ",
-      "cost_per_1m_in": 21,
-      "cost_per_1m_out": 168,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 21,
+        "output": 168
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -972,10 +1033,11 @@
     {
       "id": "openai/gpt-5.2-fast",
       "name": "GPT 5.2 (Fast)",
-      "cost_per_1m_in": 3.5,
-      "cost_per_1m_out": 28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.35,
+      "pricing": {
+        "input": 3.5,
+        "output": 28,
+        "cache_hit": 0.35
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -990,10 +1052,11 @@
     {
       "id": "openai/gpt-5.2-codex",
       "name": "GPT 5.2 Codex",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1008,10 +1071,11 @@
     {
       "id": "openai/gpt-5.3-codex",
       "name": "GPT 5.3 Codex",
-      "cost_per_1m_in": 1.75,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 1.75,
+        "output": 14,
+        "cache_hit": 0.175
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1026,10 +1090,11 @@
     {
       "id": "openai/gpt-5.3-codex-fast",
       "name": "GPT 5.3 Codex (Fast)",
-      "cost_per_1m_in": 3.5,
-      "cost_per_1m_out": 28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.35,
+      "pricing": {
+        "input": 3.5,
+        "output": 28,
+        "cache_hit": 0.35
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1044,10 +1109,11 @@
     {
       "id": "openai/gpt-5.4",
       "name": "GPT 5.4",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 15,
+        "cache_hit": 0.25
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1062,10 +1128,11 @@
     {
       "id": "openai/gpt-5.4-fast",
       "name": "GPT 5.4 (Fast)",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 30,
+        "cache_hit": 0.5
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1080,10 +1147,11 @@
     {
       "id": "openai/gpt-5.4-mini",
       "name": "GPT 5.4 Mini",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 4.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.75,
+        "output": 4.5,
+        "cache_hit": 0.075
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1098,10 +1166,11 @@
     {
       "id": "openai/gpt-5.4-mini-fast",
       "name": "GPT 5.4 Mini (Fast)",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.5,
+        "output": 9,
+        "cache_hit": 0.15
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1116,10 +1185,11 @@
     {
       "id": "openai/gpt-5.4-nano",
       "name": "GPT 5.4 Nano",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.25,
+        "cache_hit": 0.02
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1134,10 +1204,10 @@
     {
       "id": "openai/gpt-5.4-pro",
       "name": "GPT 5.4 Pro",
-      "cost_per_1m_in": 30,
-      "cost_per_1m_out": 180,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 30,
+        "output": 180
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1152,10 +1222,11 @@
     {
       "id": "openai/gpt-5.5",
       "name": "GPT 5.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 5,
+        "output": 30,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1170,10 +1241,11 @@
     {
       "id": "openai/gpt-5.5-fast",
       "name": "GPT 5.5 (Fast)",
-      "cost_per_1m_in": 12.5,
-      "cost_per_1m_out": 75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1.25,
+      "pricing": {
+        "input": 12.5,
+        "output": 75,
+        "cache_hit": 1.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1188,10 +1260,10 @@
     {
       "id": "openai/gpt-5.5-pro",
       "name": "GPT 5.5 Pro",
-      "cost_per_1m_in": 30,
-      "cost_per_1m_out": 180,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 30,
+        "output": 180
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1206,10 +1278,12 @@
     {
       "id": "openai/gpt-5.6-luna",
       "name": "GPT 5.6 Luna",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.25,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.2,
+        "cache_create": 0.25,
+        "cache_hit": 0.02
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1224,10 +1298,12 @@
     {
       "id": "openai/gpt-5.6-luna-fast",
       "name": "GPT 5.6 Luna (Fast)",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.25,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.4,
+        "output": 2.4,
+        "cache_create": 0.25,
+        "cache_hit": 0.04
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1242,10 +1318,12 @@
     {
       "id": "openai/gpt-5.6-sol",
       "name": "GPT 5.6 Sol",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 10,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1260,10 +1338,12 @@
     {
       "id": "openai/gpt-5.6-sol-fast",
       "name": "GPT 5.6 Sol (Fast)",
-      "cost_per_1m_in": 4,
-      "cost_per_1m_out": 20,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.4,
+      "pricing": {
+        "input": 4,
+        "output": 20,
+        "cache_create": 2.5,
+        "cache_hit": 0.4
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1278,10 +1358,12 @@
     {
       "id": "openai/gpt-5.6-terra",
       "name": "GPT 5.6 Terra",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_create": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1296,10 +1378,12 @@
     {
       "id": "openai/gpt-5.6-terra-fast",
       "name": "GPT 5.6 Terra (Fast)",
-      "cost_per_1m_in": 4,
-      "cost_per_1m_out": 24,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.4,
+      "pricing": {
+        "input": 4,
+        "output": 24,
+        "cache_create": 2.5,
+        "cache_hit": 0.4
+      },
       "context_window": 1050000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1314,10 +1398,10 @@
     {
       "id": "openai/gpt-oss-120b",
       "name": "GPT OSS 120B",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.5
+      },
       "context_window": 131072,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1332,10 +1416,10 @@
     {
       "id": "openai/gpt-oss-20b",
       "name": "GPT OSS 20B",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.2
+      },
       "context_window": 131072,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -1350,10 +1434,10 @@
     {
       "id": "openai/gpt-oss-safeguard-120b",
       "name": "GPT OSS Safeguard 120B",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6
+      },
       "context_window": 128000,
       "default_max_tokens": 16000,
       "can_reason": true,
@@ -1368,10 +1452,10 @@
     {
       "id": "openai/gpt-oss-safeguard-20b",
       "name": "GPT OSS Safeguard 20B",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.07,
+        "output": 0.2
+      },
       "context_window": 128000,
       "default_max_tokens": 16000,
       "can_reason": true,
@@ -1386,10 +1470,10 @@
     {
       "id": "openai/gpt-3.5-turbo",
       "name": "GPT-3.5 Turbo",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 1.5
+      },
       "context_window": 16385,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -1398,10 +1482,10 @@
     {
       "id": "openai/gpt-4-turbo",
       "name": "GPT-4 Turbo",
-      "cost_per_1m_in": 10,
-      "cost_per_1m_out": 30,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 10,
+        "output": 30
+      },
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
@@ -1410,10 +1494,11 @@
     {
       "id": "openai/gpt-4.1",
       "name": "GPT-4.1",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -1422,10 +1507,11 @@
     {
       "id": "openai/gpt-4.1-fast",
       "name": "GPT-4.1 (Fast)",
-      "cost_per_1m_in": 3.5,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.875,
+      "pricing": {
+        "input": 3.5,
+        "output": 14,
+        "cache_hit": 0.875
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -1434,10 +1520,11 @@
     {
       "id": "openai/gpt-4.1-mini",
       "name": "GPT-4.1 mini",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 1.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_hit": 0.1
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -1446,10 +1533,11 @@
     {
       "id": "openai/gpt-4.1-mini-fast",
       "name": "GPT-4.1 mini (Fast)",
-      "cost_per_1m_in": 0.7,
-      "cost_per_1m_out": 2.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.175,
+      "pricing": {
+        "input": 0.7,
+        "output": 2.8,
+        "cache_hit": 0.175
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -1458,10 +1546,11 @@
     {
       "id": "openai/gpt-4.1-nano",
       "name": "GPT-4.1 nano",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_hit": 0.025
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -1470,10 +1559,11 @@
     {
       "id": "openai/gpt-4.1-nano-fast",
       "name": "GPT-4.1 nano (Fast)",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.8,
+        "cache_hit": 0.05
+      },
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -1482,10 +1572,11 @@
     {
       "id": "openai/gpt-4o",
       "name": "GPT-4o",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 10,
+        "cache_hit": 1.25
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1494,10 +1585,11 @@
     {
       "id": "openai/gpt-4o-fast",
       "name": "GPT-4o (Fast)",
-      "cost_per_1m_in": 4.25,
-      "cost_per_1m_out": 17,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 2.125,
+      "pricing": {
+        "input": 4.25,
+        "output": 17,
+        "cache_hit": 2.125
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1506,10 +1598,11 @@
     {
       "id": "openai/gpt-4o-mini",
       "name": "GPT-4o mini",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.075
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1518,10 +1611,11 @@
     {
       "id": "openai/gpt-4o-mini-fast",
       "name": "GPT-4o mini (Fast)",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 0.25,
+        "output": 1,
+        "cache_hit": 0.125
+      },
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -1530,10 +1624,11 @@
     {
       "id": "openai/gpt-5",
       "name": "GPT-5",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1548,10 +1643,11 @@
     {
       "id": "openai/gpt-5-fast",
       "name": "GPT-5 (Fast)",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 20,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2.5,
+        "output": 20,
+        "cache_hit": 0.25
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1566,10 +1662,11 @@
     {
       "id": "openai/gpt-5-mini",
       "name": "GPT-5 mini",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_hit": 0.025
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1584,10 +1681,11 @@
     {
       "id": "openai/gpt-5-mini-fast",
       "name": "GPT-5 mini (Fast)",
-      "cost_per_1m_in": 0.45,
-      "cost_per_1m_out": 3.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.045,
+      "pricing": {
+        "input": 0.45,
+        "output": 3.6,
+        "cache_hit": 0.045
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1602,10 +1700,11 @@
     {
       "id": "openai/gpt-5-nano",
       "name": "GPT-5 nano",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.005,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.4,
+        "cache_hit": 0.005
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1620,10 +1719,10 @@
     {
       "id": "openai/gpt-5-pro",
       "name": "GPT-5 pro",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 120,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 15,
+        "output": 120
+      },
       "context_window": 400000,
       "default_max_tokens": 272000,
       "can_reason": true,
@@ -1638,10 +1737,11 @@
     {
       "id": "openai/gpt-5-codex",
       "name": "GPT-5-Codex",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.13
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1656,10 +1756,11 @@
     {
       "id": "openai/gpt-5.1-codex",
       "name": "GPT-5.1-Codex",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.13,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.13
+      },
       "context_window": 400000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -1674,10 +1775,11 @@
     {
       "id": "google/gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_hit": 0.03
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1692,10 +1794,11 @@
     {
       "id": "google/gemini-2.5-flash-lite",
       "name": "Gemini 2.5 Flash Lite",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_hit": 0.01
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1710,10 +1813,11 @@
     {
       "id": "google/gemini-2.5-pro",
       "name": "Gemini 2.5 Pro",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 1048576,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1728,10 +1832,11 @@
     {
       "id": "google/gemini-3-flash",
       "name": "Gemini 3 Flash",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_hit": 0.05
+      },
       "context_window": 1000000,
       "default_max_tokens": 65000,
       "can_reason": true,
@@ -1746,10 +1851,11 @@
     {
       "id": "google/gemini-3.1-flash-lite",
       "name": "Gemini 3.1 Flash Lite",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.25,
+        "output": 1.5,
+        "cache_hit": 0.03
+      },
       "context_window": 1000000,
       "default_max_tokens": 65000,
       "can_reason": true,
@@ -1764,10 +1870,11 @@
     {
       "id": "google/gemini-3.1-pro-preview",
       "name": "Gemini 3.1 Pro Preview",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1782,10 +1889,11 @@
     {
       "id": "google/gemini-3.5-flash",
       "name": "Gemini 3.5 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.5,
+        "output": 9,
+        "cache_hit": 0.15
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1800,10 +1908,11 @@
     {
       "id": "google/gemini-3.5-flash-lite",
       "name": "Gemini 3.5 Flash Lite",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_hit": 0.03
+      },
       "context_window": 1000000,
       "default_max_tokens": 65000,
       "can_reason": true,
@@ -1818,10 +1927,11 @@
     {
       "id": "google/gemini-3.6-flash",
       "name": "Gemini 3.6 Flash",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 3.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.75,
+        "output": 3.75,
+        "cache_hit": 0.075
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -1836,10 +1946,11 @@
     {
       "id": "google/gemini-3.7-flash",
       "name": "Gemini 3.7 Flash",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 3.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.75,
+        "output": 3.75,
+        "cache_hit": 0.075
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1854,10 +1965,11 @@
     {
       "id": "google/gemini-3.8-flash",
       "name": "Gemini 3.8 Flash",
-      "cost_per_1m_in": 0.75,
-      "cost_per_1m_out": 3.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.75,
+        "output": 3.75,
+        "cache_hit": 0.075
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -1872,10 +1984,10 @@
     {
       "id": "google/gemma-4-31b-it",
       "name": "Gemma 4 31B IT",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.4
+      },
       "context_window": 262144,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1890,10 +2002,11 @@
     {
       "id": "google/gemma-4-26b-a4b-it",
       "name": "Google Gemma 4 26B A4B",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.015,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.015
+      },
       "context_window": 262144,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -1908,10 +2021,11 @@
     {
       "id": "spacexai/grok-4.1-fast-non-reasoning",
       "name": "Grok 4.1 Fast Non-Reasoning",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.5,
+        "cache_hit": 0.05
+      },
       "context_window": 1000000,
       "default_max_tokens": 1000000,
       "can_reason": false,
@@ -1920,10 +2034,11 @@
     {
       "id": "spacexai/grok-4.1-fast-reasoning",
       "name": "Grok 4.1 Fast Reasoning",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.5,
+        "cache_hit": 0.05
+      },
       "context_window": 1000000,
       "default_max_tokens": 1000000,
       "can_reason": true,
@@ -1938,10 +2053,11 @@
     {
       "id": "spacexai/grok-4.20-non-reasoning-beta",
       "name": "Grok 4.20 Beta Non-Reasoning",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 2000000,
       "can_reason": false,
@@ -1950,10 +2066,11 @@
     {
       "id": "spacexai/grok-4.20-reasoning-beta",
       "name": "Grok 4.20 Beta Reasoning",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 2000000,
       "can_reason": true,
@@ -1968,10 +2085,11 @@
     {
       "id": "spacexai/grok-4.20-multi-agent-beta",
       "name": "Grok 4.20 Multi Agent Beta",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 2000000,
       "can_reason": true,
@@ -1986,10 +2104,11 @@
     {
       "id": "spacexai/grok-4.20-multi-agent",
       "name": "Grok 4.20 Multi-Agent",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 2000000,
       "can_reason": true,
@@ -2004,10 +2123,11 @@
     {
       "id": "spacexai/grok-4.20-non-reasoning",
       "name": "Grok 4.20 Non-Reasoning",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 2000000,
       "can_reason": false,
@@ -2016,10 +2136,11 @@
     {
       "id": "spacexai/grok-4.20-reasoning",
       "name": "Grok 4.20 Reasoning",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 2000000,
       "default_max_tokens": 2000000,
       "can_reason": true,
@@ -2034,10 +2155,11 @@
     {
       "id": "spacexai/grok-4.3",
       "name": "Grok 4.3",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 1000000,
       "can_reason": true,
@@ -2052,10 +2174,11 @@
     {
       "id": "spacexai/grok-4.5",
       "name": "Grok 4.5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.3
+      },
       "context_window": 500000,
       "default_max_tokens": 500000,
       "can_reason": true,
@@ -2070,10 +2193,11 @@
     {
       "id": "spacexai/grok-4.6",
       "name": "Grok 4.6",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.5
+      },
       "context_window": 500000,
       "default_max_tokens": 500000,
       "can_reason": true,
@@ -2088,10 +2212,11 @@
     {
       "id": "spacexai/grok-build-0.1",
       "name": "Grok Build 0.1",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1,
+        "output": 2,
+        "cache_hit": 0.2
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": true,
@@ -2106,10 +2231,11 @@
     {
       "id": "tencent/hy3",
       "name": "Hy3",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.58,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.035,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.58,
+        "cache_hit": 0.035
+      },
       "context_window": 262144,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -2124,10 +2250,11 @@
     {
       "id": "thinkingmachines/inkling",
       "name": "Inkling",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 4.05,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.17,
+      "pricing": {
+        "input": 1,
+        "output": 4.05,
+        "cache_hit": 0.17
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": true,
@@ -2142,10 +2269,11 @@
     {
       "id": "thinkingmachines/inkling-small",
       "name": "Inkling Small",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.5,
+        "output": 1.2,
+        "cache_hit": 0.1
+      },
       "context_window": 1000000,
       "default_max_tokens": 1000000,
       "can_reason": true,
@@ -2160,10 +2288,10 @@
     {
       "id": "interfaze/interfaze-beta",
       "name": "Interfaze Beta",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 3.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.5,
+        "output": 3.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -2178,10 +2306,11 @@
     {
       "id": "kwaipilot/kat-coder-pro-v1",
       "name": "KAT-Coder-Pro V1",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.06
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
@@ -2190,10 +2319,11 @@
     {
       "id": "kwaipilot/kat-coder-air-v2.5",
       "name": "Kat Coder Air V2.5",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6,
+        "cache_hit": 0.03
+      },
       "context_window": 256000,
       "default_max_tokens": 80000,
       "can_reason": true,
@@ -2208,10 +2338,11 @@
     {
       "id": "kwaipilot/kat-coder-pro-v2",
       "name": "Kat Coder Pro V2",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.06
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": true,
@@ -2226,10 +2357,11 @@
     {
       "id": "kwaipilot/kat-coder-pro-v2.5",
       "name": "Kat Coder Pro V2.5",
-      "cost_per_1m_in": 0.74,
-      "cost_per_1m_out": 2.96,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 0.74,
+        "output": 2.96,
+        "cache_hit": 0.15
+      },
       "context_window": 256000,
       "default_max_tokens": 80000,
       "can_reason": true,
@@ -2244,10 +2376,10 @@
     {
       "id": "moonshotai/kimi-k2",
       "name": "Kimi K2 Instruct",
-      "cost_per_1m_in": 0.57,
-      "cost_per_1m_out": 2.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.57,
+        "output": 2.3
+      },
       "context_window": 131072,
       "default_max_tokens": 131072,
       "can_reason": false,
@@ -2256,10 +2388,11 @@
     {
       "id": "moonshotai/kimi-k2-thinking",
       "name": "Kimi K2 Thinking",
-      "cost_per_1m_in": 0.47,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.141,
+      "pricing": {
+        "input": 0.47,
+        "output": 2,
+        "cache_hit": 0.141
+      },
       "context_window": 216144,
       "default_max_tokens": 216144,
       "can_reason": true,
@@ -2274,10 +2407,11 @@
     {
       "id": "moonshotai/kimi-k2.5",
       "name": "Kimi K2.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.6,
+        "output": 3,
+        "cache_hit": 0.1
+      },
       "context_window": 262114,
       "default_max_tokens": 262114,
       "can_reason": true,
@@ -2292,10 +2426,11 @@
     {
       "id": "moonshotai/kimi-k2.6",
       "name": "Kimi K2.6",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.16,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_hit": 0.16
+      },
       "context_window": 262000,
       "default_max_tokens": 262000,
       "can_reason": true,
@@ -2310,10 +2445,11 @@
     {
       "id": "moonshotai/kimi-k2.7-code",
       "name": "Kimi K2.7 Code",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.16,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_hit": 0.16
+      },
       "context_window": 256000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -2328,10 +2464,11 @@
     {
       "id": "moonshotai/kimi-k2.7-code-highspeed",
       "name": "Kimi K2.7 Code High Speed",
-      "cost_per_1m_in": 1.9,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.38,
+      "pricing": {
+        "input": 1.9,
+        "output": 8,
+        "cache_hit": 0.38
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -2346,10 +2483,11 @@
     {
       "id": "moonshotai/kimi-k3",
       "name": "Kimi K3",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -2364,10 +2502,11 @@
     {
       "id": "moonshotai/kimi-k3-fast",
       "name": "Kimi K3 Fast",
-      "cost_per_1m_in": 4.5,
-      "cost_per_1m_out": 22.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.45,
+      "pricing": {
+        "input": 4.5,
+        "output": 22.5,
+        "cache_hit": 0.45
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -2382,10 +2521,11 @@
     {
       "id": "poolside/laguna-s-2.1",
       "name": "Laguna S 2.1",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.2,
+        "cache_hit": 0.01
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -2400,10 +2540,10 @@
     {
       "id": "poolside/laguna-s-2.1-free",
       "name": "Laguna S 2.1 Free",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -2418,10 +2558,11 @@
     {
       "id": "inclusionai/ling-3.0-flash",
       "name": "Ling 3.0 Flash",
-      "cost_per_1m_in": 0.06,
-      "cost_per_1m_out": 0.18,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.012,
+      "pricing": {
+        "input": 0.06,
+        "output": 0.18,
+        "cache_hit": 0.012
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -2436,10 +2577,10 @@
     {
       "id": "inclusionai/ling-3.0-flash-fin",
       "name": "Ling 3.0 Flash Fin",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -2454,10 +2595,10 @@
     {
       "id": "inclusionai/ling-3.0-flash-fin-free",
       "name": "Ling 3.0 Flash Fin (Free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -2472,10 +2613,10 @@
     {
       "id": "meta/llama-3.1-70b",
       "name": "Llama 3.1 70B Instruct",
-      "cost_per_1m_in": 0.72,
-      "cost_per_1m_out": 0.72,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.72,
+        "output": 0.72
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2484,10 +2625,10 @@
     {
       "id": "meta/llama-3.1-8b",
       "name": "Llama 3.1 8B Instruct",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 0.22,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.22,
+        "output": 0.22
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2496,10 +2637,10 @@
     {
       "id": "meta/llama-3.3-70b",
       "name": "Llama 3.3 70B Instruct",
-      "cost_per_1m_in": 0.72,
-      "cost_per_1m_out": 0.72,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.72,
+        "output": 0.72
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2508,10 +2649,10 @@
     {
       "id": "meta/llama-4-maverick",
       "name": "Llama 4 Maverick 17B Instruct",
-      "cost_per_1m_in": 0.24,
-      "cost_per_1m_out": 0.97,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.24,
+        "output": 0.97
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2520,10 +2661,10 @@
     {
       "id": "meta/llama-4-scout",
       "name": "Llama 4 Scout 17B Instruct",
-      "cost_per_1m_in": 0.17,
-      "cost_per_1m_out": 0.66,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.17,
+        "output": 0.66
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -2532,10 +2673,11 @@
     {
       "id": "inception/mercury-2",
       "name": "Mercury 2",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.75,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.025,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.75,
+        "cache_hit": 0.025
+      },
       "context_window": 128000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -2550,10 +2692,10 @@
     {
       "id": "inception/mercury-coder-small",
       "name": "Mercury Coder Small Beta",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 1
+      },
       "context_window": 32000,
       "default_max_tokens": 16384,
       "can_reason": false,
@@ -2562,10 +2704,11 @@
     {
       "id": "xiaomi/mimo-v2.5",
       "name": "MiMo M2.5",
-      "cost_per_1m_in": 0.14,
-      "cost_per_1m_out": 0.28,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0028,
+      "pricing": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_hit": 0.0028
+      },
       "context_window": 1050000,
       "default_max_tokens": 131100,
       "can_reason": true,
@@ -2580,10 +2723,11 @@
     {
       "id": "xiaomi/mimo-v2.5-pro",
       "name": "MiMo V2.5 Pro",
-      "cost_per_1m_in": 0.435,
-      "cost_per_1m_out": 0.87,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0036,
+      "pricing": {
+        "input": 0.435,
+        "output": 0.87,
+        "cache_hit": 0.0036
+      },
       "context_window": 1050000,
       "default_max_tokens": 131000,
       "can_reason": true,
@@ -2598,10 +2742,11 @@
     {
       "id": "xiaomi/mimo-v2.5-pro-ultraspeed",
       "name": "MiMo V2.5 Pro UltraSpeed",
-      "cost_per_1m_in": 1.305,
-      "cost_per_1m_out": 2.61,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.0108,
+      "pricing": {
+        "input": 1.305,
+        "output": 2.61,
+        "cache_hit": 0.0108
+      },
       "context_window": 1048576,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -2616,10 +2761,12 @@
     {
       "id": "minimax/minimax-m2",
       "name": "MiniMax M2",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.375,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.375,
+        "cache_hit": 0.03
+      },
       "context_window": 205000,
       "default_max_tokens": 205000,
       "can_reason": true,
@@ -2634,10 +2781,12 @@
     {
       "id": "minimax/minimax-m2.1",
       "name": "MiniMax M2.1",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.375,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.375,
+        "cache_hit": 0.03
+      },
       "context_window": 204800,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -2652,10 +2801,12 @@
     {
       "id": "minimax/minimax-m2.1-lightning",
       "name": "MiniMax M2.1 Lightning",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.375,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.4,
+        "cache_create": 0.375,
+        "cache_hit": 0.03
+      },
       "context_window": 204800,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -2670,10 +2821,12 @@
     {
       "id": "minimax/minimax-m2.5",
       "name": "MiniMax M2.5",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.375,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.375,
+        "cache_hit": 0.03
+      },
       "context_window": 204800,
       "default_max_tokens": 131000,
       "can_reason": true,
@@ -2688,10 +2841,12 @@
     {
       "id": "minimax/minimax-m2.5-highspeed",
       "name": "MiniMax M2.5 High Speed",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.375,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_create": 0.375,
+        "cache_hit": 0.03
+      },
       "context_window": 204800,
       "default_max_tokens": 131000,
       "can_reason": true,
@@ -2706,10 +2861,12 @@
     {
       "id": "minimax/minimax-m2.7",
       "name": "MiniMax M2.7",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0.375,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_create": 0.375,
+        "cache_hit": 0.06
+      },
       "context_window": 204800,
       "default_max_tokens": 131000,
       "can_reason": true,
@@ -2724,10 +2881,10 @@
     {
       "id": "minimax/minimax-m2.7-free",
       "name": "MiniMax M2.7 (Free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 196608,
       "default_max_tokens": 196608,
       "can_reason": true,
@@ -2742,10 +2899,12 @@
     {
       "id": "minimax/minimax-m2.7-highspeed",
       "name": "MiniMax M2.7 High Speed",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.375,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_create": 0.375,
+        "cache_hit": 0.06
+      },
       "context_window": 204800,
       "default_max_tokens": 131100,
       "can_reason": true,
@@ -2760,10 +2919,11 @@
     {
       "id": "minimax/minimax-m3",
       "name": "MiniMax M3",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.06,
+      "pricing": {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_hit": 0.06
+      },
       "context_window": 512000,
       "default_max_tokens": 512000,
       "can_reason": true,
@@ -2778,10 +2938,10 @@
     {
       "id": "minimax/minimax-m3-free",
       "name": "MiniMax M3 (Free)",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1048576,
       "default_max_tokens": 1048576,
       "can_reason": true,
@@ -2796,10 +2956,10 @@
     {
       "id": "mistral/ministral-14b",
       "name": "Ministral 14B",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.2
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": false,
@@ -2808,10 +2968,10 @@
     {
       "id": "mistral/ministral-3b",
       "name": "Ministral 3B",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.1,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.1
+      },
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
@@ -2820,10 +2980,10 @@
     {
       "id": "mistral/ministral-8b",
       "name": "Ministral 8B",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.15
+      },
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
@@ -2832,10 +2992,10 @@
     {
       "id": "mistral/codestral",
       "name": "Mistral Codestral",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.9
+      },
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
@@ -2844,10 +3004,10 @@
     {
       "id": "mistral/mistral-large-3",
       "name": "Mistral Large 3",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 1.5
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": false,
@@ -2856,10 +3016,10 @@
     {
       "id": "mistral/mistral-medium",
       "name": "Mistral Medium 3.1",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 2
+      },
       "context_window": 128000,
       "default_max_tokens": 64000,
       "can_reason": false,
@@ -2868,10 +3028,10 @@
     {
       "id": "mistral/mistral-medium-3.5",
       "name": "Mistral Medium Latest",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 1.5,
+        "output": 7.5
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": true,
@@ -2886,10 +3046,10 @@
     {
       "id": "mistral/mistral-nemo",
       "name": "Mistral Nemo 12B",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.15
+      },
       "context_window": 128000,
       "default_max_tokens": 128000,
       "can_reason": false,
@@ -2898,10 +3058,10 @@
     {
       "id": "mistral/mistral-small",
       "name": "Mistral Small",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.3
+      },
       "context_window": 32000,
       "default_max_tokens": 4000,
       "can_reason": false,
@@ -2910,10 +3070,11 @@
     {
       "id": "meta/muse-glimmer-30b",
       "name": "Muse Glimmer 30B",
-      "cost_per_1m_in": 0.35,
-      "cost_per_1m_out": 1.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.35,
+        "output": 1.5,
+        "cache_hit": 0.04
+      },
       "context_window": 131072,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -2928,10 +3089,11 @@
     {
       "id": "meta/muse-spark-1.1",
       "name": "Muse Spark 1.1",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 4.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.25,
+        "output": 4.25,
+        "cache_hit": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 1048576,
       "can_reason": true,
@@ -2946,10 +3108,11 @@
     {
       "id": "meta/muse-spark-1.2",
       "name": "Muse Spark 1.2",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 4.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.25,
+        "output": 4.25,
+        "cache_hit": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 1048576,
       "can_reason": true,
@@ -2964,10 +3127,11 @@
     {
       "id": "meta/muse-spark-1.2-contributor",
       "name": "Muse Spark 1.2 Contributor",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.002,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.2,
+        "cache_hit": 0.002
+      },
       "context_window": 1048576,
       "default_max_tokens": 1048576,
       "can_reason": true,
@@ -2982,10 +3146,11 @@
     {
       "id": "meta/muse-spark-1.3",
       "name": "Muse Spark 1.3",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 4.25,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 1.25,
+        "output": 4.25,
+        "cache_hit": 0.15
+      },
       "context_window": 1048576,
       "default_max_tokens": 1048576,
       "can_reason": true,
@@ -3000,10 +3165,11 @@
     {
       "id": "meta/muse-spark-1.3-contributor",
       "name": "Muse Spark 1.3 Contributor",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.002,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.2,
+        "cache_hit": 0.002
+      },
       "context_window": 1048576,
       "default_max_tokens": 1048576,
       "can_reason": true,
@@ -3018,10 +3184,10 @@
     {
       "id": "nvidia/nemotron-3-super-120b-a12b",
       "name": "NVIDIA Nemotron 3 Super 120B A12B",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.65,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.65
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -3036,10 +3202,10 @@
     {
       "id": "nvidia/nemotron-3-nano-30b-a3b",
       "name": "Nemotron 3 Nano 30B A3B",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.24,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.24
+      },
       "context_window": 262144,
       "default_max_tokens": 262144,
       "can_reason": true,
@@ -3054,10 +3220,11 @@
     {
       "id": "nvidia/nemotron-3-ultra-550b-a55b",
       "name": "Nemotron 3 Ultra",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.12,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_hit": 0.12
+      },
       "context_window": 1000000,
       "default_max_tokens": 65000,
       "can_reason": true,
@@ -3072,10 +3239,11 @@
     {
       "id": "nvidia/nemotron-3.5-lightning",
       "name": "Nemotron 3.5 Lightning 30B",
-      "cost_per_1m_in": 0.05,
-      "cost_per_1m_out": 0.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.05,
+        "output": 0.2,
+        "cache_hit": 0.01
+      },
       "context_window": 262144,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -3090,10 +3258,11 @@
     {
       "id": "amazon/nova-2-lite",
       "name": "Nova 2 Lite",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.075,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_hit": 0.075
+      },
       "context_window": 1000000,
       "default_max_tokens": 1000000,
       "can_reason": true,
@@ -3108,10 +3277,10 @@
     {
       "id": "amazon/nova-lite",
       "name": "Nova Lite",
-      "cost_per_1m_in": 0.06,
-      "cost_per_1m_out": 0.24,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.06,
+        "output": 0.24
+      },
       "context_window": 300000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -3120,10 +3289,10 @@
     {
       "id": "amazon/nova-micro",
       "name": "Nova Micro",
-      "cost_per_1m_in": 0.035,
-      "cost_per_1m_out": 0.14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.035,
+        "output": 0.14
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -3132,10 +3301,10 @@
     {
       "id": "amazon/nova-pro",
       "name": "Nova Pro",
-      "cost_per_1m_in": 0.8,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.8,
+        "output": 3.2
+      },
       "context_window": 300000,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -3144,10 +3313,10 @@
     {
       "id": "nvidia/nemotron-nano-12b-v2-vl",
       "name": "Nvidia Nemotron Nano 12B V2 VL",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.2,
+        "output": 0.6
+      },
       "context_window": 131072,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -3162,10 +3331,10 @@
     {
       "id": "nvidia/nemotron-nano-9b-v2",
       "name": "Nvidia Nemotron Nano 9B V2",
-      "cost_per_1m_in": 0.06,
-      "cost_per_1m_out": 0.23,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.06,
+        "output": 0.23
+      },
       "context_window": 131072,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -3180,10 +3349,10 @@
     {
       "id": "mistral/pixtral-12b",
       "name": "Pixtral 12B 2409",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.15
+      },
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
@@ -3192,10 +3361,10 @@
     {
       "id": "alibaba/qwen-3-32b",
       "name": "Qwen 3 32B",
-      "cost_per_1m_in": 0.16,
-      "cost_per_1m_out": 0.64,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.16,
+        "output": 0.64
+      },
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": true,
@@ -3210,10 +3379,10 @@
     {
       "id": "alibaba/qwen3-coder-30b-a3b",
       "name": "Qwen 3 Coder 30B A3B Instruct",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.6
+      },
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
@@ -3222,10 +3391,11 @@
     {
       "id": "alibaba/qwen3-max-thinking",
       "name": "Qwen 3 Max Thinking",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 6,
+        "cache_hit": 0.24
+      },
       "context_window": 256000,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -3240,10 +3410,12 @@
     {
       "id": "alibaba/qwen3.5-flash",
       "name": "Qwen 3.5 Flash",
-      "cost_per_1m_in": 0.1,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.125,
-      "cost_per_1m_out_cached": 0.001,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.4,
+        "cache_create": 0.125,
+        "cache_hit": 0.001
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -3258,10 +3430,12 @@
     {
       "id": "alibaba/qwen3.5-plus",
       "name": "Qwen 3.5 Plus",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 2.4,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.4,
+        "output": 2.4,
+        "cache_create": 0.5,
+        "cache_hit": 0.04
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -3276,10 +3450,10 @@
     {
       "id": "alibaba/qwen3.6-27b",
       "name": "Qwen 3.6 27B",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 3.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.6,
+        "output": 3.6
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": true,
@@ -3294,10 +3468,12 @@
     {
       "id": "alibaba/qwen-3.6-max-preview",
       "name": "Qwen 3.6 Max Preview",
-      "cost_per_1m_in": 1.3,
-      "cost_per_1m_out": 7.8,
-      "cost_per_1m_in_cached": 1.625,
-      "cost_per_1m_out_cached": 0.26,
+      "pricing": {
+        "input": 1.3,
+        "output": 7.8,
+        "cache_create": 1.625,
+        "cache_hit": 0.26
+      },
       "context_window": 240000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -3312,10 +3488,12 @@
     {
       "id": "alibaba/qwen3.6-plus",
       "name": "Qwen 3.6 Plus",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.625,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_create": 0.625,
+        "cache_hit": 0.1
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -3330,10 +3508,12 @@
     {
       "id": "alibaba/qwen3.7-flash",
       "name": "Qwen 3.7 Flash",
-      "cost_per_1m_in": 0.03,
-      "cost_per_1m_out": 0.13,
-      "cost_per_1m_in_cached": 0.038,
-      "cost_per_1m_out_cached": 0.006,
+      "pricing": {
+        "input": 0.03,
+        "output": 0.13,
+        "cache_create": 0.038,
+        "cache_hit": 0.006
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -3348,10 +3528,12 @@
     {
       "id": "alibaba/qwen3.7-max",
       "name": "Qwen 3.7 Max",
-      "cost_per_1m_in": 2.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 3.125,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2.5,
+        "output": 7.5,
+        "cache_create": 3.125,
+        "cache_hit": 0.5
+      },
       "context_window": 991000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -3366,10 +3548,12 @@
     {
       "id": "alibaba/qwen3.7-plus",
       "name": "Qwen 3.7 Plus",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 1.6,
-      "cost_per_1m_in_cached": 0.5,
-      "cost_per_1m_out_cached": 0.08,
+      "pricing": {
+        "input": 0.4,
+        "output": 1.6,
+        "cache_create": 0.5,
+        "cache_hit": 0.08
+      },
       "context_window": 1000000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -3384,10 +3568,12 @@
     {
       "id": "alibaba/qwen3.8-flash",
       "name": "Qwen 3.8 Flash",
-      "cost_per_1m_in": 0.16,
-      "cost_per_1m_out": 0.47,
-      "cost_per_1m_in_cached": 0.2,
-      "cost_per_1m_out_cached": 0.016,
+      "pricing": {
+        "input": 0.16,
+        "output": 0.47,
+        "cache_create": 0.2,
+        "cache_hit": 0.016
+      },
       "context_window": 991000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -3402,10 +3588,11 @@
     {
       "id": "alibaba/qwen3.8-flash-next",
       "name": "Qwen 3.8 Flash Next",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.01,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.4,
+        "cache_hit": 0.01
+      },
       "context_window": 1048576,
       "default_max_tokens": 1048576,
       "can_reason": true,
@@ -3420,10 +3607,12 @@
     {
       "id": "alibaba/qwen3.8-max",
       "name": "Qwen 3.8 Max",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_create": 2.5,
+        "cache_hit": 0.25
+      },
       "context_window": 1000000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -3438,10 +3627,10 @@
     {
       "id": "alibaba/qwen-3-235b",
       "name": "Qwen3 235B A22B",
-      "cost_per_1m_in": 0.22,
-      "cost_per_1m_out": 0.88,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.22,
+        "output": 0.88
+      },
       "context_window": 262144,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -3456,10 +3645,11 @@
     {
       "id": "alibaba/qwen3-coder",
       "name": "Qwen3 Coder 480B A35B Instruct",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 7.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 1.5,
+        "output": 7.5,
+        "cache_hit": 0.3
+      },
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -3468,10 +3658,10 @@
     {
       "id": "alibaba/qwen3-coder-next",
       "name": "Qwen3 Coder Next",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.5,
+        "output": 1.2
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": false,
@@ -3480,10 +3670,11 @@
     {
       "id": "alibaba/qwen3-coder-plus",
       "name": "Qwen3 Coder Plus",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1,
+        "output": 5,
+        "cache_hit": 0.2
+      },
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": false,
@@ -3492,10 +3683,11 @@
     {
       "id": "alibaba/qwen3-max",
       "name": "Qwen3 Max",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 6,
+        "cache_hit": 0.24
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -3504,10 +3696,11 @@
     {
       "id": "alibaba/qwen3-max-preview",
       "name": "Qwen3 Max Preview",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 6,
+        "cache_hit": 0.24
+      },
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -3516,10 +3709,10 @@
     {
       "id": "alibaba/qwen3-next-80b-a3b-instruct",
       "name": "Qwen3 Next 80B A3B Instruct",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 1.2
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": false,
@@ -3528,10 +3721,10 @@
     {
       "id": "alibaba/qwen3-next-80b-a3b-thinking",
       "name": "Qwen3 Next 80B A3B Thinking",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 1.2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.15,
+        "output": 1.2
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3546,10 +3739,10 @@
     {
       "id": "alibaba/qwen3-vl-235b-a22b-instruct",
       "name": "Qwen3 VL 235B A22B Instruct",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 1.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 1.6
+      },
       "context_window": 131072,
       "default_max_tokens": 129024,
       "can_reason": false,
@@ -3558,10 +3751,10 @@
     {
       "id": "alibaba/qwen3-vl-instruct",
       "name": "Qwen3 VL 235B A22B Instruct",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 1.6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 1.6
+      },
       "context_window": 131072,
       "default_max_tokens": 129024,
       "can_reason": false,
@@ -3570,10 +3763,10 @@
     {
       "id": "alibaba/qwen3-235b-a22b-thinking",
       "name": "Qwen3 VL 235B A22B Thinking",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 4
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3588,10 +3781,10 @@
     {
       "id": "alibaba/qwen3-vl-thinking",
       "name": "Qwen3 VL 235B A22B Thinking",
-      "cost_per_1m_in": 0.4,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.4,
+        "output": 4
+      },
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": true,
@@ -3606,10 +3799,10 @@
     {
       "id": "alibaba/qwen-3-14b",
       "name": "Qwen3-14B",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.24,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.24
+      },
       "context_window": 40960,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -3624,10 +3817,10 @@
     {
       "id": "alibaba/qwen-3-30b",
       "name": "Qwen3-30B-A3B",
-      "cost_per_1m_in": 0.12,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.12,
+        "output": 0.5
+      },
       "context_window": 40960,
       "default_max_tokens": 16384,
       "can_reason": true,
@@ -3642,10 +3835,11 @@
     {
       "id": "alibaba/qwen3.8-2.4t-a95b",
       "name": "Qwen3.8 2.4T A95B",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.25
+      },
       "context_window": 262144,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -3660,10 +3854,12 @@
     {
       "id": "alibaba/qwen3.8-27b",
       "name": "Qwen3.8 27B",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0.625,
-      "cost_per_1m_out_cached": 0.1,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_create": 0.625,
+        "cache_hit": 0.1
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -3678,10 +3874,12 @@
     {
       "id": "alibaba/qwen3.8-max-0902",
       "name": "Qwen3.8 Max 0902",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 2.5,
-      "cost_per_1m_out_cached": 0.25,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_create": 2.5,
+        "cache_hit": 0.25
+      },
       "context_window": 991000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -3696,10 +3894,11 @@
     {
       "id": "sakana/namazu",
       "name": "Sakana Namazu",
-      "cost_per_1m_in": 0.95,
-      "cost_per_1m_out": 4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.15,
+      "pricing": {
+        "input": 0.95,
+        "output": 4,
+        "cache_hit": 0.15
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": true,
@@ -3714,10 +3913,11 @@
     {
       "id": "bytedance/seed-1.6",
       "name": "Seed 1.6",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.25,
+        "output": 2,
+        "cache_hit": 0.05
+      },
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": true,
@@ -3732,10 +3932,11 @@
     {
       "id": "stepfun/step-3.7-flash",
       "name": "Step 3.7 Flash",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.15,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.04,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.15,
+        "cache_hit": 0.04
+      },
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": true,
@@ -3750,10 +3951,11 @@
     {
       "id": "stepfun/step-3.5-flash",
       "name": "StepFun 3.5 Flash",
-      "cost_per_1m_in": 0.09,
-      "cost_per_1m_out": 0.3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.02,
+      "pricing": {
+        "input": 0.09,
+        "output": 0.3,
+        "cache_hit": 0.02
+      },
       "context_window": 262114,
       "default_max_tokens": 262114,
       "can_reason": true,
@@ -3768,10 +3970,11 @@
     {
       "id": "tencent/hy4-preview",
       "name": "Tencent Hy4 Preview",
-      "cost_per_1m_in": 0.834,
-      "cost_per_1m_out": 2.501,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.042,
+      "pricing": {
+        "input": 0.834,
+        "output": 2.501,
+        "cache_hit": 0.042
+      },
       "context_window": 1024000,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -3786,10 +3989,10 @@
     {
       "id": "arcee-ai/trinity-large-thinking",
       "name": "Trinity Large Thinking",
-      "cost_per_1m_in": 0.25,
-      "cost_per_1m_out": 0.9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0.25,
+        "output": 0.9
+      },
       "context_window": 262100,
       "default_max_tokens": 80000,
       "can_reason": true,
@@ -3804,10 +4007,11 @@
     {
       "id": "openai/o1",
       "name": "o1",
-      "cost_per_1m_in": 15,
-      "cost_per_1m_out": 60,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 7.5,
+      "pricing": {
+        "input": 15,
+        "output": 60,
+        "cache_hit": 7.5
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3822,10 +4026,11 @@
     {
       "id": "openai/o3",
       "name": "o3",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3840,10 +4045,11 @@
     {
       "id": "openai/o3-fast",
       "name": "o3 (Fast)",
-      "cost_per_1m_in": 3.5,
-      "cost_per_1m_out": 14,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.875,
+      "pricing": {
+        "input": 3.5,
+        "output": 14,
+        "cache_hit": 0.875
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3858,10 +4064,10 @@
     {
       "id": "openai/o3-pro",
       "name": "o3 Pro",
-      "cost_per_1m_in": 20,
-      "cost_per_1m_out": 80,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 20,
+        "output": 80
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3876,10 +4082,11 @@
     {
       "id": "openai/o3-mini",
       "name": "o3-mini",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.55,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.55
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3894,10 +4101,11 @@
     {
       "id": "openai/o4-mini",
       "name": "o4-mini",
-      "cost_per_1m_in": 1.1,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.275,
+      "pricing": {
+        "input": 1.1,
+        "output": 4.4,
+        "cache_hit": 0.275
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,
@@ -3912,10 +4120,11 @@
     {
       "id": "openai/o4-mini-fast",
       "name": "o4-mini (Fast)",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 8,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 8,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 100000,
       "can_reason": true,

--- a/internal/providers/configs/vercel.json
+++ b/internal/providers/configs/vercel.json
@@ -24,7 +24,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-3-haiku",
@@ -38,7 +40,9 @@
       "context_window": 200000,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-fable-5",
@@ -61,7 +65,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-fable-5.1",
@@ -84,7 +90,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-haiku-4.5",
@@ -107,7 +115,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4",
@@ -130,7 +140,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4.5",
@@ -153,7 +165,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4.6",
@@ -176,7 +190,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4.7",
@@ -199,7 +215,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4.8",
@@ -222,7 +240,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-4.8-fast",
@@ -245,7 +265,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-5",
@@ -268,7 +290,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-opus-5-fast",
@@ -291,7 +315,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-sonnet-4",
@@ -314,7 +340,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-sonnet-4.5",
@@ -337,7 +365,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-sonnet-4.6",
@@ -360,7 +390,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "anthropic/claude-sonnet-5",
@@ -383,7 +415,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "cohere/command-a",
@@ -395,7 +429,9 @@
       "context_window": 256000,
       "default_max_tokens": 8000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v3.1",
@@ -414,7 +450,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v3.1-terminus",
@@ -433,7 +471,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v3.2",
@@ -446,7 +486,9 @@
       "context_window": 128000,
       "default_max_tokens": 8000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v3.2-thinking",
@@ -458,7 +500,9 @@
       "context_window": 128000,
       "default_max_tokens": 8000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-flash",
@@ -477,7 +521,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-flash-0731",
@@ -496,7 +542,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-flash-vision-exp",
@@ -515,7 +563,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "deepseek/deepseek-v4-pro",
@@ -534,7 +584,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-v4-pro-0813",
@@ -553,7 +605,9 @@
         "max"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "deepseek/deepseek-r1",
@@ -571,7 +625,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral/devstral-2",
@@ -583,7 +639,9 @@
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral/devstral-small-2",
@@ -595,7 +653,9 @@
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "sakana/fugu-ultra",
@@ -614,7 +674,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "zai/glm-4.5",
@@ -633,7 +695,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-4.5-air",
@@ -652,7 +716,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-4.5v",
@@ -671,7 +737,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "zai/glm-4.6",
@@ -690,7 +758,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-4.7",
@@ -709,7 +779,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-4.7-flash",
@@ -727,7 +799,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-4.7-flashx",
@@ -746,7 +820,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-5",
@@ -764,7 +840,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-5-turbo",
@@ -783,7 +861,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-5.1",
@@ -802,7 +882,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-5.2",
@@ -820,7 +902,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-5.2-fast",
@@ -839,7 +923,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-5.3",
@@ -858,7 +944,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-5.3-promo-50",
@@ -877,7 +965,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "zai/glm-5.3-flash",
@@ -896,7 +986,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "zai/glm-5v-turbo",
@@ -915,7 +1007,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.1-codex-max",
@@ -934,7 +1028,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.1-codex-mini",
@@ -953,7 +1049,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.1-thinking",
@@ -972,7 +1070,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.1-thinking-fast",
@@ -991,7 +1091,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.2",
@@ -1010,7 +1112,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.2-pro",
@@ -1028,7 +1132,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.2-fast",
@@ -1047,7 +1153,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.2-codex",
@@ -1066,7 +1174,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.3-codex",
@@ -1085,7 +1195,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.3-codex-fast",
@@ -1104,7 +1216,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.4",
@@ -1123,7 +1237,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.4-fast",
@@ -1142,7 +1258,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.4-mini",
@@ -1161,7 +1279,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.4-mini-fast",
@@ -1180,7 +1300,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.4-nano",
@@ -1199,7 +1321,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.4-pro",
@@ -1217,7 +1341,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.5",
@@ -1236,7 +1362,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.5-fast",
@@ -1255,7 +1383,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.5-pro",
@@ -1273,7 +1403,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-luna",
@@ -1293,7 +1425,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-luna-fast",
@@ -1313,7 +1447,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-sol",
@@ -1333,7 +1469,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-sol-fast",
@@ -1353,7 +1491,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-terra",
@@ -1373,7 +1513,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.6-terra-fast",
@@ -1393,7 +1535,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -1411,7 +1555,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-20b",
@@ -1429,7 +1575,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-safeguard-120b",
@@ -1447,7 +1595,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-oss-safeguard-20b",
@@ -1465,7 +1615,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-3.5-turbo",
@@ -1477,7 +1629,9 @@
       "context_window": 16385,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/gpt-4-turbo",
@@ -1489,7 +1643,9 @@
       "context_window": 128000,
       "default_max_tokens": 4096,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4.1",
@@ -1502,7 +1658,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4.1-fast",
@@ -1515,7 +1673,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4.1-mini",
@@ -1528,7 +1688,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4.1-mini-fast",
@@ -1541,7 +1703,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4.1-nano",
@@ -1554,7 +1718,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4.1-nano-fast",
@@ -1567,7 +1733,9 @@
       "context_window": 1047576,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4o",
@@ -1580,7 +1748,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4o-fast",
@@ -1593,7 +1763,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4o-mini",
@@ -1606,7 +1778,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-4o-mini-fast",
@@ -1619,7 +1793,9 @@
       "context_window": 128000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5",
@@ -1638,7 +1814,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5-fast",
@@ -1657,7 +1835,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5-mini",
@@ -1676,7 +1856,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5-mini-fast",
@@ -1695,7 +1877,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5-nano",
@@ -1714,7 +1898,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5-pro",
@@ -1732,7 +1918,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5-codex",
@@ -1751,7 +1939,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/gpt-5.1-codex",
@@ -1770,7 +1960,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-2.5-flash",
@@ -1789,7 +1981,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-2.5-flash-lite",
@@ -1808,7 +2002,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-2.5-pro",
@@ -1827,7 +2023,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3-flash",
@@ -1846,7 +2044,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.1-flash-lite",
@@ -1865,7 +2065,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.1-pro-preview",
@@ -1884,7 +2086,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.5-flash",
@@ -1903,7 +2107,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.5-flash-lite",
@@ -1922,7 +2128,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.6-flash",
@@ -1941,7 +2149,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.7-flash",
@@ -1960,7 +2170,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemini-3.8-flash",
@@ -1979,7 +2191,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemma-4-31b-it",
@@ -1997,7 +2211,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "google/gemma-4-26b-a4b-it",
@@ -2016,7 +2232,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.1-fast-non-reasoning",
@@ -2029,7 +2247,9 @@
       "context_window": 1000000,
       "default_max_tokens": 1000000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.1-fast-reasoning",
@@ -2048,7 +2268,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.20-non-reasoning-beta",
@@ -2061,7 +2283,9 @@
       "context_window": 2000000,
       "default_max_tokens": 2000000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.20-reasoning-beta",
@@ -2080,7 +2304,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.20-multi-agent-beta",
@@ -2099,7 +2325,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.20-multi-agent",
@@ -2118,7 +2346,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.20-non-reasoning",
@@ -2131,7 +2361,9 @@
       "context_window": 2000000,
       "default_max_tokens": 2000000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.20-reasoning",
@@ -2150,7 +2382,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.3",
@@ -2169,7 +2403,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.5",
@@ -2188,7 +2424,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-4.6",
@@ -2207,7 +2445,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "spacexai/grok-build-0.1",
@@ -2226,7 +2466,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "tencent/hy3",
@@ -2245,7 +2487,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "thinkingmachines/inkling",
@@ -2264,7 +2508,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "thinkingmachines/inkling-small",
@@ -2283,7 +2529,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "interfaze/interfaze-beta",
@@ -2301,7 +2549,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kwaipilot/kat-coder-pro-v1",
@@ -2314,7 +2564,9 @@
       "context_window": 256000,
       "default_max_tokens": 32000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kwaipilot/kat-coder-air-v2.5",
@@ -2333,7 +2585,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "kwaipilot/kat-coder-pro-v2",
@@ -2352,7 +2606,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "kwaipilot/kat-coder-pro-v2.5",
@@ -2371,7 +2627,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k2",
@@ -2383,7 +2641,9 @@
       "context_window": 131072,
       "default_max_tokens": 131072,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/kimi-k2-thinking",
@@ -2402,7 +2662,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "moonshotai/kimi-k2.5",
@@ -2421,7 +2683,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k2.6",
@@ -2440,7 +2704,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k2.7-code",
@@ -2459,7 +2725,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k2.7-code-highspeed",
@@ -2478,7 +2746,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k3",
@@ -2497,7 +2767,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "moonshotai/kimi-k3-fast",
@@ -2516,7 +2788,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "poolside/laguna-s-2.1",
@@ -2535,7 +2809,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "poolside/laguna-s-2.1-free",
@@ -2553,7 +2829,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "inclusionai/ling-3.0-flash",
@@ -2572,7 +2850,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "inclusionai/ling-3.0-flash-fin",
@@ -2590,7 +2870,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "inclusionai/ling-3.0-flash-fin-free",
@@ -2608,7 +2890,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta/llama-3.1-70b",
@@ -2620,7 +2904,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta/llama-3.1-8b",
@@ -2632,7 +2918,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta/llama-3.3-70b",
@@ -2644,7 +2932,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "meta/llama-4-maverick",
@@ -2656,7 +2946,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/llama-4-scout",
@@ -2668,7 +2960,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "inception/mercury-2",
@@ -2687,7 +2981,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "inception/mercury-coder-small",
@@ -2699,7 +2995,9 @@
       "context_window": 32000,
       "default_max_tokens": 16384,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "xiaomi/mimo-v2.5",
@@ -2718,7 +3016,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "xiaomi/mimo-v2.5-pro",
@@ -2737,7 +3037,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "xiaomi/mimo-v2.5-pro-ultraspeed",
@@ -2756,7 +3058,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2",
@@ -2776,7 +3080,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.1",
@@ -2796,7 +3102,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.1-lightning",
@@ -2816,7 +3124,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.5",
@@ -2836,7 +3146,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.5-highspeed",
@@ -2856,7 +3168,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.7",
@@ -2876,7 +3190,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.7-free",
@@ -2894,7 +3210,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m2.7-highspeed",
@@ -2914,7 +3232,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "minimax/minimax-m3",
@@ -2933,7 +3253,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "minimax/minimax-m3-free",
@@ -2951,7 +3273,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral/ministral-14b",
@@ -2963,7 +3287,9 @@
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral/ministral-3b",
@@ -2975,7 +3301,9 @@
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral/ministral-8b",
@@ -2987,7 +3315,9 @@
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral/codestral",
@@ -2999,7 +3329,9 @@
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral/mistral-large-3",
@@ -3011,7 +3343,9 @@
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral/mistral-medium",
@@ -3023,7 +3357,9 @@
       "context_window": 128000,
       "default_max_tokens": 64000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral/mistral-medium-3.5",
@@ -3041,7 +3377,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral/mistral-nemo",
@@ -3053,7 +3391,9 @@
       "context_window": 128000,
       "default_max_tokens": 128000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "mistral/mistral-small",
@@ -3065,7 +3405,9 @@
       "context_window": 32000,
       "default_max_tokens": 4000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-glimmer-30b",
@@ -3084,7 +3426,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-spark-1.1",
@@ -3103,7 +3447,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-spark-1.2",
@@ -3122,7 +3468,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-spark-1.2-contributor",
@@ -3141,7 +3489,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-spark-1.3",
@@ -3160,7 +3510,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "meta/muse-spark-1.3-contributor",
@@ -3179,7 +3531,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nvidia/nemotron-3-super-120b-a12b",
@@ -3197,7 +3551,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/nemotron-3-nano-30b-a3b",
@@ -3215,7 +3571,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/nemotron-3-ultra-550b-a55b",
@@ -3234,7 +3592,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "nvidia/nemotron-3.5-lightning",
@@ -3253,7 +3613,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "amazon/nova-2-lite",
@@ -3272,7 +3634,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "amazon/nova-lite",
@@ -3284,7 +3648,9 @@
       "context_window": 300000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "amazon/nova-micro",
@@ -3296,7 +3662,9 @@
       "context_window": 128000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "amazon/nova-pro",
@@ -3308,7 +3676,9 @@
       "context_window": 300000,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nvidia/nemotron-nano-12b-v2-vl",
@@ -3326,7 +3696,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "nvidia/nemotron-nano-9b-v2",
@@ -3344,7 +3716,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "mistral/pixtral-12b",
@@ -3356,7 +3730,9 @@
       "context_window": 128000,
       "default_max_tokens": 4000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen-3-32b",
@@ -3374,7 +3750,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3-coder-30b-a3b",
@@ -3386,7 +3764,9 @@
       "context_window": 262144,
       "default_max_tokens": 8192,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3-max-thinking",
@@ -3405,7 +3785,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3.5-flash",
@@ -3425,7 +3807,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3.5-plus",
@@ -3445,7 +3829,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3.6-27b",
@@ -3463,7 +3849,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen-3.6-max-preview",
@@ -3483,7 +3871,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3.6-plus",
@@ -3503,7 +3893,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3.7-flash",
@@ -3523,7 +3915,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3.7-max",
@@ -3543,7 +3937,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3.7-plus",
@@ -3563,7 +3959,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3.8-flash",
@@ -3583,7 +3981,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3.8-flash-next",
@@ -3602,7 +4002,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3.8-max",
@@ -3622,7 +4024,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen-3-235b",
@@ -3640,7 +4044,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3-coder",
@@ -3653,7 +4059,9 @@
       "context_window": 262144,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3-coder-next",
@@ -3665,7 +4073,9 @@
       "context_window": 256000,
       "default_max_tokens": 256000,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3-coder-plus",
@@ -3678,7 +4088,9 @@
       "context_window": 1000000,
       "default_max_tokens": 65536,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3-max",
@@ -3691,7 +4103,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3-max-preview",
@@ -3704,7 +4118,9 @@
       "context_window": 262144,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3-next-80b-a3b-instruct",
@@ -3716,7 +4132,9 @@
       "context_window": 131072,
       "default_max_tokens": 32768,
       "can_reason": false,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3-next-80b-a3b-thinking",
@@ -3734,7 +4152,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3-vl-235b-a22b-instruct",
@@ -3746,7 +4166,9 @@
       "context_window": 131072,
       "default_max_tokens": 129024,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3-vl-instruct",
@@ -3758,7 +4180,9 @@
       "context_window": 131072,
       "default_max_tokens": 129024,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3-235b-a22b-thinking",
@@ -3776,7 +4200,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3-vl-thinking",
@@ -3794,7 +4220,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen-3-14b",
@@ -3812,7 +4240,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen-3-30b",
@@ -3830,7 +4260,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "alibaba/qwen3.8-2.4t-a95b",
@@ -3849,7 +4281,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3.8-27b",
@@ -3869,7 +4303,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "alibaba/qwen3.8-max-0902",
@@ -3889,7 +4325,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "sakana/namazu",
@@ -3908,7 +4346,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "bytedance/seed-1.6",
@@ -3927,7 +4367,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "stepfun/step-3.7-flash",
@@ -3946,7 +4388,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "stepfun/step-3.5-flash",
@@ -3965,7 +4409,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "tencent/hy4-preview",
@@ -3984,7 +4430,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "arcee-ai/trinity-large-thinking",
@@ -4002,7 +4450,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/o1",
@@ -4021,7 +4471,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/o3",
@@ -4040,7 +4492,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/o3-fast",
@@ -4059,7 +4513,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/o3-pro",
@@ -4077,7 +4533,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/o3-mini",
@@ -4096,7 +4554,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "openai/o4-mini",
@@ -4115,7 +4575,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "openai/o4-mini-fast",
@@ -4134,7 +4596,9 @@
         "high"
       ],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ],
   "default_headers": {

--- a/internal/providers/configs/vertexai.json
+++ b/internal/providers/configs/vertexai.json
@@ -10,10 +10,11 @@
     {
       "id": "gemini-3.5-flash",
       "name": "Gemini 3.5 Flash",
-      "cost_per_1m_in": 1.5,
-      "cost_per_1m_out": 9,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 1,
+      "pricing": {
+        "input": 1.5,
+        "output": 9,
+        "cache_hit": 1
+      },
       "context_window": 1048576,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -24,10 +25,11 @@
     {
       "id": "gemini-3.1-pro-preview",
       "name": "Gemini 3.1 Pro (Regular)",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_hit": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -38,10 +40,11 @@
     {
       "id": "gemini-3.1-pro-preview-customtools",
       "name": "Gemini 3.1 Pro (Optimized for Coding Agents)",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_hit": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -52,10 +55,11 @@
     {
       "id": "gemini-3-pro-preview",
       "name": "Gemini 3 Pro",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 12,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 2,
+        "output": 12,
+        "cache_hit": 0.2
+      },
       "context_window": 1048576,
       "default_max_tokens": 64000,
       "can_reason": true,
@@ -66,10 +70,11 @@
     {
       "id": "gemini-3-flash-preview",
       "name": "Gemini 3 Flash",
-      "cost_per_1m_in": 0.5,
-      "cost_per_1m_out": 3,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.05,
+      "pricing": {
+        "input": 0.5,
+        "output": 3,
+        "cache_hit": 0.05
+      },
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -80,10 +85,11 @@
     {
       "id": "gemini-2.5-pro",
       "name": "Gemini 2.5 Pro",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 10,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.125,
+      "pricing": {
+        "input": 1.25,
+        "output": 10,
+        "cache_hit": 0.125
+      },
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -92,10 +98,11 @@
     {
       "id": "gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.03,
+      "pricing": {
+        "input": 0.3,
+        "output": 2.5,
+        "cache_hit": 0.03
+      },
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -104,10 +111,12 @@
     {
       "id": "claude-sonnet-4-6",
       "name": "Claude Sonnet 4.6",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 1000000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -118,10 +127,12 @@
     {
       "id": "claude-sonnet-4-5-20250929",
       "name": "Claude Sonnet 4.5",
-      "cost_per_1m_in": 3,
-      "cost_per_1m_out": 15,
-      "cost_per_1m_in_cached": 3.75,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 3,
+        "output": 15,
+        "cache_create": 3.75,
+        "cache_hit": 0.3
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -130,10 +141,12 @@
     {
       "id": "claude-opus-4-6",
       "name": "Claude Opus 4.6",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.50,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 1000000,
       "default_max_tokens": 126000,
       "can_reason": true,
@@ -144,10 +157,12 @@
     {
       "id": "claude-opus-4-5-20251101",
       "name": "Claude Opus 4.5",
-      "cost_per_1m_in": 5,
-      "cost_per_1m_out": 25,
-      "cost_per_1m_in_cached": 6.25,
-      "cost_per_1m_out_cached": 0.50,
+      "pricing": {
+        "input": 5,
+        "output": 25,
+        "cache_create": 6.25,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -156,10 +171,12 @@
     {
       "id": "claude-haiku-4-5-20251001",
       "name": "Claude 4.5 Haiku",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 5,
-      "cost_per_1m_in_cached": 1.25,
-      "cost_per_1m_out_cached": 0.09999999999999999,
+      "pricing": {
+        "input": 1,
+        "output": 5,
+        "cache_create": 1.25,
+        "cache_hit": 0.1
+      },
       "context_window": 200000,
       "default_max_tokens": 32000,
       "can_reason": true,

--- a/internal/providers/configs/vertexai.json
+++ b/internal/providers/configs/vertexai.json
@@ -20,7 +20,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.1-pro-preview",
@@ -35,7 +37,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3.1-pro-preview-customtools",
@@ -50,7 +54,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-pro-preview",
@@ -65,7 +71,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "high"],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-3-flash-preview",
@@ -80,7 +88,9 @@
       "can_reason": true,
       "reasoning_levels": ["minimal", "low", "medium", "high"],
       "default_reasoning_effort": "minimal",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-pro",
@@ -93,7 +103,9 @@
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "gemini-2.5-flash",
@@ -106,7 +118,9 @@
       "context_window": 1048576,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-6",
@@ -122,7 +136,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-sonnet-4-5-20250929",
@@ -136,7 +152,9 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-6",
@@ -152,7 +170,9 @@
       "can_reason": true,
       "reasoning_levels": ["low", "medium", "high", "max"],
       "default_reasoning_effort": "medium",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-opus-4-5-20251101",
@@ -166,7 +186,9 @@
       "context_window": 200000,
       "default_max_tokens": 50000,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "claude-haiku-4-5-20251001",
@@ -181,7 +203,9 @@
       "default_max_tokens": 32000,
       "can_reason": true,
       "has_reasoning_efforts": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/xai.json
+++ b/internal/providers/configs/xai.json
@@ -18,7 +18,9 @@
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.20-non-reasoning",
@@ -31,7 +33,9 @@
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.3",
@@ -44,7 +48,9 @@
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.5",
@@ -63,7 +69,9 @@
         "high"
       ],
       "default_reasoning_effort": "high",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-4.6",
@@ -76,7 +84,9 @@
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "grok-build-0.1",
@@ -89,7 +99,9 @@
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/xai.json
+++ b/internal/providers/configs/xai.json
@@ -10,10 +10,11 @@
     {
       "id": "grok-4.20",
       "name": "Grok 4.20",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": false,
@@ -22,10 +23,11 @@
     {
       "id": "grok-4.20-non-reasoning",
       "name": "Grok 4.20 Non-Reasoning",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": false,
@@ -34,10 +36,11 @@
     {
       "id": "grok-4.3",
       "name": "Grok 4.3",
-      "cost_per_1m_in": 1.25,
-      "cost_per_1m_out": 2.5,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1.25,
+        "output": 2.5,
+        "cache_hit": 0.2
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": false,
@@ -46,10 +49,11 @@
     {
       "id": "grok-4.5",
       "name": "Grok 4.5",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.3,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.3
+      },
       "context_window": 500000,
       "default_max_tokens": 50000,
       "can_reason": true,
@@ -64,10 +68,11 @@
     {
       "id": "grok-4.6",
       "name": "grok-4.6",
-      "cost_per_1m_in": 2,
-      "cost_per_1m_out": 6,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.5,
+      "pricing": {
+        "input": 2,
+        "output": 6,
+        "cache_hit": 0.5
+      },
       "context_window": 200000,
       "default_max_tokens": 20000,
       "can_reason": false,
@@ -76,10 +81,11 @@
     {
       "id": "grok-build-0.1",
       "name": "Grok Build 0.1",
-      "cost_per_1m_in": 1,
-      "cost_per_1m_out": 2,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.2,
+      "pricing": {
+        "input": 1,
+        "output": 2,
+        "cache_hit": 0.2
+      },
       "context_window": 131072,
       "default_max_tokens": 13107,
       "can_reason": false,

--- a/internal/providers/configs/zai.json
+++ b/internal/providers/configs/zai.json
@@ -24,7 +24,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-5.3",
@@ -43,7 +45,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2",
@@ -60,7 +64,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.1",
@@ -73,7 +79,9 @@
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5-turbo",
@@ -86,7 +94,9 @@
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5",
@@ -99,7 +109,9 @@
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.7",
@@ -112,7 +124,9 @@
       "context_window": 204800,
       "default_max_tokens": 98000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.7-flash",
@@ -125,7 +139,9 @@
       "context_window": 200000,
       "default_max_tokens": 65550,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.6",
@@ -138,7 +154,9 @@
       "context_window": 204800,
       "default_max_tokens": 102400,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.6v",
@@ -150,7 +168,9 @@
       "context_window": 131072,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-4.5",
@@ -163,7 +183,9 @@
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.5-air",
@@ -176,7 +198,9 @@
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.5v",
@@ -189,7 +213,9 @@
       "context_window": 65536,
       "default_max_tokens": 8192,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/zai.json
+++ b/internal/providers/configs/zai.json
@@ -10,9 +10,11 @@
     {
       "id": "glm-5.3-flash",
       "name": "GLM-5.3 Flash",
-      "cost_per_1m_in": 0.15,
-      "cost_per_1m_out": 0.5,
-      "cost_per_1m_in_cached": 0.03,
+      "pricing": {
+        "input": 0.15,
+        "output": 0.5,
+        "cache_create": 0.03
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -27,10 +29,11 @@
     {
       "id": "glm-5.3",
       "name": "GLM-5.3",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.26,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.26
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -45,9 +48,10 @@
     {
       "id": "glm-5.2",
       "name": "GLM-5.2",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -61,9 +65,11 @@
     {
       "id": "glm-5.1",
       "name": "GLM-5.1",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0.26,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_create": 0.26
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -72,9 +78,11 @@
     {
       "id": "glm-5-turbo",
       "name": "GLM-5-Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4.0,
-      "cost_per_1m_in_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 4,
+        "cache_create": 0.24
+      },
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -83,9 +91,11 @@
     {
       "id": "glm-5",
       "name": "GLM-5",
-      "cost_per_1m_in": 1.0,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0.2,
+      "pricing": {
+        "input": 1,
+        "output": 3.2,
+        "cache_create": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -94,9 +104,11 @@
     {
       "id": "glm-4.7",
       "name": "GLM-4.7",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_create": 0.11
+      },
       "context_window": 204800,
       "default_max_tokens": 98000,
       "can_reason": true,
@@ -105,9 +117,11 @@
     {
       "id": "glm-4.7-flash",
       "name": "GLM-4.7 Flash",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.01,
+      "pricing": {
+        "input": 0.07,
+        "output": 0.4,
+        "cache_create": 0.01
+      },
       "context_window": 200000,
       "default_max_tokens": 65550,
       "can_reason": true,
@@ -116,9 +130,11 @@
     {
       "id": "glm-4.6",
       "name": "GLM-4.6",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_create": 0.11
+      },
       "context_window": 204800,
       "default_max_tokens": 102400,
       "can_reason": true,
@@ -127,8 +143,10 @@
     {
       "id": "glm-4.6v",
       "name": "GLM-4.6V",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.9
+      },
       "context_window": 131072,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -137,9 +155,11 @@
     {
       "id": "glm-4.5",
       "name": "GLM-4.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_create": 0.11
+      },
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
@@ -148,9 +168,11 @@
     {
       "id": "glm-4.5-air",
       "name": "GLM-4.5-Air",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.1,
-      "cost_per_1m_in_cached": 0.03,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.1,
+        "cache_create": 0.03
+      },
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
@@ -159,9 +181,11 @@
     {
       "id": "glm-4.5v",
       "name": "GLM-4.5V",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 1.8,
+        "cache_create": 0.11
+      },
       "context_window": 65536,
       "default_max_tokens": 8192,
       "can_reason": true,

--- a/internal/providers/configs/zhipu-coding.json
+++ b/internal/providers/configs/zhipu-coding.json
@@ -10,10 +10,10 @@
     {
       "id": "glm-5.3",
       "name": "GLM-5.3",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -28,9 +28,10 @@
     {
       "id": "glm-5.2",
       "name": "GLM-5.2",
-      "cost_per_1m_in": 0,
-      "cost_per_1m_out": 0,
-      "cost_per_1m_in_cached": 0,
+      "pricing": {
+        "input": 0,
+        "output": 0
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -44,9 +45,11 @@
     {
       "id": "glm-5.1",
       "name": "GLM-5.1",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0.26,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_create": 0.26
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -55,9 +58,11 @@
     {
       "id": "glm-5-turbo",
       "name": "GLM-5-Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4.0,
-      "cost_per_1m_in_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 4,
+        "cache_create": 0.24
+      },
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -66,9 +71,11 @@
     {
       "id": "glm-5",
       "name": "GLM-5",
-      "cost_per_1m_in": 1.0,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0.2,
+      "pricing": {
+        "input": 1,
+        "output": 3.2,
+        "cache_create": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -77,9 +84,11 @@
     {
       "id": "glm-4.7",
       "name": "GLM-4.7",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_create": 0.11
+      },
       "context_window": 204800,
       "default_max_tokens": 98000,
       "can_reason": true,
@@ -88,9 +97,11 @@
     {
       "id": "glm-4.7-flash",
       "name": "GLM-4.7 Flash",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.01,
+      "pricing": {
+        "input": 0.07,
+        "output": 0.4,
+        "cache_create": 0.01
+      },
       "context_window": 200000,
       "default_max_tokens": 65550,
       "can_reason": true,
@@ -99,9 +110,11 @@
     {
       "id": "glm-4.6",
       "name": "GLM-4.6",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_create": 0.11
+      },
       "context_window": 204800,
       "default_max_tokens": 102400,
       "can_reason": true,
@@ -110,8 +123,10 @@
     {
       "id": "glm-4.6v",
       "name": "GLM-4.6V",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.9
+      },
       "context_window": 131072,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -120,9 +135,11 @@
     {
       "id": "glm-4.5",
       "name": "GLM-4.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_create": 0.11
+      },
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
@@ -131,9 +148,11 @@
     {
       "id": "glm-4.5-air",
       "name": "GLM-4.5-Air",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.1,
-      "cost_per_1m_in_cached": 0.03,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.1,
+        "cache_create": 0.03
+      },
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
@@ -142,9 +161,11 @@
     {
       "id": "glm-4.5v",
       "name": "GLM-4.5V",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 1.8,
+        "cache_create": 0.11
+      },
       "context_window": 65536,
       "default_max_tokens": 8192,
       "can_reason": true,

--- a/internal/providers/configs/zhipu-coding.json
+++ b/internal/providers/configs/zhipu-coding.json
@@ -23,7 +23,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.2",
@@ -40,7 +42,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.1",
@@ -53,7 +57,9 @@
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5-turbo",
@@ -66,7 +72,9 @@
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5",
@@ -79,7 +87,9 @@
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.7",
@@ -92,7 +102,9 @@
       "context_window": 204800,
       "default_max_tokens": 98000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.7-flash",
@@ -105,7 +117,9 @@
       "context_window": 200000,
       "default_max_tokens": 65550,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.6",
@@ -118,7 +132,9 @@
       "context_window": 204800,
       "default_max_tokens": 102400,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.6v",
@@ -130,7 +146,9 @@
       "context_window": 131072,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-4.5",
@@ -143,7 +161,9 @@
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.5-air",
@@ -156,7 +176,9 @@
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.5v",
@@ -169,7 +191,9 @@
       "context_window": 65536,
       "default_max_tokens": 8192,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/configs/zhipu.json
+++ b/internal/providers/configs/zhipu.json
@@ -10,10 +10,11 @@
     {
       "id": "glm-5.3",
       "name": "GLM-5.3",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0,
-      "cost_per_1m_out_cached": 0.26,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_hit": 0.26
+      },
       "context_window": 1000000,
       "default_max_tokens": 131072,
       "can_reason": true,
@@ -28,9 +29,11 @@
     {
       "id": "glm-5.1",
       "name": "GLM-5.1",
-      "cost_per_1m_in": 1.4,
-      "cost_per_1m_out": 4.4,
-      "cost_per_1m_in_cached": 0.26,
+      "pricing": {
+        "input": 1.4,
+        "output": 4.4,
+        "cache_create": 0.26
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -39,9 +42,11 @@
     {
       "id": "glm-5-turbo",
       "name": "GLM-5-Turbo",
-      "cost_per_1m_in": 1.2,
-      "cost_per_1m_out": 4.0,
-      "cost_per_1m_in_cached": 0.24,
+      "pricing": {
+        "input": 1.2,
+        "output": 4,
+        "cache_create": 0.24
+      },
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
@@ -50,9 +55,11 @@
     {
       "id": "glm-5",
       "name": "GLM-5",
-      "cost_per_1m_in": 1.0,
-      "cost_per_1m_out": 3.2,
-      "cost_per_1m_in_cached": 0.2,
+      "pricing": {
+        "input": 1,
+        "output": 3.2,
+        "cache_create": 0.2
+      },
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -61,9 +68,11 @@
     {
       "id": "glm-4.7",
       "name": "GLM-4.7",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_create": 0.11
+      },
       "context_window": 204800,
       "default_max_tokens": 98000,
       "can_reason": true,
@@ -72,9 +81,11 @@
     {
       "id": "glm-4.7-flash",
       "name": "GLM-4.7 Flash",
-      "cost_per_1m_in": 0.07,
-      "cost_per_1m_out": 0.4,
-      "cost_per_1m_in_cached": 0.01,
+      "pricing": {
+        "input": 0.07,
+        "output": 0.4,
+        "cache_create": 0.01
+      },
       "context_window": 200000,
       "default_max_tokens": 65550,
       "can_reason": true,
@@ -83,9 +94,11 @@
     {
       "id": "glm-4.6",
       "name": "GLM-4.6",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_create": 0.11
+      },
       "context_window": 204800,
       "default_max_tokens": 102400,
       "can_reason": true,
@@ -94,8 +107,10 @@
     {
       "id": "glm-4.6v",
       "name": "GLM-4.6V",
-      "cost_per_1m_in": 0.3,
-      "cost_per_1m_out": 0.9,
+      "pricing": {
+        "input": 0.3,
+        "output": 0.9
+      },
       "context_window": 131072,
       "default_max_tokens": 65536,
       "can_reason": true,
@@ -104,9 +119,11 @@
     {
       "id": "glm-4.5",
       "name": "GLM-4.5",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 2.2,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 2.2,
+        "cache_create": 0.11
+      },
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
@@ -115,9 +132,11 @@
     {
       "id": "glm-4.5-air",
       "name": "GLM-4.5-Air",
-      "cost_per_1m_in": 0.2,
-      "cost_per_1m_out": 1.1,
-      "cost_per_1m_in_cached": 0.03,
+      "pricing": {
+        "input": 0.2,
+        "output": 1.1,
+        "cache_create": 0.03
+      },
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
@@ -126,9 +145,11 @@
     {
       "id": "glm-4.5v",
       "name": "GLM-4.5V",
-      "cost_per_1m_in": 0.6,
-      "cost_per_1m_out": 1.8,
-      "cost_per_1m_in_cached": 0.11,
+      "pricing": {
+        "input": 0.6,
+        "output": 1.8,
+        "cache_create": 0.11
+      },
       "context_window": 65536,
       "default_max_tokens": 8192,
       "can_reason": true,

--- a/internal/providers/configs/zhipu.json
+++ b/internal/providers/configs/zhipu.json
@@ -24,7 +24,9 @@
         "xhigh"
       ],
       "default_reasoning_effort": "xhigh",
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5.1",
@@ -37,7 +39,9 @@
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5-turbo",
@@ -50,7 +54,9 @@
       "context_window": 200000,
       "default_max_tokens": 128000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-5",
@@ -63,7 +69,9 @@
       "context_window": 204800,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.7",
@@ -76,7 +84,9 @@
       "context_window": 204800,
       "default_max_tokens": 98000,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.7-flash",
@@ -89,7 +99,9 @@
       "context_window": 200000,
       "default_max_tokens": 65550,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.6",
@@ -102,7 +114,9 @@
       "context_window": 204800,
       "default_max_tokens": 102400,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.6v",
@@ -114,7 +128,9 @@
       "context_window": 131072,
       "default_max_tokens": 65536,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     },
     {
       "id": "glm-4.5",
@@ -127,7 +143,9 @@
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.5-air",
@@ -140,7 +158,9 @@
       "context_window": 131072,
       "default_max_tokens": 49152,
       "can_reason": true,
-      "supports_attachments": false
+      "capabilities": {
+        "vision": false
+      }
     },
     {
       "id": "glm-4.5v",
@@ -153,7 +173,9 @@
       "context_window": 65536,
       "default_max_tokens": 8192,
       "can_reason": true,
-      "supports_attachments": true
+      "capabilities": {
+        "vision": true
+      }
     }
   ]
 }

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -5,6 +5,20 @@ import (
 	"testing"
 )
 
+func TestValidPricingOverrides(t *testing.T) {
+	for _, p := range GetAll() {
+		t.Run(p.Name, func(t *testing.T) {
+			for _, m := range p.Models {
+				for i, override := range m.PricingOverrides {
+					if err := override.Validate(); err != nil {
+						t.Errorf("model %q pricing_overrides[%d]: %v", m.ID, i, err)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestValidDefaultModels(t *testing.T) {
 	for _, p := range GetAll() {
 		t.Run(p.Name, func(t *testing.T) {

--- a/pkg/catwalk/pricing.go
+++ b/pkg/catwalk/pricing.go
@@ -1,0 +1,268 @@
+package catwalk
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Weekday is a day of the week used in time-based pricing conditions.
+type Weekday string
+
+// All the days of the week.
+const (
+	Monday    Weekday = "mon"
+	Tuesday   Weekday = "tue"
+	Wednesday Weekday = "wed"
+	Thursday  Weekday = "thu"
+	Friday    Weekday = "fri"
+	Saturday  Weekday = "sat"
+	Sunday    Weekday = "sun"
+)
+
+// PricingValues stores optional prices in US dollars per 1M tokens. Only
+// the fields that are set replace the corresponding base pricing fields
+// when a pricing override matches.
+type PricingValues struct {
+	Input       *float64 `json:"input,omitempty"`
+	Output      *float64 `json:"output,omitempty"`
+	CacheCreate *float64 `json:"cache_create,omitempty"`
+	CacheHit    *float64 `json:"cache_hit,omitempty"`
+}
+
+// TokenRange is a half-open range of token counts, [gte, lt). A missing
+// bound is unbounded.
+type TokenRange struct {
+	GTE *int64 `json:"gte,omitempty"`
+	LT  *int64 `json:"lt,omitempty"`
+}
+
+// Contains reports whether n falls within the range.
+func (r TokenRange) Contains(n int64) bool {
+	if r.GTE != nil && n < *r.GTE {
+		return false
+	}
+	if r.LT != nil && n >= *r.LT {
+		return false
+	}
+	return true
+}
+
+// TimeWindow describes a weekly recurring time window. Days is empty for
+// every day. Start and End use 24-hour "HH:MM" notation; when Start is
+// later than End the window wraps around midnight. Timezone is an IANA
+// time zone name and defaults to UTC when empty.
+type TimeWindow struct {
+	Days     []Weekday `json:"days,omitempty"`
+	Start    string    `json:"start"`
+	End      string    `json:"end"`
+	Timezone string    `json:"timezone,omitempty"`
+}
+
+// Contains reports whether t falls within the window. It returns false
+// when t is the zero time or the window is malformed.
+func (w TimeWindow) Contains(t time.Time) bool {
+	if t.IsZero() {
+		return false
+	}
+	loc := time.UTC
+	if w.Timezone != "" {
+		loaded, err := time.LoadLocation(w.Timezone)
+		if err != nil {
+			return false
+		}
+		loc = loaded
+	}
+	local := t.In(loc)
+	if len(w.Days) > 0 && !containsDay(w.Days, local.Weekday()) {
+		return false
+	}
+	start, ok := parseClock(w.Start)
+	if !ok {
+		return false
+	}
+	end, ok := parseClock(w.End)
+	if !ok {
+		return false
+	}
+	minutes := local.Hour()*60 + local.Minute()
+	if start <= end {
+		return minutes >= start && minutes < end
+	}
+	return minutes >= start || minutes < end
+}
+
+// PricingCondition describes when a pricing override applies. All the
+// populated fields must match (AND semantics). A zero time in the pricing
+// context never matches a time window condition.
+type PricingCondition struct {
+	// InputTokens matches on the number of input tokens of a request,
+	// e.g. for providers that charge more once the context grows past a
+	// certain size.
+	InputTokens *TokenRange `json:"input_tokens,omitempty"`
+	// Time matches requests made inside a recurring time window, e.g. for
+	// providers with peak vs. off-peak pricing.
+	Time *TimeWindow `json:"time,omitempty"`
+}
+
+// Matches reports whether the condition applies to the given context.
+func (c PricingCondition) Matches(ctx PricingContext) bool {
+	if c.InputTokens != nil && !c.InputTokens.Contains(ctx.InputTokens) {
+		return false
+	}
+	if c.Time != nil && !c.Time.Contains(ctx.Time) {
+		return false
+	}
+	return true
+}
+
+// PricingOverride replaces parts of the base pricing of a model when its
+// condition matches.
+type PricingOverride struct {
+	Condition PricingCondition `json:"condition"`
+	Pricing   PricingValues    `json:"pricing"`
+}
+
+// PricingContext carries the request information used to resolve pricing
+// overrides.
+type PricingContext struct {
+	// InputTokens is the number of input tokens of the request.
+	InputTokens int64
+	// Time is when the request is made. A zero time never matches
+	// time-based overrides.
+	Time time.Time
+}
+
+// ResolvePricing returns the effective pricing of the model for the given
+// context. Overrides are applied in declaration order on top of the base
+// pricing, so later matching overrides win over earlier ones.
+func (m Model) ResolvePricing(ctx PricingContext) Pricing {
+	resolved := m.Pricing
+	for _, override := range m.PricingOverrides {
+		if !override.Condition.Matches(ctx) {
+			continue
+		}
+		if override.Pricing.Input != nil {
+			resolved.Input = *override.Pricing.Input
+		}
+		if override.Pricing.Output != nil {
+			resolved.Output = *override.Pricing.Output
+		}
+		if override.Pricing.CacheCreate != nil {
+			resolved.CacheCreate = *override.Pricing.CacheCreate
+		}
+		if override.Pricing.CacheHit != nil {
+			resolved.CacheHit = *override.Pricing.CacheHit
+		}
+	}
+	return resolved
+}
+
+// Validate reports whether the override is well-formed.
+func (o PricingOverride) Validate() error {
+	if err := o.Condition.Validate(); err != nil {
+		return err
+	}
+	for name, value := range map[string]*float64{
+		"input":        o.Pricing.Input,
+		"output":       o.Pricing.Output,
+		"cache_create": o.Pricing.CacheCreate,
+		"cache_hit":    o.Pricing.CacheHit,
+	} {
+		if value != nil && *value < 0 {
+			return fmt.Errorf("pricing override: %s must not be negative", name)
+		}
+	}
+	return nil
+}
+
+// Validate reports whether the condition is well-formed.
+func (c PricingCondition) Validate() error {
+	if c.InputTokens != nil {
+		r := c.InputTokens
+		if r.GTE != nil && *r.GTE < 0 {
+			return fmt.Errorf("pricing condition: input_tokens.gte must not be negative")
+		}
+		if r.LT != nil && *r.LT <= 0 {
+			return fmt.Errorf("pricing condition: input_tokens.lt must be positive")
+		}
+		if r.GTE != nil && r.LT != nil && *r.GTE >= *r.LT {
+			return fmt.Errorf("pricing condition: input_tokens.gte must be less than input_tokens.lt")
+		}
+	}
+	if c.Time != nil {
+		if err := c.Time.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Validate reports whether the time window is well-formed.
+func (w TimeWindow) Validate() error {
+	for _, day := range w.Days {
+		if !validDay(day) {
+			return fmt.Errorf("pricing condition: unknown day %q", day)
+		}
+	}
+	if _, ok := parseClock(w.Start); !ok {
+		return fmt.Errorf("pricing condition: invalid start time %q, want HH:MM", w.Start)
+	}
+	if _, ok := parseClock(w.End); !ok {
+		return fmt.Errorf("pricing condition: invalid end time %q, want HH:MM", w.End)
+	}
+	if w.Timezone != "" {
+		if _, err := time.LoadLocation(w.Timezone); err != nil {
+			return fmt.Errorf("pricing condition: invalid timezone %q: %w", w.Timezone, err)
+		}
+	}
+	return nil
+}
+
+func parseClock(s string) (int, bool) {
+	t, err := time.Parse("15:04", strings.TrimSpace(s))
+	if err != nil {
+		return 0, false
+	}
+	return t.Hour()*60 + t.Minute(), true
+}
+
+func containsDay(days []Weekday, target time.Weekday) bool {
+	abbrev := weekdayAbbrev(target)
+	for _, day := range days {
+		if day == abbrev {
+			return true
+		}
+	}
+	return false
+}
+
+func validDay(day Weekday) bool {
+	switch day {
+	case Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday:
+		return true
+	default:
+		return false
+	}
+}
+
+func weekdayAbbrev(day time.Weekday) Weekday {
+	switch day {
+	case time.Monday:
+		return Monday
+	case time.Tuesday:
+		return Tuesday
+	case time.Wednesday:
+		return Wednesday
+	case time.Thursday:
+		return Thursday
+	case time.Friday:
+		return Friday
+	case time.Saturday:
+		return Saturday
+	case time.Sunday:
+		return Sunday
+	default:
+		return ""
+	}
+}

--- a/pkg/catwalk/pricing_test.go
+++ b/pkg/catwalk/pricing_test.go
@@ -1,0 +1,262 @@
+package catwalk
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func f64(v float64) *float64 { return &v }
+func i64(v int64) *int64     { return &v }
+
+func alibabaLikeModel() Model {
+	return Model{
+		ID: "qwen-test",
+		Pricing: Pricing{
+			Input:  1.6,
+			Output: 6.4,
+		},
+		PricingOverrides: []PricingOverride{
+			{
+				Condition: PricingCondition{
+					InputTokens: &TokenRange{GTE: i64(32000), LT: i64(128000)},
+				},
+				Pricing: PricingValues{Input: f64(2.4), Output: f64(9.6)},
+			},
+			{
+				Condition: PricingCondition{
+					InputTokens: &TokenRange{GTE: i64(128000)},
+				},
+				Pricing: PricingValues{Input: f64(4), Output: f64(16)},
+			},
+		},
+	}
+}
+
+func TestResolvePricingTokenRanges(t *testing.T) {
+	m := alibabaLikeModel()
+	tests := []struct {
+		name            string
+		inputTokens     int64
+		wantIn, wantOut float64
+	}{
+		{"base tier", 1000, 1.6, 6.4},
+		{"exactly at boundary", 32000, 2.4, 9.6},
+		{"middle tier", 100000, 2.4, 9.6},
+		{"last boundary exclusive", 127999, 2.4, 9.6},
+		{"top tier", 200000, 4, 16},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := m.ResolvePricing(PricingContext{InputTokens: tt.inputTokens})
+			if got.Input != tt.wantIn || got.Output != tt.wantOut {
+				t.Errorf("ResolvePricing(%d) = {%v %v}, want {%v %v}",
+					tt.inputTokens, got.Input, got.Output, tt.wantIn, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestResolvePricingPeakHours(t *testing.T) {
+	m := Model{
+		ID:      "peak-model",
+		Pricing: Pricing{Input: 1, Output: 4},
+		PricingOverrides: []PricingOverride{
+			{
+				Condition: PricingCondition{
+					Time: &TimeWindow{
+						Days:     []Weekday{Monday, Tuesday, Wednesday, Thursday, Friday},
+						Start:    "08:00",
+						End:      "20:00",
+						Timezone: "Asia/Shanghai",
+					},
+				},
+				Pricing: PricingValues{Input: f64(2), Output: f64(8)},
+			},
+		},
+	}
+
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	peak := time.Date(2026, 9, 7, 10, 30, 0, 0, shanghai)     // Monday 10:30
+	offPeak := time.Date(2026, 9, 7, 22, 0, 0, 0, shanghai)   // Monday 22:00
+	weekend := time.Date(2026, 9, 12, 10, 30, 0, 0, shanghai) // Saturday 10:30
+
+	if got := m.ResolvePricing(PricingContext{Time: peak}); got.Input != 2 || got.Output != 8 {
+		t.Errorf("peak hours = %+v, want {2 8}", got)
+	}
+	if got := m.ResolvePricing(PricingContext{Time: offPeak}); got.Input != 1 || got.Output != 4 {
+		t.Errorf("off-peak hours = %+v, want {1 4}", got)
+	}
+	if got := m.ResolvePricing(PricingContext{Time: weekend}); got.Input != 1 || got.Output != 4 {
+		t.Errorf("weekend = %+v, want {1 4}", got)
+	}
+	if got := m.ResolvePricing(PricingContext{}); got.Input != 1 || got.Output != 4 {
+		t.Errorf("zero time = %+v, want base pricing {1 4}", got)
+	}
+}
+
+func TestTimeWindowWrapsMidnight(t *testing.T) {
+	w := TimeWindow{Start: "20:00", End: "08:00"}
+	tests := []struct {
+		hour int
+		want bool
+	}{
+		{23, true},
+		{0, true},
+		{7, true},
+		{8, false},
+		{12, false},
+		{19, false},
+		{20, true},
+	}
+	for _, tt := range tests {
+		at := time.Date(2026, 9, 7, tt.hour, 30, 0, 0, time.UTC)
+		if got := w.Contains(at); got != tt.want {
+			t.Errorf("Contains(%02d:30) = %v, want %v", tt.hour, got, tt.want)
+		}
+	}
+}
+
+func TestResolvePricingPartialOverrideAndOrder(t *testing.T) {
+	m := Model{
+		ID:      "partial",
+		Pricing: Pricing{Input: 1, Output: 4, CacheHit: 0.1},
+		PricingOverrides: []PricingOverride{
+			{
+				Condition: PricingCondition{InputTokens: &TokenRange{GTE: i64(100)}},
+				Pricing:   PricingValues{Output: f64(8)},
+			},
+			{
+				Condition: PricingCondition{InputTokens: &TokenRange{GTE: i64(200)}},
+				Pricing:   PricingValues{Output: f64(12)},
+			},
+		},
+	}
+	got := m.ResolvePricing(PricingContext{InputTokens: 150})
+	if got.Input != 1 || got.Output != 8 || got.CacheHit != 0.1 {
+		t.Errorf("got %+v, want input 1 output 8 cache_hit 0.1", got)
+	}
+	got = m.ResolvePricing(PricingContext{InputTokens: 250})
+	if got.Output != 12 {
+		t.Errorf("later override should win, got output %v, want 12", got.Output)
+	}
+}
+
+func TestPricingOverrideJSONRoundTrip(t *testing.T) {
+	raw := `{
+		"id": "m",
+		"name": "M",
+		"pricing": {"input": 1, "output": 2},
+		"pricing_overrides": [
+			{
+				"condition": {"input_tokens": {"gte": 32000, "lt": 128000}},
+				"pricing": {"input": 1.5}
+			},
+			{
+				"condition": {"time": {"days": ["mon", "fri"], "start": "08:00", "end": "20:00", "timezone": "Asia/Shanghai"}},
+				"pricing": {"output": 6}
+			}
+		],
+		"context_window": 1000,
+		"default_max_tokens": 100,
+		"can_reason": false,
+		"capabilities": {"vision": false}
+	}`
+	var m Model
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatal(err)
+	}
+	if len(m.PricingOverrides) != 2 {
+		t.Fatalf("got %d overrides, want 2", len(m.PricingOverrides))
+	}
+	for _, o := range m.PricingOverrides {
+		if err := o.Validate(); err != nil {
+			t.Errorf("Validate() = %v", err)
+		}
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var round Model
+	if err := json.Unmarshal(out, &round); err != nil {
+		t.Fatal(err)
+	}
+	if len(round.PricingOverrides) != 2 {
+		t.Fatalf("round trip lost overrides: %s", out)
+	}
+
+	var withoutOverrides Model
+	if err := json.Unmarshal([]byte(`{"id":"m","name":"M","pricing":{"input":1,"output":2}}`), &withoutOverrides); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(withoutOverrides)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(encoded); strings.Contains(got, "pricing_overrides") {
+		t.Errorf("empty overrides should be omitted, got %s", got)
+	}
+}
+
+func TestPricingOverrideValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		override PricingOverride
+		wantErr  bool
+	}{
+		{
+			name:     "valid token range",
+			override: PricingOverride{Condition: PricingCondition{InputTokens: &TokenRange{GTE: i64(0), LT: i64(32000)}}, Pricing: PricingValues{Input: f64(1)}},
+		},
+		{
+			name:     "valid time window",
+			override: PricingOverride{Condition: PricingCondition{Time: &TimeWindow{Days: []Weekday{Monday}, Start: "08:00", End: "20:00", Timezone: "UTC"}}, Pricing: PricingValues{Input: f64(1)}},
+		},
+		{
+			name:     "inverted range",
+			override: PricingOverride{Condition: PricingCondition{InputTokens: &TokenRange{GTE: i64(100), LT: i64(100)}}, Pricing: PricingValues{Input: f64(1)}},
+			wantErr:  true,
+		},
+		{
+			name:     "negative gte",
+			override: PricingOverride{Condition: PricingCondition{InputTokens: &TokenRange{GTE: i64(-1)}}, Pricing: PricingValues{Input: f64(1)}},
+			wantErr:  true,
+		},
+		{
+			name:     "negative price",
+			override: PricingOverride{Pricing: PricingValues{Output: f64(-1)}},
+			wantErr:  true,
+		},
+		{
+			name:     "unknown day",
+			override: PricingOverride{Condition: PricingCondition{Time: &TimeWindow{Days: []Weekday{"funday"}, Start: "08:00", End: "20:00"}}, Pricing: PricingValues{Input: f64(1)}},
+			wantErr:  true,
+		},
+		{
+			name:     "bad clock format",
+			override: PricingOverride{Condition: PricingCondition{Time: &TimeWindow{Start: "8am", End: "20:00"}}, Pricing: PricingValues{Input: f64(1)}},
+			wantErr:  true,
+		},
+		{
+			name:     "bad timezone",
+			override: PricingOverride{Condition: PricingCondition{Time: &TimeWindow{Start: "08:00", End: "20:00", Timezone: "Mars/Olympus"}}, Pricing: PricingValues{Input: f64(1)}},
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.override.Validate()
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -93,6 +93,13 @@ type Pricing struct {
 	CacheHit    float64 `json:"cache_hit,omitempty"`
 }
 
+// Capabilities describes the capabilities of a model. Each capability is
+// always serialized, even when false, so consumers can distinguish between
+// "unknown" (field absent) and "explicitly unsupported".
+type Capabilities struct {
+	Vision bool `json:"vision"`
+}
+
 // Model represents an AI model configuration.
 type Model struct {
 	ID                     string       `json:"id"`
@@ -103,7 +110,7 @@ type Model struct {
 	CanReason              bool         `json:"can_reason"`
 	ReasoningLevels        []string     `json:"reasoning_levels,omitempty"`
 	DefaultReasoningEffort string       `json:"default_reasoning_effort,omitempty"`
-	SupportsImages         bool         `json:"supports_attachments"`
+	Capabilities           Capabilities `json:"capabilities"`
 	Options                ModelOptions `json:"options,omitzero"`
 }
 

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -102,16 +102,17 @@ type Capabilities struct {
 
 // Model represents an AI model configuration.
 type Model struct {
-	ID                     string       `json:"id"`
-	Name                   string       `json:"name"`
-	Pricing                Pricing      `json:"pricing"`
-	ContextWindow          int64        `json:"context_window"`
-	DefaultMaxTokens       int64        `json:"default_max_tokens"`
-	CanReason              bool         `json:"can_reason"`
-	ReasoningLevels        []string     `json:"reasoning_levels,omitempty"`
-	DefaultReasoningEffort string       `json:"default_reasoning_effort,omitempty"`
-	Capabilities           Capabilities `json:"capabilities"`
-	Options                ModelOptions `json:"options,omitzero"`
+	ID                     string            `json:"id"`
+	Name                   string            `json:"name"`
+	Pricing                Pricing           `json:"pricing"`
+	PricingOverrides       []PricingOverride `json:"pricing_overrides,omitempty"`
+	ContextWindow          int64             `json:"context_window"`
+	DefaultMaxTokens       int64             `json:"default_max_tokens"`
+	CanReason              bool              `json:"can_reason"`
+	ReasoningLevels        []string          `json:"reasoning_levels,omitempty"`
+	DefaultReasoningEffort string            `json:"default_reasoning_effort,omitempty"`
+	Capabilities           Capabilities      `json:"capabilities"`
+	Options                ModelOptions      `json:"options,omitzero"`
 }
 
 // KnownProviders returns all the known inference providers.

--- a/pkg/catwalk/provider.go
+++ b/pkg/catwalk/provider.go
@@ -85,14 +85,19 @@ type ModelOptions struct {
 	ProviderOptions  map[string]any `json:"provider_options,omitempty"`
 }
 
+// Pricing stores the pricing of a model in US dollars per 1M tokens.
+type Pricing struct {
+	Input       float64 `json:"input"`
+	Output      float64 `json:"output"`
+	CacheCreate float64 `json:"cache_create,omitempty"`
+	CacheHit    float64 `json:"cache_hit,omitempty"`
+}
+
 // Model represents an AI model configuration.
 type Model struct {
 	ID                     string       `json:"id"`
 	Name                   string       `json:"name"`
-	CostPer1MIn            float64      `json:"cost_per_1m_in"`
-	CostPer1MOut           float64      `json:"cost_per_1m_out"`
-	CostPer1MInCached      float64      `json:"cost_per_1m_in_cached"`
-	CostPer1MOutCached     float64      `json:"cost_per_1m_out_cached"`
+	Pricing                Pricing      `json:"pricing"`
 	ContextWindow          int64        `json:"context_window"`
 	DefaultMaxTokens       int64        `json:"default_max_tokens"`
 	CanReason              bool         `json:"can_reason"`


### PR DESCRIPTION
## What?

Adds optional pricing overrides based on token range and peak/no-peak hours

```json
{
  "id": "claude-fable-5-1",
  "name": "Claude Fable 5.1",
  "pricing": {
    "input": 10,
    "output": 50,
    "cache_create": 12.5,
    "cache_hit": 0.25
  },
  "pricing_overrides": [
    {
      "condition": {
        "input_tokens": { "gte": 200000 }
      },
      "pricing": { "input": 15, "output": 75, "cache_create": 18.75, "cache_hit": 0.375 }
    },
    {
      "condition": {
        "time": {
          "days": ["mon", "tue", "wed", "thu", "fri"],
          "start": "08:00",
          "end": "20:00",
          "timezone": "America/New_York"
        }
      },
      "pricing": { "input": 12.5, "output": 62.5 }
    }
  ],
  "context_window": 1000000,
  "default_max_tokens": 128000,
  "can_reason": true,
  "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
  "default_reasoning_effort": "high",
  "capabilities": { "vision": true }
}
```

## Why?

Part of CHARM-1634

Services, like Alibaba Cloud, or Deepseek have variable pricing on different condition, and in order for crush to report the prices correctly, we need to be able to override the pricing in catwalk.